### PR TITLE
Realign switch styles

### DIFF
--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -200,7 +200,7 @@ $sage-switch-toggle-size: 1.25rem !default;
 // Focus state
 $sage-switch-focus-outline-spacing: sage-spacing(2xs) !default;
 $sage-switch-focus-outline-width: 1 !default;
-$sage-switch-focus-outline-color: currentColor !default;
+$sage-switch-focus-outline-color: sage-color(primary) !default;
 
 
 // ==================================================

--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -24,7 +24,7 @@
   transition: background 0.3s ease-out;
   cursor: pointer;
 
-  + label {
+  + .sage-switch__label {
     display: inline-block;
     margin-left: sage-spacing(2xs);
     vertical-align: top;
@@ -101,7 +101,7 @@
     &:checked {
       background: $sage-switch-color-disabled-checked;
 
-      + label {
+      + .sage-switch__label {
         color: $sage-switch-color-disabled-checked-text;
       }
     }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -92,7 +92,7 @@
       box-shadow: none;
     }
 
-    + label {
+    + .sage-switch__label {
       color: $sage-switch-color-disabled-text;
       cursor: inherit;
     }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -23,7 +23,7 @@
     transition: background 0.3s ease-out;
     cursor: pointer;
 
-    & + label {
+    + label {
       display: inline-block;
       margin-left: sage-spacing(2xs);
       vertical-align: top;
@@ -43,9 +43,9 @@
 
     &::before { // switch background
       transform: translate3d(-50%, -50%, 0) scale(0.94);
-      width: calc(100% + ((#{$sage-switch-focus-outline-width}px ) + (#{$sage-switch-focus-outline-spacing} * 2)));
-      height: calc(100% + ((#{$sage-switch-focus-outline-width}px) + (#{$sage-switch-focus-outline-spacing} * 2)));
-      border: calc(#{$sage-switch-focus-outline-width}px) solid $sage-switch-focus-outline-color;
+      width: calc(100% + ((#{$sage-switch-focus-outline-width} * 1px ) + (#{$sage-switch-focus-outline-spacing} * 2)));
+      height: calc(100% + ((#{$sage-switch-focus-outline-width} * 1px) + (#{$sage-switch-focus-outline-spacing} * 2)));
+      border: calc(#{$sage-switch-focus-outline-width} * 1px) solid $sage-switch-focus-outline-color;
       border-radius: $sage-switch-border-radius;
       transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
       pointer-events: none;
@@ -58,8 +58,14 @@
       width: $sage-switch-toggle-size;
       background: #fff;
       border-radius: sage-border(radius-round);
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 1px 3px rgba(0, 0, 0, 0.1);
-      transition: transform 0.2s ease-in-out;
+      box-shadow: sage-shadow(sm);
+      transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+    }
+
+    &:hover:not(:disabled):not(:checked) {
+      &::after {
+        box-shadow: sage-shadow(md);
+      }
     }
 
     // checked
@@ -81,7 +87,7 @@
         box-shadow: none;
       }
 
-      & + label {
+      + label {
         color: $sage-switch-color-disabled-text;
         cursor: inherit;
       }
@@ -90,7 +96,7 @@
       &:checked {
         background: $sage-switch-color-disabled-checked;
 
-        & + label {
+        + label {
           color: $sage-switch-color-disabled-checked-text;
         }
       }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -81,6 +81,10 @@
 
   &:invalid {
     background-color: sage-color(red);
+
+    + .sage-switch__label {
+      color: sage-color(red);
+    }
   }
 
   // disabled

--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -7,107 +7,111 @@
 
 .sage-switch {
   color: $sage-switch-color-default-text;
+}
 
-  input[type="checkbox"] {
+.sage-switch__input {
+  display: inline-block;
+  position: relative;
+  height: $sage-switch-height;
+  width: $sage-switch-width;
+  margin: 0;
+  vertical-align: top;
+  appearance: none;
+  color: $sage-switch-color-default;
+  background: $sage-switch-color-default;
+  border-radius: $sage-switch-border-radius;
+  outline: none;
+  transition: background 0.3s ease-out;
+  cursor: pointer;
+
+  + label {
     display: inline-block;
-    position: relative;
-    height: $sage-switch-height;
-    width: $sage-switch-width;
-    margin: 0;
+    margin-left: sage-spacing(2xs);
     vertical-align: top;
-    appearance: none;
-    color: $sage-switch-color-default;
-    background: $sage-switch-color-default;
-    border-radius: $sage-switch-border-radius;
-    outline: none;
-    transition: background 0.3s ease-out;
+    font-size: sage-font-size();
+    line-height: sage-font-height();
     cursor: pointer;
+  }
+
+  &::before,
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+  }
+
+  &::before { // switch background
+    transform: translate3d(-50%, -50%, 0) scale(0.94);
+    width: calc(100% + ((#{$sage-switch-focus-outline-width} * 1px ) + (#{$sage-switch-focus-outline-spacing} * 2)));
+    height: calc(100% + ((#{$sage-switch-focus-outline-width} * 1px) + (#{$sage-switch-focus-outline-spacing} * 2)));
+    border: calc(#{$sage-switch-focus-outline-width} * 1px) solid $sage-switch-focus-outline-color;
+    border-radius: $sage-switch-border-radius;
+    transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  &::after {  // switch toggle
+    transform: translate3d(-100%, -50%, 0);
+    height: $sage-switch-toggle-size;
+    width: $sage-switch-toggle-size;
+    background: #fff;
+    border-radius: sage-border(radius-round);
+    box-shadow: sage-shadow(sm);
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  }
+
+  &:hover:not(:disabled):not(:checked) {
+    &::after {
+      box-shadow: sage-shadow(md);
+    }
+  }
+
+  // checked
+  &:checked {
+    color: $sage-switch-color-checked;
+    background: $sage-switch-color-checked;
+
+    &::after {
+      transform: translate3d(0, -50%, 0);
+    }
+  }
+
+  &:invalid {
+    background-color: sage-color(red);
+  }
+
+  // disabled
+  &:disabled {
+    background: $sage-switch-color-disabled;
+    cursor: not-allowed;
+
+    &::after {
+      box-shadow: none;
+    }
 
     + label {
-      display: inline-block;
-      margin-left: sage-spacing(2xs);
-      vertical-align: top;
-      font-size: sage-font-size();
-      line-height: sage-line-height();
-      cursor: pointer;
+      color: $sage-switch-color-disabled-text;
+      cursor: inherit;
     }
 
-    &::before,
-    &::after {
-      content: "";
-      display: block;
-      position: absolute;
-      left: 50%;
-      top: 50%;
-    }
-
-    &::before { // switch background
-      transform: translate3d(-50%, -50%, 0) scale(0.94);
-      width: calc(100% + ((#{$sage-switch-focus-outline-width} * 1px ) + (#{$sage-switch-focus-outline-spacing} * 2)));
-      height: calc(100% + ((#{$sage-switch-focus-outline-width} * 1px) + (#{$sage-switch-focus-outline-spacing} * 2)));
-      border: calc(#{$sage-switch-focus-outline-width} * 1px) solid $sage-switch-focus-outline-color;
-      border-radius: $sage-switch-border-radius;
-      transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
-      pointer-events: none;
-      opacity: 0;
-    }
-
-    &::after {  // switch toggle
-      transform: translate3d(-100%, -50%, 0);
-      height: $sage-switch-toggle-size;
-      width: $sage-switch-toggle-size;
-      background: #fff;
-      border-radius: sage-border(radius-round);
-      box-shadow: sage-shadow(sm);
-      transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-    }
-
-    &:hover:not(:disabled):not(:checked) {
-      &::after {
-        box-shadow: sage-shadow(md);
-      }
-    }
-
-    // checked
+    // disabled & checked
     &:checked {
-      color: $sage-switch-color-checked;
-      background: $sage-switch-color-checked;
-
-      &::after {
-        transform: translate3d(0, -50%, 0);
-      }
-    }
-
-    // disabled
-    &:disabled {
-      background: $sage-switch-color-disabled;
-      cursor: not-allowed;
-
-      &::after {
-        box-shadow: none;
-      }
+      background: $sage-switch-color-disabled-checked;
 
       + label {
-        color: $sage-switch-color-disabled-text;
-        cursor: inherit;
-      }
-
-      // disabled & checked
-      &:checked {
-        background: $sage-switch-color-disabled-checked;
-
-        + label {
-          color: $sage-switch-color-disabled-checked-text;
-        }
+        color: $sage-switch-color-disabled-checked-text;
       }
     }
+  }
 
-    &:focus:not(:disabled),
-    &:active:not(:disabled) {
-      &::before {
-        transform: translate3d(-50%, -50%, 0);
-        opacity: 1;
-      }
+  &:focus:not(:disabled),
+  &:active:not(:disabled) {
+    &::before {
+      transform: translate3d(-50%, -50%, 0);
+      opacity: 1;
     }
   }
 }

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -15,7 +15,7 @@ module Sage
         # Sage Generated Elements
         {
           title: "tooltip",
-          description: "Tooltips display helpful text when users hover over an element.", 
+          description: "Tooltips display helpful text when users hover over an element.",
           scss_design:  "done",
           scss_dev:     "done",
           scss_doc:     "done",
@@ -80,7 +80,7 @@ module Sage
         },
         {
           title: "switch",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+          description: "Checkbox or radio element styled to appear as a toggle",
           scss_design:  "todo",
           scss_dev:     "todo",
           scss_doc:     "todo",

--- a/app/views/sage/examples/elements/switch/_preview.html.erb
+++ b/app/views/sage/examples/elements/switch/_preview.html.erb
@@ -3,18 +3,18 @@
     <!-- Default, checkbox -->
     <div class="sage-switch">
       <input type="checkbox" class="sage-switch__input" id="sage-switch-1" name="sage-switch-1" value="switch-1-value">
-      <label for="sage-switch-1">Switch (checkbox)</label>
+      <label class="sage-switch__label" for="sage-switch-1">Switch (checkbox)</label>
     </div>
   </div>
   <div class="sage-col--md-6">
     <!-- Default, radio -->
     <div class="sage-switch">
       <input type="radio" class="sage-switch__input" id="sage-switch-2a" name="sage-switch-2" value="switch-2a-value" checked>
-      <label for="sage-switch-2a">Switch (radio)</label>
+      <label class="sage-switch__label" for="sage-switch-2a">Switch (radio)</label>
     </div>
     <div class="sage-switch">
       <input type="radio" class="sage-switch__input" id="sage-switch-2b" name="sage-switch-2" value="switch-2b-value">
-      <label for="sage-switch-2b">Switch (radio)</label>
+      <label class="sage-switch__label" for="sage-switch-2b">Switch (radio)</label>
     </div>
   </div>
 </div>
@@ -24,19 +24,19 @@
     <!-- Disabled -->
     <div class="sage-switch">
       <input type="checkbox" class="sage-switch__input" id="sage-switch-4" name="sage-switch-4" value="switch-4-value" disabled>
-      <label for="sage-switch-4">Switch disabled</label>
+      <label class="sage-switch__label" for="sage-switch-4">Switch disabled</label>
     </div>
     <!-- Checked & Disabled -->
     <div class="sage-switch">
       <input type="checkbox" class="sage-switch__input" id="sage-switch-5" name="sage-switch-5" value="switch-5-value" checked disabled>
-      <label for="sage-switch-5">Switch on disabled</label>
+      <label class="sage-switch__label" for="sage-switch-5">Switch on disabled</label>
     </div>
   </div>
   <div class="sage-col--md-6">
     <!-- Error -->
     <div class="sage-switch">
       <input type="checkbox" class="sage-switch__input" id="sage-switch-6" name="sage-switch-6" value="switch-6-value" required>
-      <label for="sage-switch-6">Switch error</label>
+      <label class="sage-switch__label" for="sage-switch-6">Switch error</label>
     </div>
   </div>
 </div>

--- a/app/views/sage/examples/elements/switch/_preview.html.erb
+++ b/app/views/sage/examples/elements/switch/_preview.html.erb
@@ -1,20 +1,42 @@
-<!-- Default -->
-<div class="sage-switch">
-  <input type="checkbox" class="sage-switch__input" id="sage-switch-1" name="sage-switch-1">
-  <label for="sage-switch-1">Switch</label>
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <!-- Default, checkbox -->
+    <div class="sage-switch">
+      <input type="checkbox" class="sage-switch__input" id="sage-switch-1" name="sage-switch-1" value="switch-1-value">
+      <label for="sage-switch-1">Switch (checkbox)</label>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <!-- Default, radio -->
+    <div class="sage-switch">
+      <input type="radio" class="sage-switch__input" id="sage-switch-2a" name="sage-switch-2" value="switch-2a-value" checked>
+      <label for="sage-switch-2a">Switch (radio)</label>
+    </div>
+    <div class="sage-switch">
+      <input type="radio" class="sage-switch__input" id="sage-switch-2b" name="sage-switch-2" value="switch-2b-value">
+      <label for="sage-switch-2b">Switch (radio)</label>
+    </div>
+  </div>
 </div>
-<!-- Disabled -->
-<div class="sage-switch">
-  <input type="checkbox" class="sage-switch__input" id="sage-switch-2" name="sage-switch-2" disabled>
-  <label for="sage-switch-2">Switch disabled</label>
-</div>
-<!-- Checked & Disabled -->
-<div class="sage-switch">
-  <input type="checkbox" class="sage-switch__input" id="sage-switch-3" name="sage-switch-3" checked disabled>
-  <label for="sage-switch-3">Switch on disabled</label>
-</div>
-<!-- Error -->
-<div class="sage-switch">
-  <input type="checkbox" class="sage-switch__input" id="sage-switch-4" name="sage-switch-4" required>
-  <label for="sage-switch-4">Switch error</label>
+
+<div class="sage-row">
+  <div class="sage-col--md-6">
+    <!-- Disabled -->
+    <div class="sage-switch">
+      <input type="checkbox" class="sage-switch__input" id="sage-switch-4" name="sage-switch-4" value="switch-4-value" disabled>
+      <label for="sage-switch-4">Switch disabled</label>
+    </div>
+    <!-- Checked & Disabled -->
+    <div class="sage-switch">
+      <input type="checkbox" class="sage-switch__input" id="sage-switch-5" name="sage-switch-5" value="switch-5-value" checked disabled>
+      <label for="sage-switch-5">Switch on disabled</label>
+    </div>
+  </div>
+  <div class="sage-col--md-6">
+    <!-- Error -->
+    <div class="sage-switch">
+      <input type="checkbox" class="sage-switch__input" id="sage-switch-6" name="sage-switch-6" value="switch-6-value" required>
+      <label for="sage-switch-6">Switch error</label>
+    </div>
+  </div>
 </div>

--- a/app/views/sage/examples/elements/switch/_preview.html.erb
+++ b/app/views/sage/examples/elements/switch/_preview.html.erb
@@ -1,15 +1,20 @@
 <!-- Default -->
 <div class="sage-switch">
-  <input id="s1" type="checkbox">
-  <label for="s1">Switch</label>
+  <input type="checkbox" class="sage-switch__input" id="sage-switch-1" name="sage-switch-1">
+  <label for="sage-switch-1">Switch</label>
 </div>
 <!-- Disabled -->
 <div class="sage-switch">
-  <input id="s2" type="checkbox" disabled>
-  <label for="s2">Switch disabled</label>
+  <input type="checkbox" class="sage-switch__input" id="sage-switch-2" name="sage-switch-2" disabled>
+  <label for="sage-switch-2">Switch disabled</label>
 </div>
 <!-- Checked & Disabled -->
 <div class="sage-switch">
-  <input id="s3" type="checkbox" checked disabled>
-  <label for="s3">Switch on disabled</label>
+  <input type="checkbox" class="sage-switch__input" id="sage-switch-3" name="sage-switch-3" checked disabled>
+  <label for="sage-switch-3">Switch on disabled</label>
+</div>
+<!-- Error -->
+<div class="sage-switch">
+  <input type="checkbox" class="sage-switch__input" id="sage-switch-4" name="sage-switch-4" required>
+  <label for="sage-switch-4">Switch error</label>
 </div>

--- a/app/views/sage/examples/elements/switch/_props.html.erb
+++ b/app/views/sage/examples/elements/switch/_props.html.erb
@@ -1,6 +1,18 @@
 <tr>
-  <td>Prop Name</td>
-  <td>The description of the property goes here.</td>
+  <td>ID</td>
+  <td>Unique identifier for this input field. Should match the "for" property on the corresponding label</td>
   <td>String</td>
-  <td>Default</td>
+  <td>null</td>
+</tr>
+<tr>
+  <td>Checked</td>
+  <td>Sets the state to "checked" by default</td>
+  <td>String</td>
+  <td>null</td>
+</tr>
+<tr>
+  <td>Required</td>
+  <td>Adding this attribute allows basic HTML form validation on this field</td>
+  <td>String</td>
+  <td>null</td>
 </tr>

--- a/app/views/sage/examples/elements/switch/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/switch/_rules_do.html.erb
@@ -1,3 +1,4 @@
 <ul>
-  <li>Rules for what you should do with this element go here.</li>
+  <li>IMPORTANT: Be sure that the label element <strong>follows</strong> the input in the HTML</li>
+  <li>Remember to check that the ID of the input and the label's for attribute match</li>
 </ul>

--- a/app/views/sage/examples/elements/switch/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/switch/_rules_dont.html.erb
@@ -1,3 +1,3 @@
 <ul>
-  <li>Rules for what you should not do with this element go here.</li>
+  <li>Use the checked &amp; disabled state with caution! Clearly describe why this item cannot be unselected.</li>
 </ul>


### PR DESCRIPTION
Focus and hover states for the switch element vary slightly from the Figma spec as seen in the attached screen.
- Focus state outline color is sage/grey instead of sage/primary
- Hover state increases intensity of the drop shadow on the toggle control and switch body
- Add error state styling

Expected:
![switch](https://user-images.githubusercontent.com/816579/77206996-8028be00-6ab5-11ea-97ad-91cb784bd54b.png)

Actual: (focus)
![switch-focus-current](https://user-images.githubusercontent.com/816579/77207085-b6663d80-6ab5-11ea-958a-8f24cf3e4566.png)

