### PR TITLE
Add visual indicators for page navigation

### DIFF
--- a/app/assets/stylesheets/sage/patterns/objects/_nav.scss
+++ b/app/assets/stylesheets/sage/patterns/objects/_nav.scss
@@ -2,9 +2,10 @@
   &__link {
     display: flex;
     align-items: center;
-    margin: sage-spacing(xs) 0;
+    margin: sage-spacing(2xs) 0;
     font-weight: 500;
     color: sage-color(charcoal, 400);
+    padding: sage-spacing(2xs) sage-spacing(xs);
     &:hover {
       color: sage-color(charcoal, 500);
       i {
@@ -19,12 +20,13 @@
         color: sage-color(primary);
       }
     }
-    &--active{
-      color: sage-color(primary);
+    &--active {
+      background: sage-color(grey, 300);
+      border-radius: sage-border(radius);
     }
     i {
-      font-size: sage-spacing();
       margin-right: sage-spacing(xs);
+      font-size: sage-spacing();
       color: sage-color(grey, 500);
     }
   }

--- a/app/assets/stylesheets/sage/patterns/objects/_nav.scss
+++ b/app/assets/stylesheets/sage/patterns/objects/_nav.scss
@@ -6,24 +6,23 @@
     padding: sage-spacing(2xs) sage-spacing(xs);
     font-weight: 500;
     color: sage-color(charcoal, 400);
+    border-radius: sage-border(radius);
     &:hover {
-      color: sage-color(charcoal, 500);
+      background: sage-color(grey, 300);
       i {
         color: sage-color(primary);
       }
     }
     &--sub {
       @extend .sage-nav__link;
-      padding: sage-spacing(2xs) sage-spacing(xs);
       margin: sage-spacing(xs);
       font-size: sage-font-size(sm);
       &:hover {
-        color: sage-color(primary);
+        background: sage-color(grey, 300);
       }
     }
     &--active {
       background: sage-color(grey, 300);
-      border-radius: sage-border(radius);
     }
     i {
       margin-right: sage-spacing(xs);

--- a/app/assets/stylesheets/sage/patterns/objects/_nav.scss
+++ b/app/assets/stylesheets/sage/patterns/objects/_nav.scss
@@ -3,9 +3,9 @@
     display: flex;
     align-items: center;
     margin: sage-spacing(2xs) 0;
+    padding: sage-spacing(2xs) sage-spacing(xs);
     font-weight: 500;
     color: sage-color(charcoal, 400);
-    padding: sage-spacing(2xs) sage-spacing(xs);
     &:hover {
       color: sage-color(charcoal, 500);
       i {

--- a/app/assets/stylesheets/sage/patterns/objects/_nav.scss
+++ b/app/assets/stylesheets/sage/patterns/objects/_nav.scss
@@ -14,7 +14,8 @@
     }
     &--sub {
       @extend .sage-nav__link;
-      margin: sage-spacing(xs) sage-spacing(lg);
+      padding: sage-spacing(2xs) sage-spacing(xs);
+      margin: sage-spacing(xs);
       font-size: sage-font-size(sm);
       &:hover {
         color: sage-color(primary);

--- a/app/assets/stylesheets/sage/patterns/objects/_nav.scss
+++ b/app/assets/stylesheets/sage/patterns/objects/_nav.scss
@@ -19,6 +19,9 @@
         color: sage-color(primary);
       }
     }
+    &--active{
+      color: sage-color(primary);
+    }
     i {
       font-size: sage-spacing();
       margin-right: sage-spacing(xs);

--- a/app/helpers/sage/application_helper.rb
+++ b/app/helpers/sage/application_helper.rb
@@ -1,4 +1,9 @@
 module Sage
   module ApplicationHelper
+    
+    def current?(key, path)
+      "#{key}" if current_page? path
+    end
+
   end
 end

--- a/app/views/sage/application/_sidebar.html.erb
+++ b/app/views/sage/application/_sidebar.html.erb
@@ -1,20 +1,20 @@
 <div class="sage-sidebar" id="sage-sidebar-menu">
   <div class="sage-sidebar__body">
     <div class="sage-nav">
-      <%= link_to "Introduction", pages_index_url, class: "sage-nav__link" %>
+      <%= link_to "Introduction", pages_index_url, class: "#{current? "sage-nav__link--active", pages_index_url} sage-nav__link" %>
       <%= link_to "Guidelines", "https://github.com/Kajabi/sage/wiki", class: "sage-nav__link", target: "_blank" %>
       <%= link_to "Styles", pages_token_url, class: "sage-nav__link" %>
       <%= yield :sidebar_styles %>
-      <%= link_to "Elements", pages_elements_url, class: "sage-nav__link" %>
+      <%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %>
       <%= yield :sidebar_elements %>
-      <%= link_to "Objects", pages_objects_url, class: "sage-nav__link" %>
+      <%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %>
       <%= yield :sidebar_objects %>
-      <%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link" %>
+      <%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_utilities_url}" %>
     </div>
   </div>
   <div class="sage-sidebar__footer">
     <div class="sage-nav">
-      <%= link_to "Code Status", pages_status_url, class: "sage-nav__link" %>
+      <%= link_to "Code Status", pages_status_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_status_url}" %>
       <%= link_to "Github", "https://github.com/Kajabi/sage", class: "sage-nav__link", target: "_blank" %>
       <%= link_to "Changelog", "https://github.com/Kajabi/sage/wiki/Changelog", class: "sage-nav__link", target: "_blank" %>
     </div>

--- a/app/views/sage/application/_sidebar_elements.html.erb
+++ b/app/views/sage/application/_sidebar_elements.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :sidebar_elements do %>
   <% sorted_sage_elements.each do |element| %>
-    <%= link_to pages_element_url(title: element[:title], description: element[:description]), class: "sage-nav__link--sub" do %>
+    <%= link_to pages_element_url(title: element[:title], description: element[:description]), class: "#{current? "sage-nav__link--active", pages_element_url(title: element[:title], description: element[:description])} sage-nav__link--sub" do %>
       <%= element[:title].titleize %>
     <% end %>
   <% end %>

--- a/app/views/sage/application/_sidebar_objects.html.erb
+++ b/app/views/sage/application/_sidebar_objects.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :sidebar_objects do %>
   <% sorted_sage_objects.each do |object| %>
-    <%= link_to pages_object_url(title: object[:title], description: object[:description]), class: "sage-nav__link--sub" do %>
+    <%= link_to pages_object_url(title: object[:title], description: object[:description]), class: "#{current? "sage-nav__link--active", pages_object_url(title: object[:title], description: object[:description])} sage-nav__link--sub" do %>
       <%= object[:title].titleize %>
     <% end %>
   <% end %>

--- a/app/views/sage/application/_sidebar_styles.html.erb
+++ b/app/views/sage/application/_sidebar_styles.html.erb
@@ -1,8 +1,8 @@
 <%= content_for :sidebar_styles do %>
-  <%= link_to "Tokens", pages_token_url, class: "sage-nav__link--sub" %>
-  <%= link_to "Colors", pages_color_url, class: "sage-nav__link--sub" %>
-  <%= link_to "Typography", pages_typography_url, class: "sage-nav__link--sub" %>
-  <%= link_to "Icons", pages_icon_url, class: "sage-nav__link--sub" %>
-  <%= link_to "Containers", pages_container_url, class: "sage-nav__link--sub" %>
-  <%= link_to "Grid", pages_grid_url, class: "sage-nav__link--sub" %>
+  <%= link_to "Tokens", pages_token_url, class: "#{current? "sage-nav__link--active", pages_token_url} sage-nav__link--sub" %>
+  <%= link_to "Colors", pages_color_url, class: "#{current? "sage-nav__link--active", pages_color_url} sage-nav__link--sub" %>
+  <%= link_to "Typography", pages_typography_url, class: "#{current? "sage-nav__link--active", pages_typography_url} sage-nav__link--sub" %>
+  <%= link_to "Icons", pages_icon_url, class: "#{current? "sage-nav__link--active", pages_icon_url} sage-nav__link--sub" %>
+  <%= link_to "Containers", pages_container_url, class: "#{current? "sage-nav__link--active", pages_container_url} sage-nav__link--sub" %>
+  <%= link_to "Grid", pages_grid_url, class: "#{current? "sage-nav__link--active", pages_grid_url} sage-nav__link--sub" %>
 <% end %>


### PR DESCRIPTION
Indicators for active navigation are not displayed, making it difficult to visualize the current page state at a glance.

![page-nav](https://user-images.githubusercontent.com/816579/74183266-7b8d0200-4bf9-11ea-9369-4c3089fa03c8.png)

Suggested solutions to explore:

- Render breadcrumb nav below the title
- Highlight current/active page in sidebar navigation

~~Adding active page states in the sidebar will most likely require remapping the existing page routing. For example, the current route `/pages/conventions` would go to `/guidelines/conventions`.~~

An 'overview' page may also need to be added when a user selects "Conventions" in the navigation, rather than redirecting to the first subitem. This would be especially necessary for a breadcrumb nav.