### PR TITLE
Grid layout updates

### DIFF
--- a/app/assets/stylesheets/sage/layout/_container.scss
+++ b/app/assets/stylesheets/sage/layout/_container.scss
@@ -1,11 +1,23 @@
 .sage-container {
   margin: 0 auto;
-  padding: 0 sage-spacing();
-  max-width: sage-container();
+  padding: 0 sage-spacing(md);
+  max-width: sage-container(md);
+
+  &--xs {
+    @extend .sage-container;
+    max-width: sage-container(xs);
+  }
+
   &--sm {
     @extend .sage-container;
     max-width: sage-container(sm);
   }
+
+  &--lg {
+    @extend .sage-container;
+    max-width: sage-container(lg);
+  }
+
   &--fluid {
     @extend .sage-container;
     max-width: sage-container(fluid);

--- a/app/assets/stylesheets/sage/layout/_grid.scss
+++ b/app/assets/stylesheets/sage/layout/_grid.scss
@@ -1,28 +1,83 @@
+// ============================================
+// Variables
+// ============================================
+
+$sage-grid-columns-sm: 12;
+$sage-grid-columns-md: 12;
+$sage-grid-columns-lg: 12;
+
+$sage-grid-gap-sm: sage-spacing(sm);
+$sage-grid-gap-md: sage-spacing(sm);
+$sage-grid-gap-lg: sage-spacing(sm);
+
+// ============================================
+// Rows
+// ============================================
+
 .sage-row {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  margin-left: - sage-spacing(sm);
-  margin-right: - sage-spacing(sm);
+  margin-left: calc(#{$sage-grid-gap-md} / -2);
+  margin-right: calc(#{$sage-grid-gap-md} / -2);
 }
+
+// ============================================
+// Columns
+// ============================================
+
 .sage-col {
-  flex-basis: 100%;
+  flex: 0 0 100%;
   max-width: 100%;
-  padding: 0 sage-spacing(sm);
-  @for $sage-i from 1 through 12 {
-    &--#{$sage-i} {
+  padding: 0 calc(#{$sage-grid-gap-md} / 2);
+
+  @for $sage-i from 1 through $sage-grid-columns-sm {
+    &--sm-#{$sage-i} {
+      @extend .sage-col;
+    }
+  }
+
+  @for $sage-i from 1 through $sage-grid-columns-md {
+    &--md-#{$sage-i} {
+      @extend .sage-col;
+    }
+  }
+
+  @for $sage-i from 1 through $sage-grid-columns-lg {
+    &--lg-#{$sage-i} {
       @extend .sage-col;
     }
   }
 }
 
-@media (min-width: sage-breakpoint()) {
+@media (min-width: sage-breakpoint(sm-min)) {
   .sage-col {
-    flex: 1;
-    @for $sage-i from 1 through 12 {
-      &--#{$sage-i} {
-        flex-basis: percentage($sage-i / 12);
-        max-width: percentage($sage-i / 12);
+    @for $sage-i from 1 through $sage-grid-columns-sm {
+      &--sm-#{$sage-i} {
+        flex: 0 1 auto;
+        width: percentage($sage-i / $sage-grid-columns-sm);
+      }
+    }
+  }
+}
+
+@media (min-width: sage-breakpoint(md-min)) {
+  .sage-col {
+    @for $sage-i from 1 through $sage-grid-columns-md {
+      &--md-#{$sage-i} {
+        flex: 0 1 auto;
+        width: percentage($sage-i / $sage-grid-columns-md);
+      }
+    }
+  }
+}
+
+@media (min-width: sage-breakpoint(lg-min)) {
+  .sage-col {
+    @for $sage-i from 1 through $sage-grid-columns-lg {
+      &--lg-#{$sage-i} {
+        flex: 0 1 auto;
+        width: percentage($sage-i / $sage-grid-columns-lg);
       }
     }
   }

--- a/app/assets/stylesheets/sage/layout/_grid.scss
+++ b/app/assets/stylesheets/sage/layout/_grid.scss
@@ -31,6 +31,7 @@ $sage-grid-gap-lg: sage-spacing(sm);
   max-width: 100%;
   padding: 0 calc(#{$sage-grid-gap-md} / 2);
 
+  // TODO: create a mixin/function to reduce duplication below
   @for $sage-i from 1 through $sage-grid-columns-sm {
     &--sm-#{$sage-i} {
       @extend .sage-col;
@@ -50,6 +51,7 @@ $sage-grid-gap-lg: sage-spacing(sm);
   }
 }
 
+// TODO: create a mixin/function to reduce duplication
 @media (min-width: sage-breakpoint(sm-min)) {
   .sage-col {
     @for $sage-i from 1 through $sage-grid-columns-sm {

--- a/app/assets/stylesheets/sage/patterns/components/_form_section.scss
+++ b/app/assets/stylesheets/sage/patterns/components/_form_section.scss
@@ -6,7 +6,7 @@
   @extend .sage-row;
   margin-bottom: sage-spacing();
   &__info {
-    @extend .sage-col--4;
+    @extend .sage-col--md-4;
   }
   &__title {
     margin-bottom: sage-spacing(xs);
@@ -15,13 +15,13 @@
     color: sage-color(charcoal, 200);
   }
   &__content {
-    @extend .sage-col--8;
+    @extend .sage-col--md-8;
   }
   &__panel {
     @extend .sage-panel;
   }
   /* form_section responsive styles */
   @media (max-width: sage-breakpoint()) {
-    
+
   }
 }

--- a/app/assets/stylesheets/sage/tokens/_breakpoints.scss
+++ b/app/assets/stylesheets/sage/tokens/_breakpoints.scss
@@ -12,4 +12,5 @@ $sage-breakpoints: (
   lg-min: 992px,
   lg-max: 1199px,
   xl-min: 1200px,
+  xxl-min: 1440px,
 );

--- a/app/assets/stylesheets/sage/tokens/_container.scss
+++ b/app/assets/stylesheets/sage/tokens/_container.scss
@@ -4,7 +4,9 @@
 }
 
 $sage-containers: (
+  xs: 760px,
   sm: 900px,
   md: 1200px,
+  lg: 1440px,
   fluid: 100%,
 );

--- a/app/assets/stylesheets/sage_docs/_grid.scss
+++ b/app/assets/stylesheets/sage_docs/_grid.scss
@@ -1,6 +1,7 @@
 .grid-item {
   background: sage-color(grey, 200);
-  margin-bottom: sage-spacing();
-  padding: sage-spacing(xs) sage-spacing();
+  text-align: center;
+  margin-bottom: sage-spacing(md);
+  padding: sage-spacing(xs) sage-spacing(md);
   border-radius: sage-border(radius);
 }

--- a/app/assets/stylesheets/sage_docs/_token.scss
+++ b/app/assets/stylesheets/sage_docs/_token.scss
@@ -10,13 +10,14 @@
   border-bottom: sage-border();
   font-size: sage-font-size(sm);
   display: flex;
-  strong {
-    min-width: 300px;
-  }
+  justify-content: space-between;
+  flex-wrap: wrap;
+
   &:after {
-    width: 50%;
-    flex: 1;
+    font-family: monospace;
+    max-width: calc(100% / 3);
   }
+
   &-border:after { content: "#{sage-border()}" }
   @each $name, $token in $sage-borders {
     &-border-#{$name}:after { content: "#{$token}" }

--- a/app/views/layouts/sage/application.html.erb
+++ b/app/views/layouts/sage/application.html.erb
@@ -14,7 +14,7 @@
     <div class="sage-content">
       <div class="sage-container--lg">
         <div class="sage-row">
-          <div class="sage-col--lg-7">
+          <div class="sage-col--lg-6">
             <%= yield :heading %>
           </div>
         </div>

--- a/app/views/layouts/sage/application.html.erb
+++ b/app/views/layouts/sage/application.html.erb
@@ -12,19 +12,17 @@
     <input type="checkbox" id="sage-sidebar__toggle" class="sage-sidebar__checkbox" />
     <%= render "sidebar" %>
     <div class="sage-content">
-      <div class="sage-container">
+      <div class="sage-container--lg">
         <div class="sage-row">
-          <div class="sage-col--7">
+          <div class="sage-col--lg-7">
             <%= yield :heading %>
           </div>
         </div>
         <div class="sage-row">
-          <div class="sage-col--8">
+          <div class="sage-col--lg-9">
             <%= yield %>
           </div>
-          <div class="sage-col--4">
-            <%= yield :quick_links %>
-          </div>
+          <div class="sage-col--lg-3"><%= yield :quick_links %></div>
         </div>
       </div>
     </div>

--- a/app/views/sage/pages/color.html.erb
+++ b/app/views/sage/pages/color.html.erb
@@ -69,7 +69,7 @@ Use them for most of our text, backgrounds, and borders, as well as for things l
     </div>
   </div>
   <div class="sage-row">
-    <div class="sage-col--6">
+    <div class="sage-col--md-6">
       <h3 id="red">Red</h3>
       <%= render "color_values", color: "red"%>
     </div>

--- a/app/views/sage/pages/container.html.erb
+++ b/app/views/sage/pages/container.html.erb
@@ -10,6 +10,7 @@
       </div>
     </div>
     <a href="#standard" class="quick-links__link">Standard Container</a>
+    <a href="#xsmall" class="quick-links__link">Extra Small Container</a>
     <a href="#small" class="quick-links__link">Small Container</a>
     <a href="#full" class="quick-links__link">Full Width Container</a>
   </div>
@@ -19,9 +20,17 @@
   <pre class="prettyprint"><code>&lt;div class=&quot;sage-container&quot;&gt;
   &lt;!-- 1200px width container --&gt;
 &lt;/div&gt;</code></pre>
+  <h3 id="xsmall">Extra Small Container</h3>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-container--xs&quot;&gt;
+  &lt;!-- 760px width container --&gt;
+&lt;/div&gt;</code></pre>
   <h3 id="small">Small Container</h3>
   <pre class="prettyprint"><code>&lt;div class=&quot;sage-container--sm&quot;&gt;
   &lt;!-- 900px width container --&gt;
+&lt;/div&gt;</code></pre>
+  <h3 id="large">Large Container</h3>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-container--lg&quot;&gt;
+  &lt;!-- 1440px width container --&gt;
 &lt;/div&gt;</code></pre>
   <h3 id="full">Full Width Container</h3>
   <pre class="prettyprint"><code>&lt;div class=&quot;sage-container--fluid&quot;&gt;

--- a/app/views/sage/pages/grid.html.erb
+++ b/app/views/sage/pages/grid.html.erb
@@ -2,26 +2,37 @@
   <h1>Grid</h1>
 <% end %>
 <div class="sage-panel">
-  <div class="sage-row">
-    <div class="sage-col"><div class="grid-item">Col</div></div>
-    <div class="sage-col"><div class="grid-item">Col</div></div>
-    <div class="sage-col"><div class="grid-item">Col</div></div>
-    <div class="sage-col"><div class="grid-item">Col</div></div>
-  </div>
-  <div class="sage-row">
-    <div class="sage-col--4"><div class="grid-item">Col</div></div>
-    <div class="sage-col"><div class="grid-item">Col</div></div>
-    <div class="sage-col"><div class="grid-item">Col</div></div>
-  </div>
-  <pre class="prettyprint"><code>&lt;div class=&quot;sage-row&quot;&gt;
-  &lt;div class=&quot;sage-col--4&quot;&gt;Col&lt;/div&gt;
-  &lt;div class=&quot;sage-col&quot;&gt;Col&lt;/div&gt;
-  &lt;div class=&quot;sage-col&quot;&gt;Col&lt;/div&gt;
-&lt;/div&gt;</code></pre>
-  <% 10.times do |num| %>
+  <% 1.upto(9) do |num| %>
     <div class="sage-row">
-      <div class="sage-col--<%= num + 1%>"><div class="grid-item"><%= num + 1%></div></div>
-      <div class="sage-col"><div class="grid-item"><%= 11 - num%></div></div>
+      <div class="sage-col--md-<%= num + 1%>"><div class="grid-item"><%= num + 1%></div></div>
+      <div class="sage-col--md-<%= 11 - num%>"><div class="grid-item"><%= 11 - num%></div></div>
     </div>
   <% end %>
+</div>
+<div class="sage-panel">
+  <div class="sage-row">
+    <div class="sage-col--md-4"><div class="grid-item">Col</div></div>
+    <div class="sage-col--md-4"><div class="grid-item">Col</div></div>
+    <div class="sage-col--md-4"><div class="grid-item">Col</div></div>
+  </div>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-row&quot;&gt;
+  &lt;div class=&quot;sage-col--md-4&quot;&gt;Col&lt;/div&gt;
+  &lt;div class=&quot;sage-col--md-4&quot;&gt;Col&lt;/div&gt;
+  &lt;div class=&quot;sage-col--md-4&quot;&gt;Col&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+</div>
+<div class="sage-panel">
+  <div class="sage-row">
+    <div class="sage-col--lg-3"><div class="grid-item">Col</div></div>
+    <div class="sage-col--lg-3"><div class="grid-item">Col</div></div>
+    <div class="sage-col--lg-3"><div class="grid-item">Col</div></div>
+    <div class="sage-col--lg-3"><div class="grid-item">Col</div></div>
+  </div>
+  <pre class="prettyprint"><code>&lt;div class=&quot;sage-row&quot;&gt;
+  &lt;div class=&quot;sage-col--lg-3&quot;&gt;Col&lt;/div&gt;
+  &lt;div class=&quot;sage-col--lg-3&quot;&gt;Col&lt;/div&gt;
+  &lt;div class=&quot;sage-col--lg-3&quot;&gt;Col&lt;/div&gt;
+  &lt;div class=&quot;sage-col--lg-3&quot;&gt;Col&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
 </div>

--- a/app/views/sage/pages/start.html.erb
+++ b/app/views/sage/pages/start.html.erb
@@ -25,7 +25,7 @@
   <p>*All generators in the sage design system are created in the top level sage folder.</p>
   <pre class="prettyprint"><code>rails generate sage_component COMPONENT_NAME</code></pre>
   <p>This will create a file for the markup of the new sage component markup file and also the .scss file needed to style your new component.</p>
-  <p>The same can be done to create both elements and modules for the system and instructions can be found on the generators page.</p>
+  <p>The same can be done to create both elements and modules for the system. Instructions can be found on the <a href="/sage/pages/generators">generators page</a>.</p>
   <p>Changes made to the Sage Design System will be reflected as you work and should not be merged until they have been reviewed by another member of the UX Development team.</p>
   <p>Once changes are final the version number should be bumped. This file can be found in: <strong>lib/sage/version.rb</strong></p>
   <p>The last step is to head over to <a href="https://themes.kajabi.com/sage/changelog">https://themes.kajabi.com/sage/changelog</a> and document the changes to the system.</p>

--- a/app/views/sage/pages/token.html.erb
+++ b/app/views/sage/pages/token.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :heading do %>
   <h1>Tokens</h1>
-  <p>Design tokens are the visual design atoms of the design system — specifically, they are named entities that store visual design attributes. We use them in place of hard-coded values (such as hex values for color or pixel values for spacing) in order to maintain a scalable and consistent visual system for UI development.</p>
+  <p>Design tokens are the visual design atoms of the design system&mdash;specifically, they are named entities that store visual design attributes. We use them in place of hard-coded values (such as hex values for color or pixel values for spacing) in order to maintain a scalable and consistent visual system for UI development.</p>
 <% end %>
 <%= content_for :quick_links do %>
   <div class="quick-links">
@@ -17,7 +17,7 @@
 <% end %>
 <% sage_tokens.each do |token| %>
   <div class="sage-panel">
-    <h3 id="<%= token[:category] %>"><%= token[:category] %></h3>
+    <h3 id="<%= token[:category] %>"><%= token[:category].titleize %></h3>
     <h6>Default</h6>
     <div class="tokens">
       <div class="token token-<%= token[:category] %>"><strong>sage-<%= token[:category] %>( )</strong></div>


### PR DESCRIPTION
## Description
- Modifies grid to allow for predefined breakpoints.  `.sage--col-<column number>` is now deprecated in favor of the following:
  - `.sage-col--md-<column number>` for the  `768px` "medium" breakpoint (default)
  - `.sage-col--sm-<column number>` for the `545px` "small" breakpoint
  - `.sage-col--lg-<column number>` for the `992px` "large" breakpoint
- Added new `xxl-min` breakpoint for extra-extra-large screens (1440px)
- Added 2 container sizes for `xs` and `lg`
- Documentation updated to use new syntax and larger grid size
- A few text edits


## Related issues
- Resolves #42 