### PR TITLE
Remove `xmp` tags from template files

### DIFF
--- a/app/assets/stylesheets/sage_docs/_code.scss
+++ b/app/assets/stylesheets/sage_docs/_code.scss
@@ -1,11 +1,6 @@
-xmp {
-  margin: 0;
-  font-family: 'Inter', sans-serif;
-}
-
-pre.prettyprint { 
-  display: block; 
-  background-color:sage-color(primary, 500);
+.prettyprint {
+  display: block;
+  background-color: sage-color(primary, 500);
   padding: sage-spacing() !important;
   font-size: sage-font-size(sm);
   margin-bottom: sage-spacing();
@@ -27,7 +22,7 @@ pre .atv { color: #ffffff } /* attribute value - pink */
 pre .dec { color: sage-color(sage, 200) } /* decimal         - lightgreen */
 
 @media print {
-  pre.prettyprint { background-color: none }
+  .prettyprint { background-color: none }
   pre .str, code .str { color: #060 }
   pre .kwd, code .kwd { color: #006; font-weight: bold }
   pre .com, code .com { color: #600; font-style: italic }

--- a/app/views/sage/examples/components/_component.html.erb
+++ b/app/views/sage/examples/components/_component.html.erb
@@ -13,6 +13,6 @@
   </div>
   <h6 class="example__label">Code</h6>
   <div class="example__code">
-    <pre class="prettyprint"><code><xmp><%= render "sage/examples/components/#{title}/preview" %></xmp></code></pre>
+    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/components/#{title}/preview") %></code></pre>
   </div>
 </div>

--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -13,6 +13,6 @@
   </div>
   <h6 class="example__label">Code</h6>
   <div class="example__code">
-    <pre class="prettyprint"><code><xmp><%= render "sage/examples/elements/#{title}/preview" %></xmp></code></pre>
+    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{title}/preview") %></code></pre>
   </div>
 </div>

--- a/app/views/sage/examples/elements/button/_preview.html.erb
+++ b/app/views/sage/examples/elements/button/_preview.html.erb
@@ -1,6 +1,6 @@
 <!-- Default -->
 <a href="#" class="sage-btn">Default Button</a>
 <!-- Primary -->
-<a href="#" class="sage-btn--primary">Priamary Button</a>
+<a href="#" class="sage-btn--primary">Primary Button</a>
 <!-- Secondary -->
 <a href="#" class="sage-btn--secondary">Secondary Button</a>

--- a/app/views/sage/examples/modules/_module.erb
+++ b/app/views/sage/examples/modules/_module.erb
@@ -1,5 +1,5 @@
 <div class="sage-panel">
   <h3 id="<%= title %>" class="example__title"><%= title %></h3>
   <h6 class="example__label">Code</h6>
-  <pre class="prettyprint"><code><xmp><%= render "sage/examples/modules/#{title}/preview" %></xmp></code></pre>
+  <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/modules/#{title}/preview") %></code></pre>
 </div>

--- a/app/views/sage/examples/utilities/_utility.html.erb
+++ b/app/views/sage/examples/utilities/_utility.html.erb
@@ -1,5 +1,5 @@
 <div class="sage-panel">
   <h3 id="<%= title %>" class="example__title"><%= title %></h3>
   <h6 class="example__label">Code</h6>
-  <pre class="prettyprint"><code><xmp><%= render "sage/examples/utilities/#{title}/preview" %></xmp></code></pre>
+  <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/utilities/#{title}/preview") %></code></pre>
 </div>

--- a/app/views/sage/pages/color.html.erb
+++ b/app/views/sage/pages/color.html.erb
@@ -24,7 +24,7 @@
   </div>
 <% end %>
 <h2 id="how">How we use color</h2>
-<p>You will notice pure black is not used at all as a text color. Instead, we rely on 400 for our darkest text color value. Our default text color is sage-color(charcoal, 400). To achive more depth use 300 to 400 shades for text on top of lighter background colors using 100 to 200 for their fill. You can also use 100 to 200 as the text color on darker backgrounds using from 300 to 400 for their fill. Pure white is used as a text color when the lightest shade (100) of a color will not pass color contrast tests. At the moment, this only occurs on the 300 shades of purple, primary, and red.</p>
+<p>You will notice <strong>pure black is not used at all as a text color</strong>. Instead, we rely on 400 for our darkest text color value. Our default text color is sage-color(charcoal, 400). To achive more depth use 300 to 400 shades for text on top of lighter background colors using 100 to 200 for their fill. You can also use 100 to 200 as the text color on darker backgrounds using from 300 to 400 for their fill. Pure white is used as a text color when the lightest shade (100) of a color will not pass color contrast tests. At the moment, this only occurs on the 300 shades of purple, primary, and red.</p>
 <h2 id="primary">Primary</h2>
 <p>These are the splashes of color that appear the most in Kajabi’s UI, and are the ones that determine the overall "look" of the app. Use these for things like primary actions, links, navigation items, icons, accent borders, or text we want to emphasize.</p>
 <div class="sage-panel">

--- a/app/views/sage/pages/container.html.erb
+++ b/app/views/sage/pages/container.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :heading do %>
-  <h1>Containers</h1> 
+  <h1>Containers</h1>
 <% end %>
 <%= content_for :quick_links do %>
   <div class="quick-links">
@@ -16,15 +16,15 @@
 <% end %>
 <div class="sage-panel">
   <h3 id="standard">Standard Container</h3>
-  <pre class="prettyprint"><code><xmp><div class="sage-container">
-    1200px
-  </div></xmp></pre></code>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-container&quot;&gt;
+  &lt;!-- 1200px width container --&gt;
+&lt;/div&gt;</code></pre>
   <h3 id="small">Small Container</h3>
-  <pre class="prettyprint"><code><xmp><div class="sage-container--sm">
-    900px
-  </div></xmp></pre></code>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-container--sm&quot;&gt;
+  &lt;!-- 900px width container --&gt;
+&lt;/div&gt;</code></pre>
   <h3 id="full">Full Width Container</h3>
-  <pre class="prettyprint"><code><xmp><div class="sage-container--fluid">
-    100%
-  </div></xmp></pre></code>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-container--fluid&quot;&gt;
+  &lt;!-- 100% width container --&gt;
+&lt;/div&gt;</code></pre>
 </div>

--- a/app/views/sage/pages/conventions.html.erb
+++ b/app/views/sage/pages/conventions.html.erb
@@ -17,65 +17,65 @@
     <a href="#media" class="quick-links__link">Media Queries</a>
     <a href="#utilities" class="quick-links__link">Utilities</a>
   </div>
-<% end %>    
+<% end %>
 <div class="sage-panel">
   <h3 id="core">Core Concepts</h3>
-  <p><strong>Make it modular</strong> –  There should be clear separation between components. When someone goes to work on a component there should be no confusion what files they should be editing. </p>
-  <p><strong>Legibility is key</strong> – Developers should be able to understand CSS code at a glance and understand the purpose of any given selector.</p>
-  <p><strong>Keep It Simple</strong> – Nesting in Sass can be very convenient, but runs the risk of poor output with overly long selector strings. We follow the Inception Rule and never nested Sass more than three layers deep.</p>
-  <p><strong>Avoid conflicts</strong> – Since our design system code is going to be introduced into an app with much legacy styles we need to ensure that our styles do not conflict with other libraries and systems. This is accomplished by the system’s namespacing of class names, described in more detail below.</p>
+  <p><strong>Make it modular</strong> &ndash;  There should be clear separation between components. When someone goes to work on a component there should be no confusion what files they should be editing. </p>
+  <p><strong>Legibility is key</strong> &ndash; Developers should be able to understand CSS code at a glance and understand the purpose of any given selector.</p>
+  <p><strong>Keep It Simple</strong> &ndash; Nesting in Sass can be very convenient, but runs the risk of poor output with overly long selector strings. We follow the Inception Rule and never nested Sass more than three layers deep.</p>
+  <p><strong>Avoid conflicts</strong> &ndash; Since our design system code is going to be introduced into an app with much legacy styles we need to ensure that our styles do not conflict with other libraries and systems. This is accomplished by the system’s namespacing of class names, described in more detail below.</p>
   <h3 id="global">Global Namespace</h3>
   <p>All classes associated with the design system are prefixed with a global namespace, which is the name of the system followed by a hyphen:</p>
-  <pre class="prettyprint"><code><xmp>.sage-</xmp></code></pre>
+  <pre class="prettyprint"><code>.sage-</code></pre>
   <p>For example a Card component in sage looks something like this:</p>
-  <pre class="prettyprint"><code><xmp>/* card.scss */
+  <pre class="prettyprint"><code>/* card.scss */
 
-  .sage-card {
-      &__img { }
-      &__title { }
-      &__subtitle { }
-  }</xmp></code></pre>
+.sage-card {
+    &__img { }
+    &__title { }
+    &__subtitle { }
+}</code></pre>
   <h3 id="tokens">Design Tokens</h3>
   <p>We utilize design tokens in the form of Scss variables. These variables are namespaced in the same way that classes are so that we do not run into conflicts with other Scss code. </p>
-  <pre class="prettyprint"><code><xmp>sage-font-height( )
+  <pre class="prettyprint"><code>sage-font-height( )
 sage-font-size( )
-sage-font-weight( )</xmp></code></pre>
+sage-font-weight( )</code></pre>
   <p>We utilize Scss functions to create these tokens so that you are able to pass in modifyers to get different values as needed.</p>
-  <pre class="prettyprint"><code><xmp>sage-font-weight(regular)
+  <pre class="prettyprint"><code>sage-font-weight(regular)
 sage-font-weight(semibold)
-sage-font-weight(bold)</xmp></code></pre>
-  <pre class="prettyprint"><code><xmp>sage-font-size(xs)
+sage-font-weight(bold)</code></pre>
+  <pre class="prettyprint"><code>sage-font-size(xs)
 sage-font-size(sm)
 sage-font-size(md)
 sage-font-size(lg)
 sage-font-size(xl)
 sage-font-size(2xl)
 sage-font-size(3xl)
-sage-font-size(4xl)</xmp></code></pre>
+sage-font-size(4xl)</code></pre>
   <h3 id="parent">Parent Selectors</h3>
   <p>The design system will make use of Sass’s parent selector mechanism. This allows all rules for a given component to be maintained in one location.</p>
-  <pre class="prettyprint"><code><xmp>/* button.scss */
+  <pre class="prettyprint"><code>/* button.scss */
 
-  .sage-btn {
-      /* Button In Sidebar Takes Full Width */
-      .sage-sidebar & {
-          display: block;
-          width: 100%;
-          text-align: center;
-      }
-  }</xmp></code></pre>
+.sage-btn {
+  /* Button In Sidebar Takes Full Width */
+  .sage-sidebar & {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+}</code></pre>
   <h3 id="media">Media Queries</h3>
   <p>Component-specific media queries should be nested inside the component block.</p>
-  <pre class="prettyprint"><code><xmp>/* button.scss */
+  <pre class="prettyprint"><code>/* button.scss */
 
-  .sage-btn {
-      /* Button On Small Screen Takes Full Width */
-      @media (min-width: sage-breakpoint()) {
-          display: block;
-          width: 100%;
-          text-align: center;
-      }
-  }</xmp></code></pre>
+.sage-btn {
+  /* Button On Small Screen Takes Full Width */
+  @media (min-width: sage-breakpoint()) {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+}</code></pre>
   <h3 id="utilities">Utilities</h3>
   <p>Utilities should be used sparingly and only when there is no way to accurately modify the block to fit the needs of the mockup. If you find yourself in a situation where you are tempted to use a utility class it might be a good opportunity to reach out to the product developer and ask if the unique treatment in the situation is needed.</p>
   <p>Utilities do not play well with responsive styling so a utility class should be used only in cases where the same treatment is needed on every device. When in doubt reach out to the designer or another developer. </p>

--- a/app/views/sage/pages/generators.html.erb
+++ b/app/views/sage/pages/generators.html.erb
@@ -20,15 +20,15 @@
 <% end %>
 <div class="sage-panel">
   <h3 id="token">Generate Token</h3>
-  <pre class="prettyprint"><code><xmp>rails generate sage_token TOKEN_NAME</xmp></code></pre>
+  <pre class="prettyprint"><code>rails generate sage_token TOKEN_NAME</code></pre>
   <h3 id="element">Generate Element</h3>
-  <pre class="prettyprint"><code><xmp>rails generate sage_element ELEMENT_NAME</xmp></code></pre>
+  <pre class="prettyprint"><code>rails generate sage_element ELEMENT_NAME</code></pre>
   <h3 id="component">Generate Component</h3>
-  <pre class="prettyprint"><code><xmp>rails generate sage_component COMPONENT_NAME</xmp></code></pre>
+  <pre class="prettyprint"><code>rails generate sage_component COMPONENT_NAME</code></pre>
   <h3 id="module">Generate Module</h3>
-  <pre class="prettyprint"><code><xmp>rails generate sage_module MODULE_NAME</xmp></code></pre>
+  <pre class="prettyprint"><code>rails generate sage_module MODULE_NAME</code></pre>
   <h3 id="utility">Generate Utility</h3>
-  <pre class="prettyprint"><code><xmp>rails generate sage_utility UTILITY_NAME</xmp></code></pre>
+  <pre class="prettyprint"><code>rails generate sage_utility UTILITY_NAME</code></pre>
   <h3 id="page">Generate Page</h3>
-  <pre class="prettyprint"><code><xmp>rails generate sage_page PAGE_NAME</xmp></code></pre>
+  <pre class="prettyprint"><code>rails generate sage_page PAGE_NAME</code></pre>
 </div>

--- a/app/views/sage/pages/grid.html.erb
+++ b/app/views/sage/pages/grid.html.erb
@@ -13,11 +13,11 @@
     <div class="sage-col"><div class="grid-item">Col</div></div>
     <div class="sage-col"><div class="grid-item">Col</div></div>
   </div>
-  <pre class="prettyprint"><code><xmp><div class="sage-row">
-    <div class="sage-col--4">Col</div>
-    <div class="sage-col">Col</div>
-    <div class="sage-col">Col</div>
-  </div></xmp></code></pre>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-row&quot;&gt;
+  &lt;div class=&quot;sage-col--4&quot;&gt;Col&lt;/div&gt;
+  &lt;div class=&quot;sage-col&quot;&gt;Col&lt;/div&gt;
+  &lt;div class=&quot;sage-col&quot;&gt;Col&lt;/div&gt;
+&lt;/div&gt;</code></pre>
   <% 10.times do |num| %>
     <div class="sage-row">
       <div class="sage-col--<%= num + 1%>"><div class="grid-item"><%= num + 1%></div></div>

--- a/app/views/sage/pages/index.html.erb
+++ b/app/views/sage/pages/index.html.erb
@@ -32,11 +32,11 @@
   <p>The Sage Design System is kept in a separate repo and served to the main Kajabi app as a version controlled gem that the different component libraries can consume.</p>
   <p>This provides a healthy amount of friction between the system and the components that are consuming it. With that friction we are able to better maintain consistency and limit code and component duplication.</p>
   <p>All System components are prefixed with the sage- prefix. For example a card component in sage looks something like this:</p>
-  <pre class="prettyprint"><code><xmp>.sage-card {
-    &__img { }
-    &__title { }
-    &__subtitle { }
-  }</xmp></code></pre>
+  <pre class="prettyprint"><code>.sage-card {
+  &__img { }
+  &__title { }
+  &__subtitle { }
+}</code></pre>
   <p>This prefix approach ensures that the consumer is quickly able to identify that the styles are indeed coming from our external design system and also gives the Sage System Developer the confidence that they can create components without conflict with existing code.</p>
   <h3 id="how_changed">How it is changed</h3>
   <p>All UX Developers are encouraged to contribute to Sage but to do so with care and with the collaboration of both other UX Developers and The Product Designers.</p>

--- a/app/views/sage/pages/start.html.erb
+++ b/app/views/sage/pages/start.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :heading do %>
-  <h1>Gettin Started</h1>
+  <h1>Getting Started</h1>
   <p>These docs are designed to give you access to every answer you need to successfully contribute to the Sage Design System.</p>
 <% end %>
 <%= content_for :quick_links do %>
@@ -17,12 +17,12 @@
 <div class="sage-panel">
   <h3 id="running">Running Sage Gem</h3>
   <p>Download or clone the sage gem from Github</p>
-  <pre class="prettyprint"><code><xmp>https://github.com/Kajabi/sage_design_system.git</xmp></code></pre>
+  <pre class="prettyprint"><code>https://github.com/Kajabi/sage_design_system.git</code></pre>
   <p>CD into test/dummy folder and run:</p>
-  <pre class="prettyprint"><code><xmp>rails s</xmp></code></pre>
+  <pre class="prettyprint"><code>rails s</code></pre>
   <p>You are then able to navigate to all the guides associated with the system by following the link: <a href="http://localhost:3000/sage/pages/index" target="_blank">http://localhost:3000/sage/pages/index</a></p>
   <h3 id="create">Create New Sage Component</h3>
-  <pre class="prettyprint"><code><xmp>rails generate sage_component COMPONENT_NAME</xmp></code></pre>
+  <pre class="prettyprint"><code>rails generate sage_component COMPONENT_NAME</code></pre>
   <p>This will create a file for the markup of the new sage component markup file and also the .scss file needed to style your new component.</p>
   <p>The same can be done to create both elements and modules for the system and instructions can be found on the generators page.</p>
   <p>Changes made to the Sage Design System will be reflected as you work and should not be merged until they have been reviewed by another member of the UX Development team.</p>

--- a/app/views/sage/pages/typography.html.erb
+++ b/app/views/sage/pages/typography.html.erb
@@ -19,16 +19,16 @@
   </div>
 <% end %>
 <div class="sage-panel">
-  <h1 id="h1">Empowering experts, entrepreneurs, and influencers to build online businesses.</h1>
-  <pre class="prettyprint"><code><xmp><h1>Heading One</h1></xmp></code></pre>
-  <h2 id="h2">Empowering experts, entrepreneurs, and influencers to build online businesses.</h2>
-  <pre class="prettyprint"><code><xmp><h2>Heading Two</h2></xmp></code></pre>
-  <h3 id="h3">Empowering experts, entrepreneurs, and influencers to build online businesses.</h3>
-  <pre class="prettyprint"><code><xmp><h3>Heading Three</h3></xmp></code></pre>
-  <h4 id="h4">Empowering experts, entrepreneurs, and influencers to build online businesses.</h4>
-  <pre class="prettyprint"><code><xmp><h4>Heading Four</h4></xmp></code></pre>
-  <h5 id="h5">Empowering experts, entrepreneurs, and influencers to build online businesses.</h5>
-  <pre class="prettyprint"><code><xmp><h5>Heading Five</h5></xmp></code></pre>
-  <h6 id="h6">Empowering experts, entrepreneurs, and influencers to build online businesses.</h6>
-  <pre class="prettyprint"><code><xmp><h6>Heading Six</h6></xmp></code></pre>
+  <h1 id="h1">H1: Empowering experts, entrepreneurs, and influencers to build online businesses.</h1>
+  <pre class="prettyprint"><code>&lt;h1&gt;Heading One&lt;/h1&gt;</code></pre>
+  <h2 id="h2">H2: Empowering experts, entrepreneurs, and influencers to build online businesses.</h2>
+  <pre class="prettyprint"><code>&lt;h2&gt;Heading Two&lt;/h2&gt;</code></pre>
+  <h3 id="h3">H3: Empowering experts, entrepreneurs, and influencers to build online businesses.</h3>
+  <pre class="prettyprint"><code>&lt;h3&gt;Heading Three&lt;/h3&gt;</code></pre>
+  <h4 id="h4">H4: Empowering experts, entrepreneurs, and influencers to build online businesses.</h4>
+  <pre class="prettyprint"><code>&lt;h4&gt;Heading Four&lt;/h4&gt;</code></pre>
+  <h5 id="h5">H5: Empowering experts, entrepreneurs, and influencers to build online businesses.</h5>
+  <pre class="prettyprint"><code>&lt;h5&gt;Heading Five&lt;/h5&gt;</code></pre>
+  <h6 id="h6">H6: Empowering experts, entrepreneurs, and influencers to build online businesses.</h6>
+  <pre class="prettyprint"><code>&lt;h6&gt;Heading Six&lt;/h6&gt;</code></pre>
 </div>


### PR DESCRIPTION
## Description
Removes `xmp` tags from template code blocks and updates formatting to prevent partials from rendering.

Renders escaped HTML of partial, then unescapes the resulting output. I'm not sure if this is the prettiest (or most secure) solution, so I'm open to alternatives.

**Templates affected:**
- [x] `app/views/example_components/_component.html.erb`
- [x] `app/views/example_elements/_element.html.erb`
- [x] `app/views/example_modules/_module.erb`
- [x] `app/views/example_utilities/_utility.html.erb`
- [x] `app/views/sage/pages/container.html.erb`
- [x] `app/views/sage/pages/conventions.html.erb`
- [x] `app/views/sage/pages/generators.html.erb`
- [x] `app/views/sage/pages/grid.html.erb`
- [x] `app/views/sage/pages/index.html.erb`
- [x] `app/views/sage/pages/start.html.erb`
- [x] `app/views/sage/pages/typography.html.erb`

## Related issues
Resolves #18 
