### PR TITLE
Code examples do not display overflow styles

### DIFF
--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -35,7 +35,9 @@
 <div class="sage-panel">
   <h3 id="code" class="example__title">Code</h3>
   <div class="example__code">
-    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{@title}/preview") %></code></pre>
+    <div class="sage-code-snippet">
+      <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{@title}/preview") %></code></pre>
+    </div>
   </div>
 </div>
 <div id="props" class="sage-panel">

--- a/app/views/sage/examples/elements/_element_preview.html.erb
+++ b/app/views/sage/examples/elements/_element_preview.html.erb
@@ -15,6 +15,8 @@
   </div>
   <h6 class="example__label">Code</h6>
   <div class="example__code">
-    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{title}/preview") %></code></pre>
+    <div class="sage-code-snippet">
+      <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{title}/preview") %></code></pre>
+    </div>
   </div>
 </div>

--- a/app/views/sage/examples/objects/_object.html.erb
+++ b/app/views/sage/examples/objects/_object.html.erb
@@ -35,7 +35,9 @@
 <div class="sage-panel">
   <h3 id="code" class="example__title">Code</h3>
   <div class="example__code">
-    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/objects/#{@title}/preview") %></code></pre>
+    <div class="sage-code-snippet">
+      <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/objects/#{@title}/preview") %></code></pre>
+    </div>
   </div>
 </div>
 <div id="props" class="sage-panel">

--- a/app/views/sage/examples/objects/_object_preview.html.erb
+++ b/app/views/sage/examples/objects/_object_preview.html.erb
@@ -15,6 +15,8 @@
   </div>
   <h6 class="example__label">Code</h6>
   <div class="example__code">
-    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/objects/#{title}/preview") %></code></pre>
+    <div class="sage-code-snippet">
+      <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/objects/#{title}/preview") %></code></pre>
+    </div>
   </div>
 </div>

--- a/app/views/sage/examples/objects/form_section/_preview.html.erb
+++ b/app/views/sage/examples/objects/form_section/_preview.html.erb
@@ -8,7 +8,7 @@
       <!-- Start Of Content -->
       <div class="sage-banner">
         <p class="sage-banner__title">Form Section Content Will Go Here</p>
-        <p class="sage-banner__copy">This component is designed to be very flexable and take any sort of content you want to pass to it.</p>
+        <p class="sage-banner__copy">This component is designed to be very flexible and take any sort of content you want to pass to it.</p>
       </div>
       <!-- End Of Content -->
     </div>

--- a/app/views/sage/examples/utilities/_utility.html.erb
+++ b/app/views/sage/examples/utilities/_utility.html.erb
@@ -6,5 +6,7 @@
   </div>
 
   <h6 class="example__label">Code</h6>
-  <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/utilities/#{title}/preview") %></code></pre>
+  <div class="sage-code-snippet">
+    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/utilities/#{title}/preview") %></code></pre>
+  </div>
 </div>


### PR DESCRIPTION
## Description
The `.sage-code-snippet` wrapper is missing on generated files. This wrapper provides a visual indicator that code examples overflow their container by using a linear gradient overlay simulating the content fading out to the right.

### Example
Expected:
![overflow](https://user-images.githubusercontent.com/816579/76882468-ee604d00-6837-11ea-95a0-34dae7b3acd8.png)

Actual:
![no-overflow](https://user-images.githubusercontent.com/816579/76882450-e7d1d580-6837-11ea-857f-5996a28d9e24.png)


### Steps to test/reproduce
1. Navigate to http://localhost:4000/sage/pages/elements in the app
2. Verify that code examples do have a gradient overlay (fade) to indicate additional content

## Related issues
- n/a