### PR TITLE
Form inputs

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -141,6 +141,7 @@
     "selector-class-pattern": null,
     "scss/double-slash-comment-whitespace-inside": "always",
     "scss/dimension-no-non-numeric-values": true,
+    "scss/dollar-variable-pattern": "^[-]?[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
     "scss/operator-no-unspaced": true,
     "scss/no-duplicate-mixins": true,
     "selector-no-qualifying-type": [true, { "ignore": ["attribute"] }],

--- a/app/assets/stylesheets/sage.css.scss
+++ b/app/assets/stylesheets/sage.css.scss
@@ -44,6 +44,7 @@
 @import "sage/patterns/elements/button";
 @import "sage/patterns/elements/icon_button";
 @import "sage/patterns/elements/menu_button";
+@import "sage/patterns/elements/form_input";
 @import "sage/patterns/elements/checkbox";
 @import "sage/patterns/elements/radio";
 @import "sage/patterns/elements/switch";

--- a/app/assets/stylesheets/sage/core/_variables.scss
+++ b/app/assets/stylesheets/sage/core/_variables.scss
@@ -100,6 +100,9 @@ $sage-inputfield-padding: 1.125rem !default;  // 18px
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
 $sage-inputfield-padding-filled: 0.25rem !default;
 
+// Spacing
+$sage-inputfield-spacing: 2rem;
+
 // Colors
 $sage-inputfield-color-default: sage-color(charcoal) !default;
 $sage-inputfield-color-disabled: sage-color(grey, 400) !default;

--- a/app/assets/stylesheets/sage/core/_variables.scss
+++ b/app/assets/stylesheets/sage/core/_variables.scss
@@ -16,6 +16,7 @@
 // FONTS
 // ==================================================
 $sage-body-font-path: "inter" !default;
+$sage-body-font-size: 1rem !default; // 16px
 $sage-body-font-version: 3.12 !default;
 $sage-body-letter-spacing: 0.01875rem !default;
 $sage-font-stack: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", sans-serif !default;
@@ -75,6 +76,32 @@ $sage-menubtn-toggle-radius: 0.125rem !default; // 2px
 $sage-menubtn-focus-outline-size: sage-spacing(xs) !default;
 $sage-menubtn-focus-outline-width: 1 !default;
 $sage-menubtn-focus-outline-color: currentColor !default;
+
+
+// ==================================================
+// INPUT FIELDS
+// ==================================================
+
+$sage-inputfield-padding: 1.125rem !default;  // 18px
+$sage-inputfield-padding-filled: 0.25rem !default;
+$sage-inputfield-font-size: $sage-body-font-size !default;
+$sage-inputfield-height: 3.5rem !default;  // 56px
+$sage-inputfield-letter-spacing: $sage-body-letter-spacing !default;
+
+// Floating label
+$sage-inputfield-label-font-size: 0.6875rem !default;
+$sage-inputfield-label-font-weight: sage-font-weight(semibold) !default;
+
+// Border
+$sage-inputfield-border-radius: sage-border(radius) !default;
+$sage-inputfield-border-width: 0.0625rem !default;  // 1px
+
+// Colors
+$sage-inputfield-color-default: sage-color(charcoal) !default;
+$sage-inputfield-color-disabled: sage-color(grey, 400) !default;
+$sage-inputfield-color-default: sage-color(grey, 300) !default;
+$sage-inputfield-color-success: sage-color(primary) !default;
+$sage-inputfield-color-error: sage-color(red) !default;
 
 
 // ==================================================

--- a/app/assets/stylesheets/sage/core/_variables.scss
+++ b/app/assets/stylesheets/sage/core/_variables.scss
@@ -92,7 +92,7 @@ $sage-inputfield-label-font-weight: sage-font-weight(semibold) !default;
 // Border
 $sage-inputfield-border-radius: sage-border(radius) !default;
 $sage-inputfield-border-width: 0.0625rem !default;  // 1px
-$sage-inputfield-box-shadow-size: 0 0 0 0.0625remx !default;
+$sage-inputfield-box-shadow-size: 0 0 0 0.0625rem !default;
 
 // Sizing
 $sage-inputfield-height: 3.5rem !default;  // 56px

--- a/app/assets/stylesheets/sage/core/_variables.scss
+++ b/app/assets/stylesheets/sage/core/_variables.scss
@@ -82,10 +82,7 @@ $sage-menubtn-focus-outline-color: currentColor !default;
 // INPUT FIELDS
 // ==================================================
 
-$sage-inputfield-padding: 1.125rem !default;  // 18px
-$sage-inputfield-padding-filled: 0.25rem !default;
 $sage-inputfield-font-size: $sage-body-font-size !default;
-$sage-inputfield-height: 3.5rem !default;  // 56px
 $sage-inputfield-letter-spacing: $sage-body-letter-spacing !default;
 
 // Floating label
@@ -96,12 +93,19 @@ $sage-inputfield-label-font-weight: sage-font-weight(semibold) !default;
 $sage-inputfield-border-radius: sage-border(radius) !default;
 $sage-inputfield-border-width: 0.0625rem !default;  // 1px
 
+// Sizing
+$sage-inputfield-height: 3.5rem !default;  // 56px
+$sage-inputfield-padding: 1.125rem !default;  // 18px
+$sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
+$sage-inputfield-padding-filled: 0.25rem !default;
+
 // Colors
 $sage-inputfield-color-default: sage-color(charcoal) !default;
 $sage-inputfield-color-disabled: sage-color(grey, 400) !default;
 $sage-inputfield-color-default: sage-color(grey, 300) !default;
 $sage-inputfield-color-success: sage-color(primary) !default;
 $sage-inputfield-color-error: sage-color(red) !default;
+$sage-inputfield-bg-disabled: sage-color(grey, 100) !default;
 
 
 // ==================================================

--- a/app/assets/stylesheets/sage/core/_variables.scss
+++ b/app/assets/stylesheets/sage/core/_variables.scss
@@ -92,6 +92,7 @@ $sage-inputfield-label-font-weight: sage-font-weight(semibold) !default;
 // Border
 $sage-inputfield-border-radius: sage-border(radius) !default;
 $sage-inputfield-border-width: 0.0625rem !default;  // 1px
+$sage-inputfield-box-shadow-size: 0 0 0 0.0625remx !default;
 
 // Sizing
 $sage-inputfield-height: 3.5rem !default;  // 56px

--- a/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
@@ -4,11 +4,6 @@
 
 ================================================== */
 
-@mixin floating-label {
-  transform: translateY(calc(-50% - (#{$sage-inputfield-font-size} - #{$sage-inputfield-padding-filled})));
-  opacity: 1;
-}
-
 .sage-input {
   position: relative;
   height: $sage-inputfield-height;
@@ -20,7 +15,7 @@
 
 .sage-input__label {
   position: absolute;
-  transform: translateY(calc(-1 * #{$sage-inputfield-font-size}));
+  transform: translateY(calc(#{$sage-inputfield-font-size} * -1));
   left: $sage-inputfield-padding;
   top: 50%;
   color: inherit;
@@ -31,6 +26,14 @@
 }
 
 .sage-input__field {
+  $-ie-label-offset: -($sage-inputfield-font-size + $sage-inputfield-padding-filled);
+
+  @mixin floating-label {
+    transform: translateY($-ie-label-offset); // IE doesn't support calc in transforms
+    transform: translateY(calc(-50% - (#{$sage-inputfield-font-size} - #{$sage-inputfield-padding-filled})));
+    opacity: 1;
+  }
+
   height: 100%;
   width: 100%;
   padding: $sage-inputfield-padding-offset $sage-inputfield-padding;
@@ -46,10 +49,14 @@
   }
 
   &:focus:not(:disabled),
-  &:active:not(:disabled),
-  &:valid:not(:placeholder-shown),
-  &:required:not(:placeholder-shown) {
+  &:active:not(:disabled) {
     padding-bottom: $sage-inputfield-padding-filled;
+    border-color: currentColor;
+    outline: none;
+
+    @include placeholder {
+      opacity: 0;
+    }
 
     .sage-input--no-label & {
       padding-bottom: $sage-inputfield-padding;
@@ -62,13 +69,18 @@
     }
   }
 
-  &:focus:not(:disabled),
-  &:active:not(:disabled) {
-    border-color: currentColor;
-    outline: none;
+  &:valid:not(:placeholder-shown),
+  &:required:not(:placeholder-shown) {
+    padding-bottom: $sage-inputfield-padding-filled;
 
-    &::placeholder {
-      opacity: 0;
+    ~ .sage-input__label {
+      @include floating-label();
+
+      transition: opacity 0.15s ease-out, transform 0.15s ease-in-out, color 0.15s ease-out;
+    }
+
+    .sage-input--no-label & {
+      padding-bottom: $sage-inputfield-padding;
     }
   }
 

--- a/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
@@ -1,0 +1,39 @@
+/* ==================================================
+  ** _form_inputs.scss
+  type: element
+
+================================================== */
+
+@mixin floating-label {
+  transform: translateY(calc(-50% - ($sage-inputfield-font-size - $sage-inputfield-padding-filled)));
+  opacity: 1;
+}
+
+.sage-input {
+  position: relative;
+}
+
+.sage-input__field {
+  height: 100%;
+  width: 100%;
+  padding: $sage-inputfield-padding;
+  color: $sage-inputfield-color-default;
+  font-family: inherit;
+  line-height: 1;
+  border: $sage-inputfield-border-width solid $sage-inputfield-color-default;
+  border-radius: $sage-inputfield-border-radius;
+  background: transparent;
+  transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.sage-input__label {
+  position: absolute;
+  transform: translateY(calc(-1 * $sage-inputfield-font-size));
+  left: $sage-inputfield-padding;
+  top: 50%;
+  color: inherit;
+  font-size: $sage-inputfield-label-font-size; // 11px
+  font-weight: $sage-inputfield-label-font-weight;
+  pointer-events: none;
+  opacity: 0;
+}

--- a/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
@@ -13,19 +13,6 @@
   position: relative;
 }
 
-.sage-input__field {
-  height: 100%;
-  width: 100%;
-  padding: $sage-inputfield-padding;
-  color: $sage-inputfield-color-default;
-  font-family: inherit;
-  line-height: 1;
-  border: $sage-inputfield-border-width solid $sage-inputfield-color-default;
-  border-radius: $sage-inputfield-border-radius;
-  background: transparent;
-  transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-}
-
 .sage-input__label {
   position: absolute;
   transform: translateY(calc(-1 * $sage-inputfield-font-size));
@@ -37,3 +24,26 @@
   pointer-events: none;
   opacity: 0;
 }
+
+.sage-input__field {
+  height: 100%;
+  width: 100%;
+  padding: $sage-inputfield-padding-offset $sage-inputfield-padding;
+  color: $sage-inputfield-color-default;
+  line-height: 1;
+  border: $sage-inputfield-border-width solid $sage-inputfield-color-default;
+  border-radius: $sage-inputfield-border-radius;
+  background: transparent;
+  transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+
+  @include placeholder {
+    color: inherit;
+  }
+
+  &:disabled {
+    color: $sage-inputfield-color-disabled;
+    background-color: $sage-inputfield-bg-disabled;
+    cursor: not-allowed;
+  }
+}
+

--- a/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
@@ -12,6 +12,10 @@
 .sage-input {
   position: relative;
   height: $sage-inputfield-height;
+
+  &:not(:last-child) {
+    margin-bottom: $sage-inputfield-spacing;
+  }
 }
 
 .sage-input__label {
@@ -44,8 +48,12 @@
   &:focus:not(:disabled),
   &:active:not(:disabled),
   &:valid:not(:placeholder-shown),
-  &:required:not(:placeholder-shown):not(:valid) {
+  &:required:not(:placeholder-shown) {
     padding-bottom: $sage-inputfield-padding-filled;
+
+    .sage-input--no-label & {
+      padding-bottom: $sage-inputfield-padding;
+    }
 
     ~ .sage-input__label {
       @include floating-label();

--- a/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/patterns/elements/_form_input.scss
@@ -5,17 +5,18 @@
 ================================================== */
 
 @mixin floating-label {
-  transform: translateY(calc(-50% - ($sage-inputfield-font-size - $sage-inputfield-padding-filled)));
+  transform: translateY(calc(-50% - (#{$sage-inputfield-font-size} - #{$sage-inputfield-padding-filled})));
   opacity: 1;
 }
 
 .sage-input {
   position: relative;
+  height: $sage-inputfield-height;
 }
 
 .sage-input__label {
   position: absolute;
-  transform: translateY(calc(-1 * $sage-inputfield-font-size));
+  transform: translateY(calc(-1 * #{$sage-inputfield-font-size}));
   left: $sage-inputfield-padding;
   top: 50%;
   color: inherit;
@@ -38,6 +39,47 @@
 
   @include placeholder {
     color: inherit;
+  }
+
+  &:focus:not(:disabled),
+  &:active:not(:disabled),
+  &:valid:not(:placeholder-shown),
+  &:required:not(:placeholder-shown):not(:valid) {
+    padding-bottom: $sage-inputfield-padding-filled;
+
+    ~ .sage-input__label {
+      @include floating-label();
+
+      transition: opacity 0.15s ease-out, transform 0.15s ease-in-out, color 0.15s ease-out;
+    }
+  }
+
+  &:focus:not(:disabled),
+  &:active:not(:disabled) {
+    border-color: currentColor;
+    outline: none;
+
+    &::placeholder {
+      opacity: 0;
+    }
+  }
+
+  &:valid:not(:placeholder-shown) {
+    border-color: $sage-inputfield-color-success;
+    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-success;
+
+    ~ .sage-input__label {
+      color: $sage-inputfield-color-success;
+    }
+  }
+
+  &:required:not(:placeholder-shown):not(:valid) {
+    border-color: $sage-inputfield-color-error;
+    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-error;
+
+    ~ .sage-input__label {
+      color: $sage-inputfield-color-error;
+    }
   }
 
   &:disabled {

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -15,16 +15,16 @@ module Sage
         # Sage Generated Elements
         {
           title: "form_input",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-          scss_design:  "todo",
-          scss_dev:     "todo",
-          scss_doc:     "todo",
-          rails_design: "todo",
-          rails_dev:    "todo",
-          rails_doc:    "todo",
-          react_design: "todo",
-          react_dev:    "todo",
-          react_doc:    "todo"
+          description: "Text or numeric input form fields",
+          scss_design:  "done",
+          scss_dev:     "doing",
+          scss_doc:     "doing",
+          rails_design: "no",
+          rails_dev:    "no",
+          rails_doc:    "no",
+          react_design: "no",
+          react_dev:    "no",
+          react_doc:    "no"
         },
         {
           title: "loader",

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -2,10 +2,10 @@ module Sage
   module ElementsHelper
     ########################################################
     # STATUS KEY
-    # Done : done 
-    # In Progress : doing 
-    # To-do : todo 
-    # Not applicable : no 
+    # Done : done
+    # In Progress : doing
+    # To-do : todo
+    # Not applicable : no
     # Deprecated : stop
     ########################################################
 
@@ -13,6 +13,19 @@ module Sage
     def sage_elements
       [
         # Sage Generated Elements
+        {
+          title: "form_input",
+          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+          scss_design:  "todo",
+          scss_dev:     "todo",
+          scss_doc:     "todo",
+          rails_design: "todo",
+          rails_dev:    "todo",
+          rails_doc:    "todo",
+          react_design: "todo",
+          react_dev:    "todo",
+          react_doc:    "todo"
+        },
         {
           title: "loader",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
@@ -26,8 +39,8 @@ module Sage
           react_dev:    "todo",
           react_doc:    "todo"
         },
-        { 
-          title: "icon_button", 
+        {
+          title: "icon_button",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "todo",
           scss_dev:     "todo",
@@ -39,8 +52,8 @@ module Sage
           react_dev:    "todo",
           react_doc:    "todo"
         },
-        { 
-          title: "checkbox", 
+        {
+          title: "checkbox",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "todo",
           scss_dev:     "todo",
@@ -52,8 +65,8 @@ module Sage
           react_dev:    "todo",
           react_doc:    "todo"
         },
-        { 
-          title: "switch", 
+        {
+          title: "switch",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "todo",
           scss_dev:     "todo",
@@ -65,8 +78,8 @@ module Sage
           react_dev:    "todo",
           react_doc:    "todo"
         },
-        { 
-          title: "radio", 
+        {
+          title: "radio",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "todo",
           scss_dev:     "todo",
@@ -78,8 +91,8 @@ module Sage
           react_dev:    "todo",
           react_doc:    "todo"
         },
-        { 
-          title: "link_button", 
+        {
+          title: "link_button",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "todo",
           scss_dev:     "todo",
@@ -91,8 +104,8 @@ module Sage
           react_dev:    "todo",
           react_doc:    "todo"
         },
-        { 
-          title: "danger_button", 
+        {
+          title: "danger_button",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "todo",
           scss_dev:     "todo",
@@ -104,8 +117,8 @@ module Sage
           react_dev:    "todo",
           react_doc:    "todo"
         },
-        { 
-          title: "button", 
+        {
+          title: "button",
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "todo",
           scss_dev:     "todo",

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -15,10 +15,10 @@ module Sage
         # Sage Generated Elements
         {
           title: "form_input",
-          description: "Text or numeric input form fields",
+          description: "Basic text input form fields with 'floating' labels",
           scss_design:  "done",
-          scss_dev:     "doing",
-          scss_doc:     "doing",
+          scss_dev:     "done",
+          scss_doc:     "done",
           rails_design: "no",
           rails_dev:    "no",
           rails_doc:    "no",

--- a/app/views/sage/examples/elements/form_input/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_input/_preview.html.erb
@@ -1,11 +1,25 @@
-<fieldset class="sage-form-section">
+<fieldset>
+  <p>Text (default)</p>
   <div class="sage-input">
-    <input class="sage-input__field" type="text" placeholder="First name" id="form__fname" required>
+    <input class="sage-input__field" type="text" placeholder="First name" id="form__fname" name="form__fname" required>
     <label for="form__fname" class="sage-input__label">First name</label>
   </div>
 
   <div class="sage-input">
-    <input class="sage-input__field" type="text" placeholder="Last name" id="form__lname" disabled>
+    <input class="sage-input__field" type="text" placeholder="Last name" id="form__lname" name="form__lname">
     <label for="form__lname" class="sage-input__label">Last name</label>
   </div>
+
+  <p>Email</p>
+  <div class="sage-input">
+    <input class="sage-input__field" type="email" placeholder="Email address" id="form__email" name="form__email" required>
+    <label for="form__email" class="sage-input__label">Email address</label>
+  </div>
+
+  <p>Password</p>
+  <div class="sage-input">
+    <input class="sage-input__field" type="password" placeholder="Create a password (8 to 32 characters)" id="form__pw" name="form__pw" minlength="8" maxlength="32" required>
+    <label for="form__pw" class="sage-input__label">Create a new password (8 to 32 characters)</label>
+  </div>
+
 </fieldset>

--- a/app/views/sage/examples/elements/form_input/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_input/_preview.html.erb
@@ -1,0 +1,6 @@
+<fieldset class="sage-form-section">
+  <div class="sage-input">
+    <input class="sage-input__field" type="text" placeholder="First name" id="form__fname" required>
+    <label for="form__fname" class="sage-input__label">First name</label>
+  </div>
+</fieldset>

--- a/app/views/sage/examples/elements/form_input/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_input/_preview.html.erb
@@ -3,4 +3,9 @@
     <input class="sage-input__field" type="text" placeholder="First name" id="form__fname" required>
     <label for="form__fname" class="sage-input__label">First name</label>
   </div>
+
+  <div class="sage-input">
+    <input class="sage-input__field" type="text" placeholder="Last name" id="form__lname" disabled>
+    <label for="form__lname" class="sage-input__label">Last name</label>
+  </div>
 </fieldset>

--- a/app/views/sage/examples/elements/form_input/_props.html.erb
+++ b/app/views/sage/examples/elements/form_input/_props.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td>Prop Name</td>
+  <td>The description of the property goes here.</td>
+  <td>String</td>
+  <td>Default</td>
+</tr>

--- a/app/views/sage/examples/elements/form_input/_props.html.erb
+++ b/app/views/sage/examples/elements/form_input/_props.html.erb
@@ -1,6 +1,18 @@
 <tr>
-  <td>Prop Name</td>
-  <td>The description of the property goes here.</td>
+  <td>ID</td>
+  <td>Unique identifier for this input field. Should match the "for" property on the corresponding label</td>
   <td>String</td>
-  <td>Default</td>
+  <td>empty</td>
+</tr>
+<tr>
+  <td>Placeholder</td>
+  <td>Inserts content to be displayed inside a default (empty) field</td>
+  <td>String</td>
+  <td>empty</td>
+</tr>
+<tr>
+  <td>Required</td>
+  <td>Adding this attribute allows basic HTML form validation on this field</td>
+  <td>String</td>
+  <td>empty</td>
 </tr>

--- a/app/views/sage/examples/elements/form_input/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_do.html.erb
@@ -1,4 +1,5 @@
 <ul>
+  <li>Make sure that the label element follows the input in the HTML</li>
   <li>Use unique ID and name values for each field</li>
   <li>Take advantage of <a href="https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation" rel="nofollow">HTML client-side validation</a> for basic fields &ndash; baked-in with most browsers</li>
 </ul>

--- a/app/views/sage/examples/elements/form_input/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_do.html.erb
@@ -1,3 +1,4 @@
 <ul>
-  <li>Rules for what you should do with this element go here.</li>
+  <li>Use unique ID and name values for each field</li>
+  <li>Take advantage of <a href="https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation" rel="nofollow">HTML client-side validation</a> for basic fields &ndash; baked-in with most browsers</li>
 </ul>

--- a/app/views/sage/examples/elements/form_input/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_do.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should do with this element go here.</li>
+</ul>

--- a/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
@@ -1,3 +1,3 @@
 <ul>
-  <li>Do not rely on HTML validation when complex and/or secure requirements are involved, such as password validation and generation</li>
+  <li>Do not rely on HTML client-side validation when complex and/or secure requirements are involved, such as password validation and generation</li>
 </ul>

--- a/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should not do with this element go here.</li>
+</ul>

--- a/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
@@ -1,3 +1,3 @@
 <ul>
-  <li>Rules for what you should not do with this element go here.</li>
+  <li>Do not rely on HTML validation when complex and/or secure requirements are involved, such as password validation and generation</li>
 </ul>


### PR DESCRIPTION
Form inputs should be styled to match Figma spec.

- Default text inputs
- Specialized text inputs (email, password, ??)
- ~Textareas~ will apply separate element/treatment TBD

example:
![input-fields](https://user-images.githubusercontent.com/816579/76664721-8d3c2f00-6542-11ea-90fc-33fce9e7e015.gif)

spec:
![form inputs](https://user-images.githubusercontent.com/816579/76439728-105e5900-637a-11ea-89d2-5638aca4daf9.png)

## Related issues
- #92 stylelint update