### PR TITLE
Replace calculated `rem` values with rem function

### DIFF
--- a/app/assets/stylesheets/sage/docs/_example.scss
+++ b/app/assets/stylesheets/sage/docs/_example.scss
@@ -17,14 +17,14 @@
 
   &__label {
     display: inline-block;
-    min-width: 100px;
+    min-width: rem(100px);
     margin: sage-spacing() 0;
     padding: sage-spacing(xs) sage-spacing();
     color: sage-color(charcoal, 500);
     text-align: center;
-    background: #fff;
+    background: sage-color(white);
     box-shadow: sage-shadow();
-    border-radius: 20px;
+    border-radius: rem(20px);
   }
 
   &__preview {

--- a/app/assets/stylesheets/sage/docs/_variables.scss
+++ b/app/assets/stylesheets/sage/docs/_variables.scss
@@ -17,5 +17,5 @@
 // STATUS KEY
 // ==================================================
 
-$status-key-icon-size: 0.8125rem; // 13px
+$status-key-icon-size: rem(13);
 

--- a/app/assets/stylesheets/sage/docs/_variables.scss
+++ b/app/assets/stylesheets/sage/docs/_variables.scss
@@ -17,5 +17,5 @@
 // STATUS KEY
 // ==================================================
 
-$status-key-icon-size: rem(13);
+$status-key-icon-size: rem(13px);
 

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -33,7 +33,7 @@ $sage-body-font-size: 1rem !default; // 16px
 $sage-body-font-weight: sage-font-weight() !default;
 $sage-body-font-line-height: sage-line-height(lg) !default;
 $sage-body-font-color: sage-color(charcoal, 400) !default;
-$sage-body-letter-spacing: sage-letter-spacing(sm) !default;  // 3px
+$sage-body-letter-spacing: sage-letter-spacing(sm) !default;
 $sage-body-margin-bottom: sage-spacing() !default;
 
 // Headings
@@ -56,7 +56,7 @@ $sage-grid-gap-lg: sage-spacing(sm) !default;
 // FORM ELEMENTS
 // ==================================================
 
-$sage-form-element-spacing: 1rem !default;
+$sage-form-element-spacing: sage-spacing(sm) !default;
 
 
 // ==================================================
@@ -65,7 +65,7 @@ $sage-form-element-spacing: 1rem !default;
 
 // Base styles
 $sage-btn-transition: $sage-transition !default;
-$sage-btn-border-width: 0.125rem !default;
+$sage-btn-border-width: rem(2) !default;
 $sage-btn-border-radius: sage-border(radius) !default;
 $sage-btn-letter-spacing: $sage-body-letter-spacing !default;
 $sage-btn-shadow-base: sage-shadow(sm) !default;
@@ -90,10 +90,10 @@ $sage-btn-danger-bg-color: sage-color(red) !default;
 $sage-btn-danger-text-color: sage-color(white) !default;
 
 // Menu button
-$sage-menubtn-toggle-size: 1.5rem !default; // 24px
+$sage-menubtn-toggle-size: rem(24) !default;
 $sage-menubtn-toggle-line-color: sage-color(grey, 100) !default;
-$sage-menubtn-toggle-line-height: 0.125rem !default; // 2px
-$sage-menubtn-toggle-radius: 0.125rem !default; // 2px
+$sage-menubtn-toggle-line-height: rem(2) !default;
+$sage-menubtn-toggle-radius: rem(2) !default;
 $sage-menubtn-focus-outline-size: sage-spacing(xs) !default;
 $sage-menubtn-focus-outline-width: 1 !default;
 $sage-menubtn-focus-outline-color: currentColor !default;
@@ -109,17 +109,17 @@ $sage-inputfield-letter-spacing: $sage-body-letter-spacing !default;
 // Border
 $sage-inputfield-border-color: sage-color(grey, 300) !default;
 $sage-inputfield-border-radius: sage-border(radius) !default;
-$sage-inputfield-border-width: 0.0625rem !default;  // 1px
-$sage-inputfield-box-shadow-size: 0 0 0 0.0625rem !default;
+$sage-inputfield-border-width: rem(1) !default;
+$sage-inputfield-box-shadow-size: 0 0 0 rem(1) !default;
 
 // Sizing
-$sage-inputfield-height: 3.5rem !default;  // 56px
-$sage-inputfield-padding: 1.125rem !default;  // 18px
+$sage-inputfield-height: rem(56) !default;
+$sage-inputfield-padding: rem(18) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
-$sage-inputfield-padding-filled: 0.25rem !default;
+$sage-inputfield-padding-filled: rem(4) !default;
 
 // Spacing
-$sage-inputfield-spacing: 2rem !default;
+$sage-inputfield-spacing: sage-spacing(lg) !default;
 
 // Colors
 $sage-inputfield-color-default: sage-color(charcoal) !default;
@@ -160,7 +160,7 @@ $sage-textarea-color-default: $sage-inputfield-color-default !default;
 $sage-textarea-color-disabled: $sage-inputfield-color-disabled !default;
 $sage-textarea-color-success: $sage-inputfield-color-success !default;
 $sage-textarea-color-error: $sage-inputfield-color-error !default;
-$sage-textarea-bg-default: #fff !default;
+$sage-textarea-bg-default: sage-color(white) !default;
 $sage-textarea-bg-disabled: $sage-inputfield-bg-disabled !default;
 $sage-textarea-label-bg-color: $sage-textarea-bg-default !default;
 
@@ -175,13 +175,13 @@ $sage-checkbox-color-checked: sage-color(primary) !default;
 $sage-checkbox-color-disabled: sage-color(grey, 200) !default;
 $sage-checkbox-color-disabled-checked: sage-color(primary, 200) !default;
 
-$sage-checkbox-size: 1.5rem !default;
+$sage-checkbox-size: rem(24) !default;
 $sage-checkbox-border-radius: sage-border(radius) !default;
 $sage-checkbox-transition: 0.15s ease-in-out !default;
 
-$sage-checkbox-marker-border: 0.125rem !default;
-$sage-checkbox-marker-height: 0.75rem !default;
-$sage-checkbox-marker-width: 0.375rem !default;
+$sage-checkbox-marker-border: rem(2) !default;
+$sage-checkbox-marker-height: rem(12) !default;
+$sage-checkbox-marker-width: rem(6) !default;
 $sage-checkbox-marker-color: sage-color(white) !default;
 $sage-checkbox-marker-rotate: 42.5deg !default;
 $sage-checkbox-marker-offset: $sage-checkbox-marker-border * 2 !default;
@@ -203,10 +203,10 @@ $sage-radio-color-hover: sage-color(grey, 500) !default;
 $sage-radio-color-disabled: sage-color(grey, 100) !default;
 $sage-radio-color-disabled-checked: sage-color(grey, 300) !default;
 
-$sage-radio-button-size: 1.5rem !default;
+$sage-radio-button-size: rem(24) !default;
 $sage-radio-border-radius: sage-border(radius-round) !default;
 $sage-radio-transition: 0.15s ease-in-out !default;
-$sage-radio-selected-indicator-size: 1rem !default;
+$sage-radio-selected-indicator-size: rem(16) !default;
 $sage-radio-selected-indicator-color: sage-color(white) !default;
 
 // Focus state
@@ -229,12 +229,12 @@ $sage-switch-color-disabled-checked: sage-color(primary, 200) !default;
 $sage-switch-color-disabled-checked-text: sage-color(charcoal, 100) !default;
 
 // Switch
-$sage-switch-border-radius: 1rem !default;
-$sage-switch-height: 1.5rem !default;
-$sage-switch-width: 2.75rem !default;
+$sage-switch-border-radius: rem(16) !default;
+$sage-switch-height: rem(24) !default;
+$sage-switch-width: rem(44) !default;
 
 // Toggle
-$sage-switch-toggle-size: 1.25rem !default;
+$sage-switch-toggle-size: rem(20) !default;
 
 // Focus state
 $sage-switch-focus-outline-spacing: sage-spacing(2xs) !default;
@@ -247,10 +247,10 @@ $sage-switch-focus-outline-color: sage-color(primary) !default;
 // ==================================================
 
 $sage-loading-bar-bg-color: sage-color(grey) !default;
-$sage-loading-bar-height: 0.625rem !default; // 10px
-$sage-loading-bar-width: 18.75rem !default; // 300px
+$sage-loading-bar-height: rem(10) !default;
+$sage-loading-bar-width: rem(300) !default;
 
-$sage-loading-spinner-size: 3rem !default; // 48px
+$sage-loading-spinner-size: rem(48) !default;
 $sage-loading-spinner-speed: 0.9s !default;
 
 
@@ -259,7 +259,7 @@ $sage-loading-spinner-speed: 0.9s !default;
 // ==================================================
 
 $sage-overlay-bg-color: rgba(sage-color(charcoal, 100), 0.5) !default;
-$sage-overlay-backdrop-filter: blur(0.125rem) !default;
+$sage-overlay-backdrop-filter: blur(rem(2)) !default;
 $sage-overlay-z-index: sage-z-index(underlay) !default;
 $sage-overlay-transition-default: opacity 0.5s ease-in-out !default;
 $sage-overlay-transition-backdrop-filter: backdrop-filter 0.7s ease-in-out !default;
@@ -279,9 +279,9 @@ $sage-panel-box-shadow: sage-shadow(sm) !default;
 // ASSISTANT
 // ==================================================
 
-$sage-assistant-height: 3.5rem !default;
-$sage-assistant-branding-height: 1.25rem !default; // 20px
-$sage-assistant-search-height: 2.5rem !default; // 40px
+$sage-assistant-height: rem(56) !default;
+$sage-assistant-branding-height: rem(20) !default;
+$sage-assistant-search-height: rem(40) !default;
 $sage-assistant-search-bg-color: sage-color(grey, 300) !default;
 $sage-assistant-search-bg-opacity: 0.1 !default;
 $sage-assistant-search-placeholder-color: sage-color(grey, 400) !default;
@@ -299,7 +299,7 @@ $sage-tabs-default-transition: 0.2s ease-in-out !default;
 $sage-tabs-active-color: sage-color(charcoal, 500) !default;
 
 // Active tab indicator
-$sage-tabs-active-border-height: 0.25rem !default; // 4px
+$sage-tabs-active-border-height: rem(4) !default;
 $sage-tabs-active-border-width: 100% !default;
 $sage-tabs-active-border-color: sage-color(primary) !default;
 $sage-tabs-active-border-radius: sage-border(radius) !default;
@@ -321,4 +321,4 @@ $tooltip-font-color: sage-color(white) !default;
 $tooltip-light-font-color: sage-color(charcoal, 400) !default;
 $tooltip-padding: sage-spacing(2xs) sage-spacing(sm) !default;
 $tooltip-zindex: sage-z_index(nuclear) !default;
-$tooltip-maxwidth: 200px !default;
+$tooltip-maxwidth: rem(200) !default;

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -65,7 +65,7 @@ $sage-form-element-spacing: sage-spacing(sm) !default;
 
 // Base styles
 $sage-btn-transition: $sage-transition !default;
-$sage-btn-border-width: rem(2) !default;
+$sage-btn-border-width: rem(2px) !default;
 $sage-btn-border-radius: sage-border(radius) !default;
 $sage-btn-letter-spacing: $sage-body-letter-spacing !default;
 $sage-btn-shadow-base: sage-shadow(sm) !default;
@@ -90,10 +90,10 @@ $sage-btn-danger-bg-color: sage-color(red) !default;
 $sage-btn-danger-text-color: sage-color(white) !default;
 
 // Menu button
-$sage-menubtn-toggle-size: rem(24) !default;
+$sage-menubtn-toggle-size: rem(24px) !default;
 $sage-menubtn-toggle-line-color: sage-color(grey, 100) !default;
-$sage-menubtn-toggle-line-height: rem(2) !default;
-$sage-menubtn-toggle-radius: rem(2) !default;
+$sage-menubtn-toggle-line-height: rem(2px) !default;
+$sage-menubtn-toggle-radius: rem(2px) !default;
 $sage-menubtn-focus-outline-size: sage-spacing(xs) !default;
 $sage-menubtn-focus-outline-width: 1 !default;
 $sage-menubtn-focus-outline-color: currentColor !default;
@@ -109,14 +109,14 @@ $sage-inputfield-letter-spacing: $sage-body-letter-spacing !default;
 // Border
 $sage-inputfield-border-color: sage-color(grey, 300) !default;
 $sage-inputfield-border-radius: sage-border(radius) !default;
-$sage-inputfield-border-width: rem(1) !default;
-$sage-inputfield-box-shadow-size: 0 0 0 rem(1) !default;
+$sage-inputfield-border-width: rem(1px) !default;
+$sage-inputfield-box-shadow-size: 0 0 0 rem(1px) !default;
 
 // Sizing
-$sage-inputfield-height: rem(56) !default;
-$sage-inputfield-padding: rem(18) !default;
+$sage-inputfield-height: rem(56px) !default;
+$sage-inputfield-padding: rem(18px) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
-$sage-inputfield-padding-filled: rem(4) !default;
+$sage-inputfield-padding-filled: rem(4px) !default;
 
 // Spacing
 $sage-inputfield-spacing: sage-spacing(lg) !default;
@@ -140,14 +140,14 @@ $sage-textarea-border-width: $sage-inputfield-border-width !default;
 $sage-textarea-box-shadow-size: $sage-inputfield-box-shadow-size !default;
 
 // Padding
-$sage-textarea-label-padding-top: rem(12) !default;
-$sage-textarea-label-padding-bottom: rem(6) !default;
+$sage-textarea-label-padding-top: rem(12px) !default;
+$sage-textarea-label-padding-bottom: rem(6px) !default;
 $sage-textarea-label-margin-bottom: 0 !default;
 $sage-textarea-padding: $sage-inputfield-padding !default;
 $sage-textarea-padding-filled: $sage-body-font-size + $sage-textarea-label-padding-top + $sage-textarea-label-padding-bottom !default; // height of label
 
 // Sizing
-$sage-textarea-min-height: rem(130) !default;
+$sage-textarea-min-height: rem(130px) !default;
 $sage-textarea-height: 100% !default;
 $sage-textarea-width: 100% !default;
 $sage-textarea-label-width: calc(100% - #{$sage-textarea-padding} * 2) !default;
@@ -175,13 +175,13 @@ $sage-checkbox-color-checked: sage-color(primary) !default;
 $sage-checkbox-color-disabled: sage-color(grey, 200) !default;
 $sage-checkbox-color-disabled-checked: sage-color(primary, 200) !default;
 
-$sage-checkbox-size: rem(24) !default;
+$sage-checkbox-size: rem(24px) !default;
 $sage-checkbox-border-radius: sage-border(radius) !default;
 $sage-checkbox-transition: 0.15s ease-in-out !default;
 
-$sage-checkbox-marker-border: rem(2) !default;
-$sage-checkbox-marker-height: rem(12) !default;
-$sage-checkbox-marker-width: rem(6) !default;
+$sage-checkbox-marker-border: rem(2px) !default;
+$sage-checkbox-marker-height: rem(12px) !default;
+$sage-checkbox-marker-width: rem(6px) !default;
 $sage-checkbox-marker-color: sage-color(white) !default;
 $sage-checkbox-marker-rotate: 42.5deg !default;
 $sage-checkbox-marker-offset: $sage-checkbox-marker-border * 2 !default;
@@ -203,10 +203,10 @@ $sage-radio-color-hover: sage-color(grey, 500) !default;
 $sage-radio-color-disabled: sage-color(grey, 100) !default;
 $sage-radio-color-disabled-checked: sage-color(grey, 300) !default;
 
-$sage-radio-button-size: rem(24) !default;
+$sage-radio-button-size: rem(24px) !default;
 $sage-radio-border-radius: sage-border(radius-round) !default;
 $sage-radio-transition: 0.15s ease-in-out !default;
-$sage-radio-selected-indicator-size: rem(16) !default;
+$sage-radio-selected-indicator-size: rem(16px) !default;
 $sage-radio-selected-indicator-color: sage-color(white) !default;
 
 // Focus state
@@ -229,12 +229,12 @@ $sage-switch-color-disabled-checked: sage-color(primary, 200) !default;
 $sage-switch-color-disabled-checked-text: sage-color(charcoal, 100) !default;
 
 // Switch
-$sage-switch-border-radius: rem(16) !default;
-$sage-switch-height: rem(24) !default;
-$sage-switch-width: rem(44) !default;
+$sage-switch-border-radius: rem(16px) !default;
+$sage-switch-height: rem(24px) !default;
+$sage-switch-width: rem(44px) !default;
 
 // Toggle
-$sage-switch-toggle-size: rem(20) !default;
+$sage-switch-toggle-size: rem(20px) !default;
 
 // Focus state
 $sage-switch-focus-outline-spacing: sage-spacing(2xs) !default;
@@ -247,10 +247,10 @@ $sage-switch-focus-outline-color: sage-color(primary) !default;
 // ==================================================
 
 $sage-loading-bar-bg-color: sage-color(grey) !default;
-$sage-loading-bar-height: rem(10) !default;
-$sage-loading-bar-width: rem(300) !default;
+$sage-loading-bar-height: rem(10px) !default;
+$sage-loading-bar-width: rem(300px) !default;
 
-$sage-loading-spinner-size: rem(48) !default;
+$sage-loading-spinner-size: rem(48px) !default;
 $sage-loading-spinner-speed: 0.9s !default;
 
 
@@ -259,7 +259,7 @@ $sage-loading-spinner-speed: 0.9s !default;
 // ==================================================
 
 $sage-overlay-bg-color: rgba(sage-color(charcoal, 100), 0.5) !default;
-$sage-overlay-backdrop-filter: blur(rem(2)) !default;
+$sage-overlay-backdrop-filter: blur(rem(2px)) !default;
 $sage-overlay-z-index: sage-z-index(underlay) !default;
 $sage-overlay-transition-default: opacity 0.5s ease-in-out !default;
 $sage-overlay-transition-backdrop-filter: backdrop-filter 0.7s ease-in-out !default;
@@ -279,9 +279,9 @@ $sage-panel-box-shadow: sage-shadow(sm) !default;
 // ASSISTANT
 // ==================================================
 
-$sage-assistant-height: rem(56) !default;
-$sage-assistant-branding-height: rem(20) !default;
-$sage-assistant-search-height: rem(40) !default;
+$sage-assistant-height: rem(56px) !default;
+$sage-assistant-branding-height: rem(20px) !default;
+$sage-assistant-search-height: rem(40px) !default;
 $sage-assistant-search-bg-color: sage-color(grey, 300) !default;
 $sage-assistant-search-bg-opacity: 0.1 !default;
 $sage-assistant-search-placeholder-color: sage-color(grey, 400) !default;
@@ -299,7 +299,7 @@ $sage-tabs-default-transition: 0.2s ease-in-out !default;
 $sage-tabs-active-color: sage-color(charcoal, 500) !default;
 
 // Active tab indicator
-$sage-tabs-active-border-height: rem(4) !default;
+$sage-tabs-active-border-height: rem(4px) !default;
 $sage-tabs-active-border-width: 100% !default;
 $sage-tabs-active-border-color: sage-color(primary) !default;
 $sage-tabs-active-border-radius: sage-border(radius) !default;
@@ -321,4 +321,4 @@ $tooltip-font-color: sage-color(white) !default;
 $tooltip-light-font-color: sage-color(charcoal, 400) !default;
 $tooltip-padding: sage-spacing(2xs) sage-spacing(sm) !default;
 $tooltip-zindex: sage-z_index(nuclear) !default;
-$tooltip-maxwidth: rem(200) !default;
+$tooltip-maxwidth: rem(200px) !default;

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -315,10 +315,19 @@ $sage-live-avatar-ring-width: 1px !default;
 // TOOLTIPS
 // ==================================================
 
-$tooltip-background-color: sage-color(charcoal, 400) !default;
-$tooltip-light-background-color: sage-color(white) !default;
-$tooltip-font-color: sage-color(white) !default;
-$tooltip-light-font-color: sage-color(charcoal, 400) !default;
-$tooltip-padding: sage-spacing(2xs) sage-spacing(sm) !default;
-$tooltip-zindex: sage-z_index(nuclear) !default;
-$tooltip-maxwidth: rem(200px) !default;
+// Colors
+$sage-tooltip-bg-color: sage-color(charcoal, 400) !default;
+$sage-tooltip-light-bg-color: sage-color(white) !default;
+$sage-tooltip-font-color: sage-color(white) !default;
+$sage-tooltip-light-font-color: sage-color(charcoal, 400) !default;
+
+// Indicator arrow
+$sage-tooltip-arrow-size: rem(6px) !default;
+$sage-tooltip-arrow-inactive: $sage-tooltip-arrow-size solid transparent !default;
+$sage-tooltip-arrow-active: $sage-tooltip-arrow-size solid $sage-tooltip-bg-color !default;
+
+// Styling
+$sage-tooltip-shadow: sage-shadow(xl) !default;
+$sage-tooltip-padding: sage-spacing(2xs) sage-spacing(sm) !default;
+$sage-tooltip-zindex: sage-z_index(modal) !default;
+$sage-tooltip-maxwidth: rem(200px) !default;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
@@ -14,7 +14,7 @@
   @extend %t-sage-body-med;
 
   position: relative;
-  padding: rem(12) sage-spacing(sm);
+  padding: rem(12px) sage-spacing(sm);
   margin-bottom: sage-spacing(sm);
   margin-right: sage-spacing(2xs);
   letter-spacing: $sage-btn-letter-spacing;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
@@ -14,7 +14,7 @@
   @extend %t-sage-body-med;
 
   position: relative;
-  padding: 0.75rem sage-spacing(sm);
+  padding: rem(12) sage-spacing(sm);
   margin-bottom: sage-spacing(sm);
   margin-right: sage-spacing(2xs);
   letter-spacing: $sage-btn-letter-spacing;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_menu_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_menu_button.scss
@@ -78,7 +78,7 @@
   transition: transform 0.2s ease-out, opacity 0.15s ease-in-out;
 
   &:not(:first-child) {
-    margin-top: 0.375rem;
+    margin-top: rem(6);
   }
 
   &:nth-child(1) {

--- a/app/assets/stylesheets/sage/system/patterns/elements/_menu_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_menu_button.scss
@@ -78,7 +78,7 @@
   transition: transform 0.2s ease-out, opacity 0.15s ease-in-out;
 
   &:not(:first-child) {
-    margin-top: rem(6);
+    margin-top: rem(6px);
   }
 
   &:nth-child(1) {

--- a/app/assets/stylesheets/sage/system/patterns/elements/_radio.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_radio.scss
@@ -21,8 +21,8 @@
     color: $sage-radio-color-default;
     vertical-align: top;
     outline: none;
-    background-color: #fff;
-    border: 1px solid $sage-radio-color-default;
+    background-color: sage-color(white);
+    border: rem(1px) solid $sage-radio-color-default;
     border-radius: $sage-radio-border-radius;
     transition: background 0.2s ease-in-out, box-shadow $sage-radio-transition, border $sage-radio-transition;
     cursor: pointer;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_tooltip.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_tooltip.scss
@@ -31,9 +31,9 @@
     &::after {
       left: 50%;
       top: 100%;
-      border-left: 6px solid transparent;
-      border-right: 6px solid transparent;
-      border-top: 6px solid $tooltip-background-color;
+      border-left: rem(6px) solid transparent;
+      border-right: rem(6px) solid transparent;
+      border-top: rem(6px) solid $tooltip-background-color;
     }
   }
   &-bottom {
@@ -41,9 +41,9 @@
       left: 50%;
       bottom: 100%;
       transform: translate3d(-50%, 0, 0);
-      border-left: 6px solid transparent;
-      border-right: 6px solid transparent;
-      border-bottom: 6px solid $tooltip-background-color;
+      border-left: rem(6px) solid transparent;
+      border-right: rem(6px) solid transparent;
+      border-bottom: rem(6px) solid $tooltip-background-color;
     }
   }
   &-left {
@@ -51,9 +51,9 @@
       left: 100%;
       bottom: 50%;
       transform: translate3d(0, 50%, 0);
-      border-top: 6px solid transparent;
-      border-bottom: 6px solid transparent;
-      border-left: 6px solid $tooltip-background-color;
+      border-top: rem(6px) solid transparent;
+      border-bottom: rem(6px) solid transparent;
+      border-left: rem(6px) solid $tooltip-background-color;
     }
   }
   &-right {
@@ -61,25 +61,26 @@
       left: 0;
       bottom: 50%;
       transform: translate3d(-100%, 50%, 0);
-      border-top: 6px solid transparent;
-      border-bottom: 6px solid transparent;
-      border-right: 6px solid $tooltip-background-color;
+      border-top: rem(6px) solid transparent;
+      border-bottom: rem(6px) solid transparent;
+      border-right: rem(6px) solid $tooltip-background-color;
     }
   }
   &--light {
     color: $tooltip-light-font-color;
     background: $tooltip-light-background-color;
+
     &.sage-tooltip-top::after {
-      border-top-color: #fff;
+      border-top-color: sage-color(white);
     }
     &.sage-tooltip-bottom::after {
-      border-bottom-color: #fff;
+      border-bottom-color: sage-color(white);
     }
     &.sage-tooltip-left::after {
-      border-left-color: #fff;
+      border-left-color: sage-color(white);
     }
     &.sage-tooltip-right::after {
-      border-right-color: #fff;
+      border-right-color: sage-color(white);
     }
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_tooltip.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_tooltip.scss
@@ -6,34 +6,33 @@
 
 .sage-tooltip {
   display: flex;
-  position: absolute;
   flex-basis: content;
   flex-wrap: wrap;
-  z-index: $tooltip-zindex;
+  position: absolute;
+  z-index: $sage-tooltip-zindex;
   width: max-content;
-  max-width: $tooltip-maxwidth;
-  padding: $tooltip-padding;
+  max-width: $sage-tooltip-maxwidth;
+  padding: $sage-tooltip-padding;
   text-align: left;
-  color: $tooltip-font-color;
+  color: $sage-tooltip-font-color;
   white-space: normal;
   border-radius: sage-border(radius);
-  background-color: $tooltip-background-color;
-  box-shadow: sage-shadow(xl);
+  background-color: $sage-tooltip-bg-color;
+  box-shadow: $sage-tooltip-shadow;
 
   @extend %t-sage-body-small;
 
   &::after {
     content: "";
     position: absolute;
-    clear: both;
   }
   &-top {
     &::after {
       left: 50%;
       top: 100%;
-      border-left: rem(6px) solid transparent;
-      border-right: rem(6px) solid transparent;
-      border-top: rem(6px) solid $tooltip-background-color;
+      border-left: $sage-tooltip-arrow-inactive;
+      border-right: $sage-tooltip-arrow-inactive;
+      border-top: $sage-tooltip-arrow-active;
     }
   }
   &-bottom {
@@ -41,9 +40,9 @@
       left: 50%;
       bottom: 100%;
       transform: translate3d(-50%, 0, 0);
-      border-left: rem(6px) solid transparent;
-      border-right: rem(6px) solid transparent;
-      border-bottom: rem(6px) solid $tooltip-background-color;
+      border-left: $sage-tooltip-arrow-inactive;
+      border-right: $sage-tooltip-arrow-inactive;
+      border-bottom: $sage-tooltip-arrow-active;
     }
   }
   &-left {
@@ -51,9 +50,9 @@
       left: 100%;
       bottom: 50%;
       transform: translate3d(0, 50%, 0);
-      border-top: rem(6px) solid transparent;
-      border-bottom: rem(6px) solid transparent;
-      border-left: rem(6px) solid $tooltip-background-color;
+      border-top: $sage-tooltip-arrow-inactive;
+      border-bottom: $sage-tooltip-arrow-inactive;
+      border-left: $sage-tooltip-arrow-active;
     }
   }
   &-right {
@@ -61,14 +60,14 @@
       left: 0;
       bottom: 50%;
       transform: translate3d(-100%, 50%, 0);
-      border-top: rem(6px) solid transparent;
-      border-bottom: rem(6px) solid transparent;
-      border-right: rem(6px) solid $tooltip-background-color;
+      border-top: $sage-tooltip-arrow-inactive;
+      border-bottom: $sage-tooltip-arrow-inactive;
+      border-right: $sage-tooltip-arrow-active;
     }
   }
   &--light {
-    color: $tooltip-light-font-color;
-    background: $tooltip-light-background-color;
+    color: $sage-tooltip-light-font-color;
+    background: $sage-tooltip-light-bg-color;
 
     &.sage-tooltip-top::after {
       border-top-color: sage-color(white);

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_avatar.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_avatar.scss
@@ -4,8 +4,8 @@
 
 ================================================== */
 
-$-live-avatar-min-size: rem(36);
-$-live-avatar-max-size: rem(128);
+$-live-avatar-min-size: rem(36px);
+$-live-avatar-max-size: rem(128px);
 $-live-avatar-ring-transition: $sage-transition;
 $-live-avatar-ring-colors: (
   charcoal,

--- a/app/assets/stylesheets/sage/system/tokens/_border.scss
+++ b/app/assets/stylesheets/sage/system/tokens/_border.scss
@@ -4,8 +4,8 @@
 }
 
 $sage-borders: (
-  default: 1px solid sage-color(grey, 300),
-  radius: 0.25rem, // 4px
-  radius-large: 0.375rem, // 6px
+  default: rem(1px) solid sage-color(grey, 300),
+  radius: rem(4px),
+  radius-large: rem(6px),
   radius-round: 50%, // rounded
 );

--- a/app/assets/stylesheets/sage/system/tokens/_font_size.scss
+++ b/app/assets/stylesheets/sage/system/tokens/_font_size.scss
@@ -4,12 +4,12 @@
 }
 
 $sage-font-sizes: (
-  xs: rem(11.11),
-  sm: rem(13.33),
-  md: rem(16),
-  lg: rem(19.2),
-  xl: rem(23.04),
-  2xl: rem(27.65),
-  3xl: rem(33.18),
-  4xl: rem(39.81)
+  xs: rem(11.11px),
+  sm: rem(13.33px),
+  md: rem(16px),
+  lg: rem(19.2px),
+  xl: rem(23.04px),
+  2xl: rem(27.65px),
+  3xl: rem(33.18px),
+  4xl: rem(39.81px)
 );

--- a/app/assets/stylesheets/sage/system/tokens/_letter_spacing.scss
+++ b/app/assets/stylesheets/sage/system/tokens/_letter_spacing.scss
@@ -4,7 +4,7 @@
 }
 
 $sage-letter-spacings: (
-  sm: rem(0.3),
-  md: rem(0.5),
-  lg: rem(0.8),
+  sm: rem(0.3px),
+  md: rem(0.5px),
+  lg: rem(0.8px),
 );

--- a/app/assets/stylesheets/sage/system/tokens/_sidebar.scss
+++ b/app/assets/stylesheets/sage/system/tokens/_sidebar.scss
@@ -4,7 +4,7 @@
 }
 
 $sage-sidebars: (
-  sm: 15rem, // 240px
-  md: 20rem, // 320px
-  lg: 25rem, // 400px
+  sm: rem(240px),
+  md: rem(320px),
+  lg: rem(400px)
 );

--- a/app/assets/stylesheets/sage/system/tokens/_spacing.scss
+++ b/app/assets/stylesheets/sage/system/tokens/_spacing.scss
@@ -4,9 +4,9 @@
 }
 
 $sage-spacings: (
-  2xs: 0.25rem, // 4px
-  xs: 0.5rem, // 8px
-  sm: 1rem, // 16px
-  md: 1.5rem, // 24px
-  lg: 2rem // 32px
+  2xs: rem(4px),
+  xs: rem(8px),
+  sm: rem(16px),
+  md: rem(24px),
+  lg: rem(32px)
 );

--- a/app/helpers/sage/tokens_helper.rb
+++ b/app/helpers/sage/tokens_helper.rb
@@ -93,6 +93,8 @@ module Sage
           tokens: [
             { name: "default" },
             { name: "radius" },
+            { name: "radius-large" },
+            { name: "radius-round" },
           ]
         },
         {


### PR DESCRIPTION
## Description
Now that we have a function that handles conversion from `px` to `rem`, we should replace our previously calculated values within stylesheets. For example, `0.125rem` becomes `rem(2px)`.

This should give developers a better idea of what defined values are at a glance, as well as avoid potential mistakes with inputting decimal values.

- No visual changes should be introduced with this PR.
- Tooltip CSS structure and variables refactored
- Updated `border` token display output

## Test notes
### Steps for testing
1. Spin up the server
2. Navigate around the documentation and verify that values and styling appear as expected
