### PR TITLE
Viewport metatag missing for mobile devices

### DIFF
--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -136,8 +136,7 @@ $sage-inputfield-bg-disabled: sage-color(grey, 100) !default;
 $sage-textarea-font-size: $sage-inputfield-font-size !default;
 $sage-textarea-line-height: sage-font-height(lg) !default;
 $sage-textarea-letter-spacing: $sage-inputfield-letter-spacing !default;
-$sage-textarea-label-font-size: $sage-inputfield-label-font-size !default;
-$sage-textarea-label-font-weight: $sage-inputfield-label-font-weight !default;
+$sage-textarea-label-font-size: sage-font-size(xs) !default;
 $sage-textarea-label-line-height: 1 !default;
 
 // Border

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_textarea.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_textarea.scss
@@ -13,6 +13,8 @@
 }
 
 .sage-textarea__label {
+  @extend %t-sage-body-xsmall-semi;
+
   position: absolute;
   left: $sage-textarea-padding;
   top: $sage-textarea-border-width;
@@ -21,8 +23,6 @@
   padding-top: $sage-textarea-label-padding-top;
   padding-bottom: $sage-textarea-label-padding-bottom;
   color: inherit;
-  font-size: $sage-textarea-label-font-size;
-  font-weight: $sage-textarea-label-font-weight;
   line-height: $sage-textarea-label-line-height;
   background-color: $sage-textarea-label-bg-color;
   pointer-events: none;

--- a/app/views/layouts/sage/application.html.erb
+++ b/app/views/layouts/sage/application.html.erb
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Sage</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag "sage/sage_system", media: "all" %>
     <%= stylesheet_link_tag "sage/sage_docs", media: "all" %>
     <%= csrf_meta_tags %>

--- a/app/views/layouts/sage/breakout.html.erb
+++ b/app/views/layouts/sage/breakout.html.erb
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Sage</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag "sage/sage_system", media: "all" %>
     <%= stylesheet_link_tag "sage/sage_docs", media: "all" %>
     <%= csrf_meta_tags %>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <title>Dummy</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Sage app HTML is missing the `<meta name="viewport" content="width=device-width, initial-scale=1">` meta tag. Because of this, mobile devices are rendering the Sage documentation page according to their screen resolution rather than by their device width.

This is reproducible on actual devices, and within the Xcode iOS simulator, but not by using Safari's "Responsive Design Mode".

- This PR also fixes an issue introduced from a missing variable in the textarea PR (#96 )

<img width="559" alt="mobile-view" src="https://user-images.githubusercontent.com/816579/77675088-bf3d9000-6f49-11ea-89a1-cc2ba9c240fa.png">
