### PR TITLE
REGRESSION: quick link structure

### DIFF
--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -14,7 +14,8 @@
         <a href="#preview" class="quick-links__link">Preview</a>
       </li>
       <li class="quick-links__item">
-        <a href="#code" class="quick-links__link">Code</a></li>
+        <a href="#code" class="quick-links__link">Code</a>
+      </li>
       <li class="quick-links__item">
         <a href="#props" class="quick-links__link">Properties</a>
       </li>

--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -5,16 +5,23 @@
 
 <%= content_for :quick_links do %>
   <div class="quick-links">
-    <div class="sage-media">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
-      <div class="sage-media__body">
-        <h5 class="quick-links__heading">Contents</h5>
-      </div>
+    <div class="quick-links__header">
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
+      <h5 class="quick-links__title">Contents</h5>
     </div>
-    <a href="#preview" class="quick-links__link">Preview</a>
-    <a href="#code" class="quick-links__link">Code</a>
-    <a href="#props" class="quick-links__link">Properties</a>
-    <a href="#best" class="quick-links__link">Best Practices</a>
+    <ul class="quick-links__body">
+      <li class="quick-links__item">
+        <a href="#preview" class="quick-links__link">Preview</a>
+      </li>
+      <li class="quick-links__item">
+        <a href="#code" class="quick-links__link">Code</a></li>
+      <li class="quick-links__item">
+        <a href="#props" class="quick-links__link">Properties</a>
+      </li>
+      <li class="quick-links__item">
+        <a href="#best" class="quick-links__link">Best Practices</a>
+      </li>
+    </ul>
   </div>
 <% end %>
 

--- a/app/views/sage/examples/objects/_object.html.erb
+++ b/app/views/sage/examples/objects/_object.html.erb
@@ -9,7 +9,7 @@
       <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
-    <ul>
+    <ul class="quick-links__body">
       <li class="quick-links__item">
         <a href="#preview" class="quick-links__link">Preview</a>
       </li>

--- a/app/views/sage/examples/objects/_object.html.erb
+++ b/app/views/sage/examples/objects/_object.html.erb
@@ -5,16 +5,24 @@
 
 <%= content_for :quick_links do %>
   <div class="quick-links">
-    <div class="sage-media">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
-      <div class="sage-media__body">
-        <h5 class="quick-links__heading">Contents</h5>
-      </div>
+    <div class="quick-links__header">
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
+      <h5 class="quick-links__title">Contents</h5>
     </div>
-    <a href="#preview" class="quick-links__link">Preview</a>
-    <a href="#code" class="quick-links__link">Code</a>
-    <a href="#props" class="quick-links__link">Properties</a>
-    <a href="#best" class="quick-links__link">Best Practices</a>
+    <ul>
+      <li class="quick-links__item">
+        <a href="#preview" class="quick-links__link">Preview</a>
+      </li>
+      <li class="quick-links__item">
+        <a href="#code" class="quick-links__link">Code</a>
+      </li>
+      <li class="quick-links__item">
+        <a href="#props" class="quick-links__link">Properties</a>
+      </li>
+      <li class="quick-links__item">
+        <a href="#best" class="quick-links__link">Best Practices</a>
+      </li>
+    </ul>
   </div>
 <% end %>
 

--- a/app/views/sage/pages/color.html.erb
+++ b/app/views/sage/pages/color.html.erb
@@ -7,7 +7,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">

--- a/app/views/sage/pages/container.html.erb
+++ b/app/views/sage/pages/container.html.erb
@@ -5,7 +5,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-file-content aria-hidden="true"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">

--- a/app/views/sage/pages/container.html.erb
+++ b/app/views/sage/pages/container.html.erb
@@ -5,7 +5,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">

--- a/app/views/sage/pages/elements.html.erb
+++ b/app/views/sage/pages/elements.html.erb
@@ -6,7 +6,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">

--- a/app/views/sage/pages/objects.html.erb
+++ b/app/views/sage/pages/objects.html.erb
@@ -5,15 +5,15 @@
 <% end %>
 <%= content_for :quick_links do %>
   <div class="quick-links">
-    <div class="sage-media">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
-      <div class="sage-media__body">
-        <h5 class="quick-links__heading">Contents</h5>
-      </div>
+    <div class="quick-links__header">
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
+      <h5 class="quick-links__title">Contents</h5>
     </div>
-    <% sorted_sage_objects.each do |object| %>
-      <a href="#<%= object[:title] %>" class="quick-links__link"><%= object[:title].titleize %></a>
-    <% end %>
+    <ul>
+      <% sorted_sage_objects.each do |object| %>
+        <li class="quick-links__item"><a href="#<%= object[:title] %>" class="quick-links__link"><%= object[:title].titleize %></a>
+      <% end %>
+    </ul>
   </div>
 <% end %>
 <% sorted_sage_objects.each do |object| %>

--- a/app/views/sage/pages/objects.html.erb
+++ b/app/views/sage/pages/objects.html.erb
@@ -9,7 +9,7 @@
       <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
-    <ul>
+    <ul class="quick-links__body">
       <% sorted_sage_objects.each do |object| %>
         <li class="quick-links__item"><a href="#<%= object[:title] %>" class="quick-links__link"><%= object[:title].titleize %></a>
       <% end %>

--- a/app/views/sage/pages/status.html.erb
+++ b/app/views/sage/pages/status.html.erb
@@ -6,7 +6,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">

--- a/app/views/sage/pages/token.html.erb
+++ b/app/views/sage/pages/token.html.erb
@@ -6,7 +6,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">

--- a/app/views/sage/pages/typography.html.erb
+++ b/app/views/sage/pages/typography.html.erb
@@ -6,7 +6,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">

--- a/app/views/sage/pages/utilities.html.erb
+++ b/app/views/sage/pages/utilities.html.erb
@@ -5,7 +5,7 @@
 <%= content_for :quick_links do %>
   <div class="quick-links">
     <div class="quick-links__header">
-      <i class="quick-links__icon sage-icon sage-icon-menu-8"></i>
+      <i class="quick-links__icon sage-icon sage-icon-file-content" aria-hidden="true"></i>
       <h5 class="quick-links__title">Contents</h5>
     </div>
     <ul class="quick-links__body">


### PR DESCRIPTION
## Description
Quick links structure and classes have reverted to the previous version.

- [X] Restructure markup to match updates performed in #54 
- [X] Update heading icon from `sage-icon-menu-8` to `sage-icon-file-content` 

### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screen Shot 2020-03-05 at 4 53 23 PM](https://user-images.githubusercontent.com/1175111/76039634-de746f00-5f01-11ea-909b-198c849d4b3f.png)|![Screen Shot 2020-03-05 at 4 53 07 PM](https://user-images.githubusercontent.com/1175111/76039643-e3d1b980-5f01-11ea-91c9-a21e769254d3.png)|

### Steps for testing

- Spin up Sage
- Visit multiple pages in the sidebar
- Verify that the markup structure in quick links matches updates from #54 

## Related PR
- #54 