### PR TITLE
Checkbox error styles

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/elements/_checkbox.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_checkbox.scss
@@ -10,115 +10,131 @@
   flex-flow: row wrap;
   align-items: center;
   margin-bottom: $sage-form-element-spacing;
+}
 
-  input[type="checkbox"] {
-    appearance: none;
-    display: inline-block;
-    position: relative;
-    height: $sage-checkbox-size;
-    width: $sage-checkbox-size;
-    margin: 0;
-    vertical-align: top;
-    color: $sage-checkbox-color-default;
-    border: 1px solid $sage-checkbox-color-default;
+.sage-checkbox__label {
+  display: inline-block;
+  margin-left: sage-spacing(sm);
+  vertical-align: top;
+  cursor: pointer;
+
+  @extend %t-sage-body;
+}
+
+.sage-checkbox__input {
+  appearance: none;
+  display: inline-block;
+  position: relative;
+  height: $sage-checkbox-size;
+  width: $sage-checkbox-size;
+  margin: 0;
+  vertical-align: top;
+  color: $sage-checkbox-color-default;
+  border: 1px solid $sage-checkbox-color-default;
+  border-radius: $sage-checkbox-border-radius;
+  outline: none;
+  transition: background $sage-checkbox-transition, box-shadow $sage-checkbox-transition, border $sage-checkbox-transition;
+  cursor: pointer;
+
+  &::before,
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transition: opacity 0.2s ease-in-out, transform $sage-checkbox-transition;
+    opacity: 0;
+  }
+
+  // focus outline
+  &::before {
+    transform: translate3d(-50%, -50%, 0) scale(0.94);
+    width: calc(100% + (#{$sage-checkbox-focus-outline-width * 1px} + #{$sage-checkbox-focus-outline-size * 2}));
+    height: calc(100% + (#{$sage-checkbox-focus-outline-width * 1px} + #{$sage-checkbox-focus-outline-size * 2}));
+    border: ($sage-checkbox-focus-outline-width * 1px) solid $sage-checkbox-focus-outline-color;
     border-radius: $sage-checkbox-border-radius;
-    outline: none;
-    transition: background $sage-checkbox-transition, box-shadow $sage-checkbox-transition, border $sage-checkbox-transition;
-    cursor: pointer;
+    pointer-events: none;
+    opacity: 0;
+  }
 
-    + label {
-      display: inline-block;
-      margin-left: sage-spacing(sm);
-      vertical-align: top;
-      cursor: pointer;
+  &::after {
+    transform: translate3d(-50%, calc(-50% + #{$sage-checkbox-marker-offset}), 0) rotate($sage-checkbox-marker-rotate);
+    height: $sage-checkbox-marker-height;
+    width: $sage-checkbox-marker-width;
+    border-right: $sage-checkbox-marker-border solid $sage-checkbox-marker-color;
+    border-bottom: $sage-checkbox-marker-border solid $sage-checkbox-marker-color;
+  }
 
-      @extend %t-sage-body;
-    }
+  &:checked {
+    color: $sage-checkbox-color-checked;
+    background: $sage-checkbox-color-checked;
+    border-color: $sage-checkbox-color-checked;
+    box-shadow: sage-shadow(sm);
 
-    &::before,
     &::after {
-      content: "";
-      display: block;
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      transition: opacity 0.2s ease-in-out, transform $sage-checkbox-transition;
-      opacity: 0;
+      transform: translate3d(-50%, calc(-50% - #{$sage-checkbox-marker-border} / 2), 0) rotate($sage-checkbox-marker-rotate);
+      opacity: 1;
     }
+  }
 
-    // focus outline
+  &:hover {
+    &:not(:checked) {
+      &:not(:disabled) {
+        border-color: sage-color(grey, 500);
+        box-shadow: sage-shadow(sm);
+      }
+    }
+  }
+
+  &:focus:not(:disabled),
+  &:active:not(:disabled) {
     &::before {
-      transform: translate3d(-50%, -50%, 0) scale(0.94);
-      width: calc(100% + (#{$sage-checkbox-focus-outline-width * 1px} + #{$sage-checkbox-focus-outline-size * 2}));
-      height: calc(100% + (#{$sage-checkbox-focus-outline-width * 1px} + #{$sage-checkbox-focus-outline-size * 2}));
-      border: ($sage-checkbox-focus-outline-width * 1px) solid $sage-checkbox-focus-outline-color;
-      border-radius: $sage-checkbox-border-radius;
-      pointer-events: none;
-      opacity: 0;
+      transform: translate3d(-50%, -50%, 0) scale(1);
+      opacity: 1;
+    }
+  }
+
+  &:disabled {
+    background: $sage-checkbox-color-disabled;
+    cursor: not-allowed;
+    opacity: 0.5;
+
+    &::before {
+      display: none;
     }
 
-    &::after {
-      transform: translate3d(-50%, calc(-50% + #{$sage-checkbox-marker-offset}), 0) rotate($sage-checkbox-marker-rotate);
-      height: $sage-checkbox-marker-height;
-      width: $sage-checkbox-marker-width;
-      border-right: $sage-checkbox-marker-border solid $sage-checkbox-marker-color;
-      border-bottom: $sage-checkbox-marker-border solid $sage-checkbox-marker-color;
-    }
-
+    // disabled & checked
     &:checked {
-      color: $sage-checkbox-color-checked;
-      background: $sage-checkbox-color-checked;
-      border-color: $sage-checkbox-color-checked;
-      box-shadow: sage-shadow(sm);
-
-      &::after {
-        transform: translate3d(-50%, calc(-50% - #{$sage-checkbox-marker-border} / 2), 0) rotate($sage-checkbox-marker-rotate);
-        opacity: 1;
-      }
-    }
-
-    &:hover {
-      &:not(:checked) {
-        &:not(:disabled) {
-          border-color: sage-color(grey, 500);
-          box-shadow: sage-shadow(sm);
-        }
-      }
-    }
-
-    &:focus:not(:disabled),
-    &:active:not(:disabled) {
-      &::before {
-        transform: translate3d(-50%, -50%, 0) scale(1);
-        opacity: 1;
-      }
-    }
-
-    &:disabled {
-      background: $sage-checkbox-color-disabled;
-      cursor: not-allowed;
-      opacity: 0.5;
+      background: $sage-checkbox-color-disabled-checked;
+      border-color: $sage-checkbox-color-disabled-checked;
+      box-shadow: none;
+      opacity: 1;
 
       &::before {
         display: none;
       }
-
-      // disabled & checked
-      &:checked {
-        background: $sage-checkbox-color-disabled-checked;
-        border-color: $sage-checkbox-color-disabled-checked;
-        box-shadow: none;
-        opacity: 1;
-
-        &::before {
-          display: none;
-        }
-      }
-
-      + label {
-        color: $sage-checkbox-color-default;
-        cursor: not-allowed;
-      }
     }
+
+    + .sage-checkbox__label {
+      color: $sage-checkbox-color-default;
+      cursor: not-allowed;
+    }
+  }
+}
+
+// error & unchecked + error & checked
+.sage-checkbox--error .sage-checkbox__input,
+.sage-checkbox__input:invalid {
+  background: sage-color(red, 100);
+  border-color: sage-color(red);
+
+  &::after {
+    border-right-color: sage-color(red);
+    border-bottom-color: sage-color(red);
+  }
+
+  + .sage-checkbox__label {
+    color: sage-color(red);
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_checkbox.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_checkbox.scss
@@ -19,6 +19,16 @@
   cursor: pointer;
 
   @extend %t-sage-body;
+
+  .sage-checkbox__input:disabled + & {
+    color: $sage-checkbox-color-default;
+    cursor: not-allowed;
+  }
+
+  .sage-checkbox--error &,
+  .sage-checkbox__input:invalid + & {
+    color: sage-color(red);
+  }
 }
 
 .sage-checkbox__input {
@@ -35,6 +45,7 @@
   outline: none;
   transition: background $sage-checkbox-transition, box-shadow $sage-checkbox-transition, border $sage-checkbox-transition;
   cursor: pointer;
+
 
   &::before,
   &::after {
@@ -115,26 +126,16 @@
         display: none;
       }
     }
+  }
 
-    + .sage-checkbox__label {
-      color: $sage-checkbox-color-default;
-      cursor: not-allowed;
+  .sage-checkbox--error &,
+  &:invalid {
+    background: sage-color(red, 100);
+    border-color: sage-color(red);
+
+    &::after {
+      border-right-color: sage-color(red);
+      border-bottom-color: sage-color(red);
     }
-  }
-}
-
-// error & unchecked + error & checked
-.sage-checkbox--error .sage-checkbox__input,
-.sage-checkbox__input:invalid {
-  background: sage-color(red, 100);
-  border-color: sage-color(red);
-
-  &::after {
-    border-right-color: sage-color(red);
-    border-bottom-color: sage-color(red);
-  }
-
-  + .sage-checkbox__label {
-    color: sage-color(red);
   }
 }

--- a/app/views/sage/examples/elements/checkbox/_preview.html.erb
+++ b/app/views/sage/examples/elements/checkbox/_preview.html.erb
@@ -1,20 +1,30 @@
 <!-- Default -->
 <div class="sage-checkbox">
-    <input id="c1" type="checkbox">
-    <label for="c1">Checkbox</label>
+  <input id="c1" type="checkbox" class="sage-checkbox__input">
+  <label for="c1" class="sage-checkbox__label">Checkbox</label>
 </div>
 <!-- Checked -->
 <div class="sage-checkbox">
-    <input id="c2" type="checkbox" checked>
-    <label for="c2">Checked</label>
+  <input id="c2" type="checkbox" class="sage-checkbox__input" checked>
+  <label for="c2" class="sage-checkbox__label">Checked</label>
 </div>
 <!-- Disabled -->
 <div class="sage-checkbox">
-    <input id="c3" type="checkbox" disabled>
-    <label for="c3">Disabled</label>
+  <input id="c3" type="checkbox" class="sage-checkbox__input" disabled>
+  <label for="c3" class="sage-checkbox__label">Disabled</label>
 </div>
 <!-- Checked & Disabled -->
 <div class="sage-checkbox">
-    <input id="c4" type="checkbox" checked disabled>
-    <label for="c4">Checked and disabled</label>
+  <input id="c4" type="checkbox" class="sage-checkbox__input" checked disabled>
+  <label for="c4" class="sage-checkbox__label">Checked and disabled</label>
+</div>
+<!-- Error -->
+<div class="sage-checkbox sage-checkbox--error">
+  <input id="c5" type="checkbox" class="sage-checkbox__input">
+  <label for="c5" class="sage-checkbox__label">Error</label>
+</div>
+<!-- Checked & Error -->
+<div class="sage-checkbox sage-checkbox--error">
+  <input id="c6" type="checkbox" class="sage-checkbox__input" checked>
+  <label for="c6" class="sage-checkbox__label">Checked &amp; Error</label>
 </div>


### PR DESCRIPTION
Resolves: #112.

## PR Includes
**1)** Add classes to `.sage-checkbox`'s children to match its `.sage-radio` implementation counterpart.

**2)** Checkbox error styles that apply either with a `.sage-checkbox--error` modifier or if the checkbox matches the criteria for the HTML5 `:invalid` pseudo selector.

**Note:** This is divergent with the error pattern used by `.sage-radio` in that it includes the `--error` modifier _in addition_ to applying error styles when `:invalid`. This is in order to match the mockup provided in #112. If a checkbox is `:checked` it doesn't qualify as `:invalid`.

Curious if there a work-around here or something I'm missing?

## Preview
![image](https://user-images.githubusercontent.com/565743/77799571-b5e02080-703a-11ea-86dc-fbe721bfb178.png)
