### PR TITLE
Add autoprefixer to build process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ gemspec
 
 gem 'sqlite3', '~> 1.3.0'
 gem 'sass-rails'
+gem 'autoprefixer-rails'

--- a/app/assets/stylesheets/sage/core/_animations.scss
+++ b/app/assets/stylesheets/sage/core/_animations.scss
@@ -1,6 +1,3 @@
 @mixin sage-simple-ease($value) {
-  -webkit-transition: $value .2s ease-in-out;
-  -moz-transition: $value .2s ease-in-out;
-  -o-transition: $value .2s ease-in-out;
   transition: $value .2s ease-in-out;
 }

--- a/app/assets/stylesheets/sage/icons/icons.scss
+++ b/app/assets/stylesheets/sage/icons/icons.scss
@@ -12,19 +12,11 @@ $sage-icon-li-margin-right:  0.4em !default;
 
 @mixin sage-icon-rotate($degrees, $rotation) {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
-  -webkit-transform: rotate($degrees);
-  -moz-transform: rotate($degrees);
-  -ms-transform: rotate($degrees);
-  -o-transform: rotate($degrees);
   transform: rotate($degrees);
 }
 
 @mixin sage-icon-flip($horiz, $vert, $rotation) {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
-  -webkit-transform: scale($horiz, $vert);
-  -moz-transform: scale($horiz, $vert);
-  -ms-transform: scale($horiz, $vert);
-  -o-transform: scale($horiz, $vert);
   transform: scale($horiz, $vert);
 }
 
@@ -79,40 +71,14 @@ $sage-icon-li-margin-right:  0.4em !default;
 -------------------------*/
 
 .sage-icon-is-spinning {
-  -webkit-animation: sage-icon-spin 2s infinite linear;
-  -moz-animation: sage-icon-spin 2s infinite linear;
   animation: sage-icon-spin 2s infinite linear;
 }
 
-@-webkit-keyframes sage-icon-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(360deg);
-  }
-}
-@-moz-keyframes sage-icon-spin {
-  0% {
-    -moz-transform: rotate(0deg);
-  }
-  100% {
-    -moz-transform: rotate(360deg);
-  }
-}
 @keyframes sage-icon-spin {
   0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    -o-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    -o-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }

--- a/app/assets/stylesheets/sage/vendor/_reboot.scss
+++ b/app/assets/stylesheets/sage/vendor/_reboot.scss
@@ -7,7 +7,7 @@
 html {
   font-family: sans-serif;
   line-height: 1.15;
-  -webkit-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;  // @TODO: investigate replacement/removal
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
@@ -63,11 +63,11 @@ p {
 abbr[title],
 abbr[data-original-title] {
   text-decoration: underline;
-  -webkit-text-decoration: underline dotted;
+  -webkit-text-decoration: underline dotted; // @TODO: investigate replacement/removal
   text-decoration: underline dotted;
   cursor: help;
   border-bottom: 0;
-  -webkit-text-decoration-skip-ink: none;
+  -webkit-text-decoration-skip-ink: none; // @TODO: investigate replacement/removal
   text-decoration-skip-ink: none;
 }
 
@@ -243,7 +243,7 @@ button,
 [type="button"],
 [type="reset"],
 [type="submit"] {
-  -webkit-appearance: button;
+  -webkit-appearance: button; // @TODO: investigate replacement/removal
 }
 
 button:not(:disabled),
@@ -271,7 +271,7 @@ input[type="date"],
 input[type="time"],
 input[type="datetime-local"],
 input[type="month"] {
-  -webkit-appearance: listbox;
+  -webkit-appearance: listbox; // @TODO: investigate replacement/removal
 }
 
 textarea {
@@ -309,16 +309,16 @@ progress {
 
 [type="search"] {
   outline-offset: -2px;
-  -webkit-appearance: none;
+  -webkit-appearance: none; // @TODO: investigate replacement/removal
 }
 
 [type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
+  -webkit-appearance: none; // @TODO: investigate replacement/removal
 }
 
 ::-webkit-file-upload-button {
   font: inherit;
-  -webkit-appearance: button;
+  -webkit-appearance: button; // @TODO: investigate replacement/removal
 }
 
 output {


### PR DESCRIPTION
# Description
Adds `autoprefixer` gem to autogenerate browser-prefixed properties in CSS.

NOTE: prefixed items in `vender/_reboot.scss` were not removed. TODOs added for a future issue.

## Test notes
1. Spin up the server locally with `rails s`
2. Navigate to "Styles" in the left panel, and choose "Icons"
3. Open your browser devtools, and inspect an icon (`.sage-icon`)
4. Modify the icon's classes to include '.sage-icon-is-spinning` to trigger an animation
5. Verify that `-webkit-animation` appears for the `.sage-icon-is-spinning` class.

Closes #21.