### PR TITLE
Remove underscore characters in documentation

### DIFF
--- a/app/views/sage/application/_itemtitle.html.erb
+++ b/app/views/sage/application/_itemtitle.html.erb
@@ -1,1 +1,1 @@
-<h3 id="<%= itemtitle.capitalize %>" class="example__title"><%= itemtitle.capitalize.sub("_", " ") %></h3>
+<h3 id="<%= itemtitle %>" class="example__title"><%= itemtitle.capitalize.sub("_", " ") %></h3>

--- a/app/views/sage/application/_itemtitle.html.erb
+++ b/app/views/sage/application/_itemtitle.html.erb
@@ -1,1 +1,1 @@
-<h3 id="<%= itemtitle %>" class="example__title"><%= itemtitle.capitalize.gsub("_", " ") %></h3>
+<h3 id="<%= itemtitle %>" class="example__title"><%= itemtitle.titleize %></h3>

--- a/app/views/sage/application/_itemtitle.html.erb
+++ b/app/views/sage/application/_itemtitle.html.erb
@@ -1,1 +1,1 @@
-<h3 id="<%= itemtitle %>" class="example__title"><%= itemtitle.capitalize.sub("_", " ") %></h3>
+<h3 id="<%= itemtitle %>" class="example__title"><%= itemtitle.capitalize.gsub("_", " ") %></h3>

--- a/app/views/sage/application/_itemtitle.html.erb
+++ b/app/views/sage/application/_itemtitle.html.erb
@@ -1,0 +1,1 @@
+<h3 id="<%= itemtitle.capitalize %>" class="example__title"><%= itemtitle.capitalize.sub("_", " ") %></h3>

--- a/app/views/sage/examples/components/_component.html.erb
+++ b/app/views/sage/examples/components/_component.html.erb
@@ -1,7 +1,7 @@
 <div class="sage-panel">
   <div class="sage-media">
     <div class="sage-media-body">
-      <h3 id="<%= title %>" class="example__title"><%= title %></h3>
+      <%= render partial: "sage/application/itemtitle", object: title, as: 'itemtitle' =%>
     </div>
     <%= link_to pages_component_url(title: title), target: "_blank", class: "example__link" do %>
       <i class="sage-icon sage-icon-launch-app"></i>

--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -1,7 +1,7 @@
 <div class="sage-panel">
   <div class="sage-media">
     <div class="sage-media-body">
-      <h3 id="<%= title %>" class="example__title"><%= title %></h3>
+      <%= render partial: "sage/application/itemtitle", object: title, as: 'itemtitle' =%>
     </div>
     <%= link_to pages_element_url(title: title), target: "_blank", class: "example__link" do %>
       <i class="sage-icon sage-icon-launch-app"></i>

--- a/app/views/sage/examples/modules/_module.erb
+++ b/app/views/sage/examples/modules/_module.erb
@@ -1,5 +1,10 @@
 <div class="sage-panel">
-  <h3 id="<%= title %>" class="example__title"><%= title %></h3>
+  <div class="sage-media">
+    <div class="sage-media-body">
+      <%= render partial: "sage/application/itemtitle", object: title, as: 'itemtitle' =%>
+    </div>
+  </div>
+
   <h6 class="example__label">Code</h6>
   <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/modules/#{title}/preview") %></code></pre>
 </div>

--- a/app/views/sage/examples/utilities/_utility.html.erb
+++ b/app/views/sage/examples/utilities/_utility.html.erb
@@ -1,5 +1,10 @@
 <div class="sage-panel">
-  <h3 id="<%= title %>" class="example__title"><%= title %></h3>
+  <div class="sage-media">
+    <div class="sage-media-body">
+      <%= render partial: "sage/application/itemtitle", object: title, as: 'itemtitle' =%>
+    </div>
+  </div>
+
   <h6 class="example__label">Code</h6>
   <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/utilities/#{title}/preview") %></code></pre>
 </div>

--- a/app/views/sage/pages/components.html.erb
+++ b/app/views/sage/pages/components.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_components.each do |component| %>
-      <a href="#<%= component[:title] %>" class="quick-links__link"><%= component[:title] %></a>
+      <a href="#<%= component[:title] %>" class="quick-links__link"><%= component[:title].capitalize.sub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/components.html.erb
+++ b/app/views/sage/pages/components.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_components.each do |component| %>
-      <a href="#<%= component[:title] %>" class="quick-links__link"><%= component[:title].capitalize.sub("_", " ") %></a>
+      <a href="#<%= component[:title] %>" class="quick-links__link"><%= component[:title].capitalize.gsub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/components.html.erb
+++ b/app/views/sage/pages/components.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_components.each do |component| %>
-      <a href="#<%= component[:title] %>" class="quick-links__link"><%= component[:title].capitalize.gsub("_", " ") %></a>
+      <a href="#<%= component[:title] %>" class="quick-links__link"><%= component[:title].titleize %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/elements.html.erb
+++ b/app/views/sage/pages/elements.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_elements.each do |element| %>
-      <a href="#<%= element[:title] %>" class="quick-links__link"><%= element[:title].capitalize.sub("_", " ") %></a>
+      <a href="#<%= element[:title] %>" class="quick-links__link"><%= element[:title].capitalize.gsub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/elements.html.erb
+++ b/app/views/sage/pages/elements.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_elements.each do |element| %>
-      <a href="#<%= element[:title] %>" class="quick-links__link"><%= element[:title] %></a>
+      <a href="#<%= element[:title] %>" class="quick-links__link"><%= element[:title].capitalize.sub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/elements.html.erb
+++ b/app/views/sage/pages/elements.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_elements.each do |element| %>
-      <a href="#<%= element[:title] %>" class="quick-links__link"><%= element[:title].capitalize.gsub("_", " ") %></a>
+      <a href="#<%= element[:title] %>" class="quick-links__link"><%= element[:title].titleize %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/modules.html.erb
+++ b/app/views/sage/pages/modules.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_modules.each do |example_module| %>
-      <a href="#<%= example_module[:title] %>" class="quick-links__link"><%= example_module[:title].capitalize.gsub("_", " ") %></a>
+      <a href="#<%= example_module[:title] %>" class="quick-links__link"><%= example_module[:title].titleize %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/modules.html.erb
+++ b/app/views/sage/pages/modules.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_modules.each do |example_module| %>
-      <a href="#<%= example_module[:title] %>" class="quick-links__link"><%= example_module[:title] %></a>
+      <a href="#<%= example_module[:title] %>" class="quick-links__link"><%= example_module[:title].capitalize.sub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/modules.html.erb
+++ b/app/views/sage/pages/modules.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_modules.each do |example_module| %>
-      <a href="#<%= example_module[:title] %>" class="quick-links__link"><%= example_module[:title].capitalize.sub("_", " ") %></a>
+      <a href="#<%= example_module[:title] %>" class="quick-links__link"><%= example_module[:title].capitalize.gsub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/token.html.erb
+++ b/app/views/sage/pages/token.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sage_tokens.each do |token| %>
-      <a href="#<%= token[:category] %>" class="quick-links__link"><%= token[:category].sub("_", " ") %></a>
+      <a href="#<%= token[:category] %>" class="quick-links__link"><%= token[:category].gsub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/token.html.erb
+++ b/app/views/sage/pages/token.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sage_tokens.each do |token| %>
-      <a href="#<%= token[:category] %>" class="quick-links__link"><%= token[:category].gsub("_", " ") %></a>
+      <a href="#<%= token[:category] %>" class="quick-links__link"><%= token[:category].titleize %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/token.html.erb
+++ b/app/views/sage/pages/token.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sage_tokens.each do |token| %>
-      <a href="#<%= token[:category] %>" class="quick-links__link"><%= token[:category] %></a>
+      <a href="#<%= token[:category] %>" class="quick-links__link"><%= token[:category].sub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/utilities.html.erb
+++ b/app/views/sage/pages/utilities.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_utilities.each do |utility| %>
-      <a href="#<%= utility[:title] %>" class="quick-links__link"><%= utility[:title].capitalize.gsub("_", " ") %></a>
+      <a href="#<%= utility[:title] %>" class="quick-links__link"><%= utility[:title].titleize %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/utilities.html.erb
+++ b/app/views/sage/pages/utilities.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_utilities.each do |utility| %>
-      <a href="#<%= utility[:title] %>" class="quick-links__link"><%= utility[:title] %></a>
+      <a href="#<%= utility[:title] %>" class="quick-links__link"><%= utility[:title].capitalize.sub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sage/pages/utilities.html.erb
+++ b/app/views/sage/pages/utilities.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <% sorted_sage_utilities.each do |utility| %>
-      <a href="#<%= utility[:title] %>" class="quick-links__link"><%= utility[:title].capitalize.sub("_", " ") %></a>
+      <a href="#<%= utility[:title] %>" class="quick-links__link"><%= utility[:title].capitalize.gsub("_", " ") %></a>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
## Description
Strips underscore (`_`) characters from documentation and navigation for readability.

### Screenshots
|  Before   |  After  |
|--------|--------|
|![underscore-before](https://user-images.githubusercontent.com/816579/74474196-d9b82000-4e59-11ea-93c2-29655dba2f0c.png)|![underscore-after](https://user-images.githubusercontent.com/816579/74474203-dfae0100-4e59-11ea-9c29-d8285ae101b7.png)|

## Test notes

### Steps for testing
1. Spin up Sage with `rails s`
2. Navigate to "Components" in the left nav
3. Verify that the component "Form Section" uses title case and does not display underscores in the item title
4. Confirm that the quick links sidebar (titled "Contents") mirrors the updated item title

## Related issues
- Closes #32 