### PR TITLE
[mobile] Switch element outline

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -22,6 +22,7 @@
     appearance: none;
     color: $sage-switch-color-default;
     background: $sage-switch-color-default;
+    border: 0;
     border-radius: $sage-switch-border-radius;
     outline: none;
     transition: background 0.3s ease-out;


### PR DESCRIPTION
## Description
Switch element displays border around control in iOS:


### Screenshots
|  Before   |  After  |
|--------|--------|
|![ios-switch](https://user-images.githubusercontent.com/816579/77709177-7ad0e500-6f87-11ea-9f7f-421f805ba791.png)|<img alt="switch-after" src="https://user-images.githubusercontent.com/816579/77792699-0e58f300-7026-11ea-80ea-3c0b61a418bb.png">|


