### PR TITLE
Added markup styling for radios and switches

### DIFF
--- a/app/assets/stylesheets/sage.css.scss
+++ b/app/assets/stylesheets/sage.css.scss
@@ -30,6 +30,8 @@
 @import "sage/utilities/media";
 
 // Elements
+@import "sage/patterns/elements/radio";
+@import "sage/patterns/elements/switch";
 @import "sage/patterns/elements/button";
 
 // Components

--- a/app/assets/stylesheets/sage/patterns/elements/_radio.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_radio.scss
@@ -16,16 +16,6 @@
     transition: 0.3s, border-color 0.3s, box-shadow 0.2s;
     vertical-align: top;
     width: 24px;
-    &:after {
-      content: "";
-      display: block;
-      left: 3px;
-      opacity: 1;
-      position: absolute;
-      top: 3px;
-      transition: transform 0.6s 0.3s cubic-bezier(0.2, 0.85, 0.32, 1.2) ease
-        opacity 0.3s 0.2s;
-    }
     // checked
     &:checked {
       background: sage-color(primary, 300);
@@ -44,6 +34,9 @@
         cursor: not-allowed;
         color: sage-color(grey, 400);
       }
+      &:not(:checked)::after {
+        background: sage-color(grey, 100);
+      }
     }
     // hover
     &:hover {
@@ -55,7 +48,7 @@
     }
     // focus
     &:focus {
-      box-shadow: 0 0 0 2px rgba(39, 94, 254, 0.3);
+      box-shadow: 0 0 0 2px fade-out(sage-color(primary), .7)
     }
     // label
     & + label {
@@ -68,9 +61,15 @@
     }
   }
   // circle when checked
-  input[type="radio"] {
+  input {
     border-radius: 50%;
     &:after {
+      content: "";
+      display: block;
+      left: 3px;
+      opacity: 1;
+      position: absolute;
+      top: 3px;
       background: #fff;
       border-radius: 50%;
       height: 16px;

--- a/app/assets/stylesheets/sage/patterns/elements/_radio.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_radio.scss
@@ -1,0 +1,86 @@
+/*------------------------------------*/
+/*-- radio element */
+/*------------------------------------*/
+.sage-radio {
+  input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: #fff;
+    border: 1px solid sage-color(grey, 400);
+    cursor: pointer;
+    display: inline-block;
+    height: 24px;
+    margin: 0;
+    outline: none;
+    position: relative;
+    transition: 0.3s, border-color 0.3s, box-shadow 0.2s;
+    vertical-align: top;
+    width: 24px;
+    &:after {
+      content: "";
+      display: block;
+      left: 3px;
+      opacity: 1;
+      position: absolute;
+      top: 3px;
+      transition: transform 0.6s 0.3s cubic-bezier(0.2, 0.85, 0.32, 1.2) ease
+        opacity 0.3s 0.2s;
+    }
+    // checked
+    &:checked {
+      background: sage-color(primary, 300);
+    }
+    // disabled
+    &:disabled {
+      background: sage-color(grey, 100);
+      border-color: sage-color(grey, 300);
+      cursor: not-allowed;
+      opacity: 0.5;
+      // disabled & checked
+      &:checked {
+        background: sage-color(grey, 200);
+      }
+      & + label {
+        cursor: not-allowed;
+        color: sage-color(grey, 400);
+      }
+    }
+    // hover
+    &:hover {
+      &:not(:checked) {
+        &:not(:disabled) {
+          box-shadow: sage-shadow(sm);
+        }
+      }
+    }
+    // focus
+    &:focus {
+      box-shadow: 0 0 0 2px rgba(39, 94, 254, 0.3);
+    }
+    // label
+    & + label {
+      cursor: pointer;
+      display: inline-block;
+      font-size: sage-font-size();
+      line-height: sage-font-height();
+      margin-left: 4px;
+      vertical-align: top;
+    }
+  }
+  // circle when checked
+  input[type="radio"] {
+    border-radius: 50%;
+    &:after {
+      background: #fff;
+      border-radius: 50%;
+      height: 16px;
+      opacity: 1;
+      transform: scale(0.5);
+      width: 16px;
+    }
+  }
+
+  /* radio responsive styles */
+  @media (max-width: sage-breakpoint()) {
+  }
+}

--- a/app/assets/stylesheets/sage/patterns/elements/_radio.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_radio.scss
@@ -3,19 +3,18 @@
 /*------------------------------------*/
 .sage-radio {
   input {
-    -webkit-appearance: none;
-    -moz-appearance: none;
+    appearance: none;
     background: #fff;
     border: 1px solid sage-color(grey, 400);
     cursor: pointer;
     display: inline-block;
-    height: 24px;
+    height: 1.5rem;
     margin: 0;
     outline: none;
     position: relative;
     transition: 0.3s, border-color 0.3s, box-shadow 0.2s;
     vertical-align: top;
-    width: 24px;
+    width: 1.5rem;
     // checked
     &:checked {
       background: sage-color(primary, 300);
@@ -56,7 +55,7 @@
       display: inline-block;
       font-size: sage-font-size();
       line-height: sage-font-height();
-      margin-left: 4px;
+      margin-left: sage-spacing(2xs);
       vertical-align: top;
     }
   }
@@ -66,16 +65,16 @@
     &:after {
       content: "";
       display: block;
-      left: 3px;
+      left: 50%;
       opacity: 1;
       position: absolute;
-      top: 3px;
+      top: 50%;
       background: #fff;
       border-radius: 50%;
-      height: 16px;
+      height: 0.5rem;
       opacity: 1;
-      transform: scale(0.5);
-      width: 16px;
+      transform: translate3d(-50%, -50%, 0);
+      width: 0.5rem;
     }
   }
 

--- a/app/assets/stylesheets/sage/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_switch.scss
@@ -1,0 +1,98 @@
+/*------------------------------------*/
+/*-- switch element */
+/*------------------------------------*/
+.sage-switch {
+  input {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    background: #fff;
+    background: sage-color(grey, 400);
+    border-radius: 11px;
+    border: 1px solid sage-color(grey, 400);
+    cursor: pointer;
+    display: inline-block;
+    height: 24px;
+    margin: 0;
+    outline: none;
+    position: relative;
+    transition: 0.3s, border-color 0.3s, box-shadow 0.2s;
+    vertical-align: top;
+    width: 44px;
+    &:after {
+      content: "";
+      display: block;
+      left: 0;
+      position: absolute;
+      top: 0;
+      transition: transform 0.6s 0.3s cubic-bezier(0.2, 0.85, 0.32, 1.2) ease opacity 0.3s 0.2s;
+    }
+    // checked
+    &:checked {
+      background: sage-color(primary, 300);
+    }
+    // disabled
+    &:disabled {
+      background: sage-color(grey, 100);
+      border-color: sage-color(grey, 300);
+      cursor: not-allowed;
+      opacity: 0.5;
+      // disabled & checked
+      &:checked {
+        background: sage-color(grey, 200);
+      }
+      & + label {
+        color: sage-color(grey, 400);
+      }
+    }
+    // hover
+    &:hover {
+      &:not(:checked) {
+        &:not(:disabled) {
+          box-shadow: sage-shadow(sm);
+        }
+      }
+    }
+    // focus
+    &:focus {
+      box-shadow: 0 0 0 2px rgba(39, 94, 254, 0.3);
+    }
+    & + label {
+      cursor: pointer;
+      display: inline-block;
+      font-size: sage-font-size();
+      line-height: sage-font-height();
+      margin-left: 4px;
+      vertical-align: top;
+    }
+  }
+  // switch circle
+  input {
+    &:after {
+      background: #fff;
+      border-radius: 50%;
+      height: 18px;
+      left: 2px;
+      top: 2px;
+      transform: translateX(1px);
+      width: 18px;
+    }
+    &:checked {
+      background: sage-color(primary);
+      &:after {
+        transform: translateX(20px);
+      }
+    }
+    &:disabled {
+      &:not(:checked) {
+        &:after {
+          background: sage-color(grey, 200);
+          opacity: 0.6;
+        }
+      }
+    }
+  }
+
+  /* switch responsive styles */
+  @media (max-width: sage-breakpoint()) {
+  }
+}

--- a/app/assets/stylesheets/sage/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_switch.scss
@@ -42,6 +42,7 @@
       }
       & + label {
         color: sage-color(grey, 400);
+        cursor: not-allowed;
       }
     }
     // hover

--- a/app/assets/stylesheets/sage/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_switch.scss
@@ -3,20 +3,19 @@
 /*------------------------------------*/
 .sage-switch {
   input {
-    -moz-appearance: none;
-    -webkit-appearance: none;
+    appearance: none;
     background: sage-color(grey, 400);
-    border-radius: 11px;
+    border-radius: 0.6875rem;
     border: 1px solid sage-color(grey, 400);
     cursor: pointer;
     display: inline-block;
-    height: 24px;
+    height: 1.5rem;
     margin: 0;
     outline: none;
     position: relative;
     transition: 0.3s, border-color 0.3s, box-shadow 0.2s;
     vertical-align: top;
-    width: 44px;
+    width: 2.75rem;
     // checked
     &:checked {
       background: sage-color(primary, 300);
@@ -45,14 +44,14 @@
     }
     // focus
     &:focus {
-      box-shadow: 0 0 0 2px fade-out(sage-color(primary), .7)
+      box-shadow: 0 0 0 2px fade-out(sage-color(primary), 0.7);
     }
     & + label {
       cursor: pointer;
       display: inline-block;
       font-size: sage-font-size();
       line-height: sage-font-height();
-      margin-left: 4px;
+      margin-left: sage-spacing(2xs);
       vertical-align: top;
     }
   }
@@ -63,17 +62,19 @@
       border-radius: 50%;
       content: "";
       display: block;
-      height: 18px;
-      left: 2px;
+      height: 1.125rem;
+      left: 50%;
       position: absolute;
-      top: 2px;
-      transform: translateX(1px);
-      width: 18px;
+      top: 50%;
+      transform: translate3d(-100%, -50%, 0);
+      transition-duration: 0.2s;
+      transition-timing-function: ease-out;
+      width: 1.125rem;
     }
     &:checked {
       background: sage-color(primary);
       &:after {
-        transform: translateX(20px);
+        transform: translate3d(0, -50%, 0);
       }
     }
     &:disabled {

--- a/app/assets/stylesheets/sage/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_switch.scss
@@ -5,7 +5,6 @@
   input {
     -moz-appearance: none;
     -webkit-appearance: none;
-    background: #fff;
     background: sage-color(grey, 400);
     border-radius: 11px;
     border: 1px solid sage-color(grey, 400);
@@ -18,14 +17,6 @@
     transition: 0.3s, border-color 0.3s, box-shadow 0.2s;
     vertical-align: top;
     width: 44px;
-    &:after {
-      content: "";
-      display: block;
-      left: 0;
-      position: absolute;
-      top: 0;
-      transition: transform 0.6s 0.3s cubic-bezier(0.2, 0.85, 0.32, 1.2) ease opacity 0.3s 0.2s;
-    }
     // checked
     &:checked {
       background: sage-color(primary, 300);
@@ -54,7 +45,7 @@
     }
     // focus
     &:focus {
-      box-shadow: 0 0 0 2px rgba(39, 94, 254, 0.3);
+      box-shadow: 0 0 0 2px fade-out(sage-color(primary), .7)
     }
     & + label {
       cursor: pointer;
@@ -70,8 +61,11 @@
     &:after {
       background: #fff;
       border-radius: 50%;
+      content: "";
+      display: block;
       height: 18px;
       left: 2px;
+      position: absolute;
       top: 2px;
       transform: translateX(1px);
       width: 18px;

--- a/app/assets/stylesheets/sage/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_switch.scss
@@ -32,8 +32,7 @@
     }
     // disabled
     &:disabled {
-      background: sage-color(grey, 100);
-      border-color: sage-color(grey, 300);
+      background: sage-color(grey, 200);
       cursor: not-allowed;
       opacity: 0.5;
       // disabled & checked
@@ -86,8 +85,7 @@
     &:disabled {
       &:not(:checked) {
         &:after {
-          background: sage-color(grey, 200);
-          opacity: 0.6;
+          background: #fff;
         }
       }
     }

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -5,6 +5,8 @@ module Sage
     def sage_elements
       [
         # Sage Generated Elements
+        { title: "switch" },
+        { title: "radio" },
         { title: "button" },
       ]
     end

--- a/app/views/sage/examples/elements/radio/_preview.html.erb
+++ b/app/views/sage/examples/elements/radio/_preview.html.erb
@@ -1,15 +1,15 @@
 <!-- Default -->
 <div class="sage-radio">
-  <input id="r1" type="radio" name="radio1" value="1" />
+  <input id="r1" type="radio" name="radio1" value="1">
   <label for="r1">Radio</label>
 </div>
 <!-- Disabled -->
 <div class="sage-radio">
-  <input id="r2" type="radio" name="radio2" value="2" disabled />
+  <input id="r2" type="radio" name="radio2" value="2" disabled>
   <label for="r2">Radio disabled</label>
 </div>
 <!-- Checked & Disabled -->
 <div class="sage-radio">
-  <input id="r3" type="radio" name="radio3" value="3" checked disabled />
+  <input id="r3" type="radio" name="radio3" value="3" checked disabled>
   <label for="r3">Radio on disabled</label>
 </div>

--- a/app/views/sage/examples/elements/radio/_preview.html.erb
+++ b/app/views/sage/examples/elements/radio/_preview.html.erb
@@ -1,0 +1,15 @@
+<!-- Default -->
+<div class="sage-radio">
+  <input id="r1" type="radio" name="radio1" value="1" />
+  <label for="r1">Radio</label>
+</div>
+<!-- Disabled -->
+<div class="sage-radio">
+  <input id="r2" type="radio" name="radio2" value="2" disabled />
+  <label for="r2">Radio disabled</label>
+</div>
+<!-- Checked & Disabled -->
+<div class="sage-radio">
+  <input id="r3" type="radio" name="radio3" value="3" checked disabled />
+  <label for="r3">Radio on disabled</label>
+</div>

--- a/app/views/sage/examples/elements/switch/_preview.html.erb
+++ b/app/views/sage/examples/elements/switch/_preview.html.erb
@@ -1,0 +1,15 @@
+<!-- Default -->
+<div class="sage-switch">
+  <input id="s1" type="checkbox" />
+  <label for="s1">Switch</label>
+</div>
+<!-- Disabled -->
+<div class="sage-switch">
+  <input id="s2" type="checkbox" disabled />
+  <label for="s2">Switch disabled</label>
+</div>
+<!-- Checked & Disabled -->
+<div class="sage-switch">
+  <input id="s3" type="checkbox" checked disabled />
+  <label for="s3">Switch on disabled</label>
+</div>

--- a/app/views/sage/examples/elements/switch/_preview.html.erb
+++ b/app/views/sage/examples/elements/switch/_preview.html.erb
@@ -1,15 +1,15 @@
 <!-- Default -->
 <div class="sage-switch">
-  <input id="s1" type="checkbox" />
+  <input id="s1" type="checkbox">
   <label for="s1">Switch</label>
 </div>
 <!-- Disabled -->
 <div class="sage-switch">
-  <input id="s2" type="checkbox" disabled />
+  <input id="s2" type="checkbox" disabled>
   <label for="s2">Switch disabled</label>
 </div>
 <!-- Checked & Disabled -->
 <div class="sage-switch">
-  <input id="s3" type="checkbox" checked disabled />
+  <input id="s3" type="checkbox" checked disabled>
   <label for="s3">Switch on disabled</label>
 </div>


### PR DESCRIPTION
## Description
Adds markup and styling for radio and switch inputs.

### Steps for testing
- Spin up Sage with `rails s`
- Navigate to "Elements" in left nav
- Verify radio and switch elements match with [design spec](https://www.figma.com/file/xlUFoRTjsFePavVT85SmLL/Sage-Design-System-v1.0?node-id=634%3A2378). 

### Notes
- This PR does not include the error states.

## Related issues
- Closes #37 