### PR TITLE
Jcm info in generators

### DIFF
--- a/app/views/sage/examples/components/_component.html.erb
+++ b/app/views/sage/examples/components/_component.html.erb
@@ -15,4 +15,6 @@
   <div class="example__code">
     <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/components/#{title}/preview") %></code></pre>
   </div>
+  <h6 class="example__label">Rules</h6>
+  <%= render "sage/examples/components/#{title}/rules" %>
 </div>

--- a/app/views/sage/examples/components/banner/_rules.html.erb
+++ b/app/views/sage/examples/components/banner/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/components/form_section/_rules.html.erb
+++ b/app/views/sage/examples/components/form_section/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/components/panel/_rules.html.erb
+++ b/app/views/sage/examples/components/panel/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/components/tabs/_rules.html.erb
+++ b/app/views/sage/examples/components/tabs/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -15,4 +15,6 @@
   <div class="example__code">
     <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{title}/preview") %></code></pre>
   </div>
+  <h6 class="example__label">Rules</h6>
+  <%= render "sage/examples/elements/#{title}/rules" %>
 </div>

--- a/app/views/sage/examples/elements/button/_rules.html.erb
+++ b/app/views/sage/examples/elements/button/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/elements/checkbox/_rules.html.erb
+++ b/app/views/sage/examples/elements/checkbox/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/elements/danger_button/_rules.html.erb
+++ b/app/views/sage/examples/elements/danger_button/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/elements/icon_button/_rules.html.erb
+++ b/app/views/sage/examples/elements/icon_button/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/elements/link_button/_rules.html.erb
+++ b/app/views/sage/examples/elements/link_button/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/elements/radio/_rules.html.erb
+++ b/app/views/sage/examples/elements/radio/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/sage/examples/elements/switch/_rules.html.erb
+++ b/app/views/sage/examples/elements/switch/_rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/lib/generators/sage_component/sage_component_generator.rb
+++ b/lib/generators/sage_component/sage_component_generator.rb
@@ -24,5 +24,10 @@ class SageComponentGenerator < Rails::Generators::NamedBase
       "#{match}\n        { title: \"#{file_name}\" },"
     end
 
+    # Rules Variables
+    markup_file = "app/views/sage/examples/components/#{file_name}/_rules.html.erb"
+    # Create Rules File
+    template "rules.html.erb", markup_file
+
   end
 end

--- a/lib/generators/sage_component/templates/rules.html.erb
+++ b/lib/generators/sage_component/templates/rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>

--- a/lib/generators/sage_element/sage_element_generator.rb
+++ b/lib/generators/sage_element/sage_element_generator.rb
@@ -24,5 +24,10 @@ class SageElementGenerator < Rails::Generators::NamedBase
       "#{match}\n        { title: \"#{file_name}\" },"
     end
 
+    # Rules Variables
+    markup_file = "app/views/sage/examples/elements/#{file_name}/_rules.html.erb"
+    # Create Markup File
+    template "rules.html.erb", markup_file
+
   end
 end

--- a/lib/generators/sage_element/sage_element_generator.rb
+++ b/lib/generators/sage_element/sage_element_generator.rb
@@ -26,7 +26,7 @@ class SageElementGenerator < Rails::Generators::NamedBase
 
     # Rules Variables
     markup_file = "app/views/sage/examples/elements/#{file_name}/_rules.html.erb"
-    # Create Markup File
+    # Create Rules File
     template "rules.html.erb", markup_file
 
   end

--- a/lib/generators/sage_element/templates/rules.html.erb
+++ b/lib/generators/sage_element/templates/rules.html.erb
@@ -1,0 +1,15 @@
+<p>Tell the developers a bit about how you expect this piece of code to be used. Be sure to point out anything that would not be clear simply by looking at the example above.</p>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <div class="sage-banner--success">
+      <p class="sage-banner__title">Do</p>
+      <p class="sage-banner__copy">An exmaple of proper use cases for this piece of code.</p>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <div class="sage-banner--danger">
+      <p class="sage-banner__title">Don't</p>
+      <p class="sage-banner__copy">An exmaple of a poor use cases for this piece of code.</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Adds a rules section to elements and components to tell developers about the gem. 
Also includes a section for do and dont info.
Adds this structure to the generators.
<img width="846" alt="Screen Shot 2020-02-26 at 11 25 16 AM" src="https://user-images.githubusercontent.com/14350772/75379790-d0cc4300-588a-11ea-91af-c068ad3b699c.png">
Closes #43
