### PR TITLE
Heading typography adjustments

### DIFF
--- a/app/assets/stylesheets/sage/core/_typography.scss
+++ b/app/assets/stylesheets/sage/core/_typography.scss
@@ -1,4 +1,4 @@
-$sage-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+$sage-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 
 body {
   text-rendering: optimizeLegibility;
@@ -9,12 +9,15 @@ body {
   font-family: 'Inter', $sage-font-stack;
   font-weight: sage-font-weight();
   font-size: sage-font-size();
+  letter-spacing: 0.01875rem; // 0.3px
   line-height: sage-font-height();
   margin-bottom: sage-spacing();
+
+  @supports (font-variation-settings: normal) {
+    font-family: 'Inter var', $sage-font-stack;
+  }
 }
-@supports (font-variation-settings: normal) {
-  body { font-family: 'Inter var', $sage-font-stack; }
-}
+
 h1,
 h2,
 h3,
@@ -26,23 +29,41 @@ h6 {
   line-height: sage-font-height(sm);
   margin-bottom: sage-spacing();
 }
+
 h1 {
   font-size: sage-font-size(4xl);
+  letter-spacing: 0.05rem; // 0.8px
+  line-height: calc(50 / 39.81);
 }
+
 h2 {
   font-size: sage-font-size(3xl);
+  letter-spacing: 0.05rem; // 0.8px
+  line-height: calc(41 / 33.18);
 }
+
 h3 {
   font-size: sage-font-size(2xl);
+  letter-spacing: 0.03125rem; // 0.5px
+  line-height: calc(35 / 27.65);
 }
+
 h4 {
   font-size: sage-font-size(xl);
+  font-weight: sage-font-weight(semibold);
+  letter-spacing: 0.03125rem; // 0.5px
+  line-height: calc(29 / 23.04);
 }
+
 h5 {
   font-size: sage-font-size(lg);
+  font-weight: sage-font-weight(semibold);
+  line-height: calc(24 / 19.2);
 }
+
 h6 {
   font-size: sage-font-size(md);
+  font-weight: sage-font-weight(semibold);
 }
 
 p {
@@ -63,6 +84,7 @@ ul, ol, dl {
 
 a {
   color: sage-color(primary);
+
   &:hover,
   &:focus {
     color: inherit;

--- a/app/assets/stylesheets/sage_docs/_specs.scss
+++ b/app/assets/stylesheets/sage_docs/_specs.scss
@@ -2,14 +2,13 @@
   columns: 2;
   font-size: sage-font-size(sm);
   margin-bottom: sage-spacing(lg);
-  padding: sage-spacing(lg) sage-spacing(sm) sage-spacing(sm);
+  padding: 2.5rem sage-spacing(sm) sage-spacing(xs);
   border: 1px solid sage-color(grey, 300);
   border-radius: sage-border(radius);
   position: relative;
 
-  @media (min-width: sage-breakpoint(sm-min)) {
-    columns: 3;
-    padding: sage-spacing(lg) sage-spacing(xs) sage-spacing(xs);
+  @media (min-width: sage-breakpoint(xl-min)) {
+    columns: 4;
   }
 
   &::before {
@@ -18,7 +17,7 @@
     display: block;
     font-size: sage-font-size(xs);
     position: absolute;
-    padding: sage-spacing(xs);
+    padding: sage-spacing(xs) sage-spacing(sm);
     top: 0;
     left: 0;
     text-transform: uppercase;
@@ -30,8 +29,4 @@
   text-transform: uppercase;
 }
 
-.sage-specs__value {
-  @media (min-width: sage-breakpoint(sm-min)) {
-    margin-bottom: 0;
-  }
-}
+// .sage-specs__value {}

--- a/app/views/sage/pages/typography.html.erb
+++ b/app/views/sage/pages/typography.html.erb
@@ -27,11 +27,13 @@
     <pre class="prettyprint"><code>&lt;h1&gt;Empowering experts, entrepreneurs, and influencers to build online businesses.&lt;/h1&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="H1 specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">2.488rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">800</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.8px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.25</dd>
   </dl>
 </div>
@@ -42,11 +44,13 @@
     <pre class="prettyprint"><code>&lt;h2&gt;Empowering experts, entrepreneurs, and influencers to build online businesses.&lt;/h2&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="H2 specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">2.074rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">800</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.8px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.25</dd>
   </dl>
 </div>
@@ -57,11 +61,13 @@
     <pre class="prettyprint"><code>&lt;h3&gt;Empowering experts, entrepreneurs, and influencers to build online businesses.&lt;/h3&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="H3 specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">1.728rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">800</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.5px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.25</dd>
   </dl>
 </div>
@@ -72,11 +78,13 @@
     <pre class="prettyprint"><code>&lt;h4&gt;Empowering experts, entrepreneurs, and influencers to build online businesses.&lt;/h4&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="H4 specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">1.44rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">800</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.5px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.25</dd>
   </dl>
 </div>
@@ -87,11 +95,13 @@
     <pre class="prettyprint"><code>&lt;h5&gt;Empowering experts, entrepreneurs, and influencers to build online businesses.&lt;/h5&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="H5 specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">1.2rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">800</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.3px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.25</dd>
   </dl>
 </div>
@@ -102,11 +112,13 @@
     <pre class="prettyprint"><code>&lt;h6&gt;Empowering experts, entrepreneurs, and influencers to build online businesses.&lt;/h6&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="H6 specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">1rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">800</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.3px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.25</dd>
   </dl>
 </div>
@@ -117,11 +129,13 @@
     <pre class="prettyprint"><code>&lt;p&gt;Empowering experts, entrepreneurs, and influencers to build online businesses.&lt;/p&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="P specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">1rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">400</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.3px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.5</dd>
   </dl>
 </div>
@@ -151,11 +165,13 @@
 &lt;/ul&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="UL specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">1rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">400</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.3px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.5</dd>
   </dl>
 </div>
@@ -185,11 +201,13 @@
 &lt;/ol&gt;</code></pre>
   </div>
   <dl class="sage-specs" data-label="OL specifications">
-    <dt class="sage-specs__property">Font size:</dt>
+    <dt class="sage-specs__property">Font size</dt>
     <dd class="sage-specs__value">1rem</dd>
-    <dt class="sage-specs__property">Font weight:</dt>
+    <dt class="sage-specs__property">Font weight</dt>
     <dd class="sage-specs__value">400</dd>
-    <dt class="sage-specs__property">Line height:</dt>
+    <dt class="sage-specs__property">Letter spacing</dt>
+    <dd class="sage-specs__value">0.3px</dd>
+    <dt class="sage-specs__property">Line height</dt>
     <dd class="sage-specs__value">1.5</dd>
   </dl>
 </div>

--- a/app/views/sage/pages/typography.html.erb
+++ b/app/views/sage/pages/typography.html.erb
@@ -34,7 +34,7 @@
     <dt class="sage-specs__property">Letter spacing</dt>
     <dd class="sage-specs__value">0.8px</dd>
     <dt class="sage-specs__property">Line height</dt>
-    <dd class="sage-specs__value">1.25</dd>
+    <dd class="sage-specs__value">1.255</dd>
   </dl>
 </div>
 
@@ -51,7 +51,7 @@
     <dt class="sage-specs__property">Letter spacing</dt>
     <dd class="sage-specs__value">0.8px</dd>
     <dt class="sage-specs__property">Line height</dt>
-    <dd class="sage-specs__value">1.25</dd>
+    <dd class="sage-specs__value">1.235</dd>
   </dl>
 </div>
 
@@ -68,7 +68,7 @@
     <dt class="sage-specs__property">Letter spacing</dt>
     <dd class="sage-specs__value">0.5px</dd>
     <dt class="sage-specs__property">Line height</dt>
-    <dd class="sage-specs__value">1.25</dd>
+    <dd class="sage-specs__value">1.265</dd>
   </dl>
 </div>
 
@@ -85,7 +85,7 @@
     <dt class="sage-specs__property">Letter spacing</dt>
     <dd class="sage-specs__value">0.5px</dd>
     <dt class="sage-specs__property">Line height</dt>
-    <dd class="sage-specs__value">1.25</dd>
+    <dd class="sage-specs__value">1.258</dd>
   </dl>
 </div>
 


### PR DESCRIPTION
## Description
Corrects `letter-spacing` and `line-height` on headings.

### Screenshots
|  Before   |  After  |
|--------|--------|
|![headings-before](https://user-images.githubusercontent.com/816579/74575063-72be6800-4f3a-11ea-89e9-5bb8ae39a025.png)|![headings-after](https://user-images.githubusercontent.com/816579/74575067-76ea8580-4f3a-11ea-9c95-7c7697a20705.png)|

## Test notes

### Steps for testing
1. Run the local server with `rails s`
2. Navigate to "Styles" -> "Typography"
3. Inspect headings H1-H6 and verify that they match [Figma specs](https://www.figma.com/file/xlUFoRTjsFePavVT85SmLL/Sage-Design-System-v1.0?node-id=1%3A2) using your devtools inspector

## Related issues
- Closes #36 