### PR TITLE
[mobile] Form field drop shadows

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
@@ -39,6 +39,7 @@
   padding: $sage-inputfield-padding-offset $sage-inputfield-padding;
   color: $sage-inputfield-color-default;
   line-height: 1;
+  appearance: none;
   border: $sage-inputfield-border-width solid $sage-inputfield-border-color;
   border-radius: $sage-inputfield-border-radius;
   background: transparent;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_textarea.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_textarea.scss
@@ -34,6 +34,7 @@
   width: $sage-textarea-width;
   padding: $sage-textarea-padding $sage-textarea-padding $sage-textarea-padding;
   color: $sage-textarea-color-default;
+  appearance: none;
   border: $sage-textarea-border-width solid $sage-textarea-border-color;
   border-radius: $sage-textarea-border-radius;
   background: $sage-textarea-bg-default;


### PR DESCRIPTION
## Description
Form inputs and text areas are displaying browser default drop shadows in iOS.

### Screenshots
|  Form inputs   |  Textareas  |
|--------|--------|
|before: ![ios-form-inputs](https://user-images.githubusercontent.com/816579/77708819-6213ff80-6f86-11ea-88be-682b3482bc36.png)|![ios-form-textarea](https://user-images.githubusercontent.com/816579/77708829-66401d00-6f86-11ea-9b85-5098628a1ff6.png)|
after: <img width="559" alt="input-after" src="https://user-images.githubusercontent.com/816579/77779563-f7a7a180-700f-11ea-9312-890cc5bd21d5.png">|after: <img width="559" alt="textarea-after" src="https://user-images.githubusercontent.com/816579/77779582-fe361900-700f-11ea-934c-05fe61225662.png">|


## Related issues
n/a