### PR TITLE
Revise input field and textarea label appearance

### DIFF
--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -117,9 +117,11 @@ $sage-inputfield-box-shadow-size: 0 0 0 rem(1px) !default;
 
 // Sizing
 $sage-inputfield-height: rem(40px) !default;
-$sage-inputfield-padding: rem(18px) !default;
+$sage-inputfield-padding: rem(12px) !default;
+$sage-inputfield-padding-x: rem(16px) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
 $sage-inputfield-padding-filled: rem(4px) !default;
+$sage-inputfield-padding-label: rem(3px) !default;
 
 // Spacing
 $sage-inputfield-spacing: sage-spacing(lg) !default;
@@ -129,6 +131,7 @@ $sage-inputfield-color-default: sage-color(charcoal) !default;
 $sage-inputfield-color-disabled: sage-color(grey, 400) !default;
 $sage-inputfield-color-success: sage-color(primary) !default;
 $sage-inputfield-color-error: sage-color(red) !default;
+$sage-inputfield-bg-label: sage-color(white) !default;
 $sage-inputfield-bg-disabled: sage-color(grey, 100) !default;
 
 

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -146,17 +146,13 @@ $sage-textarea-border-width: $sage-inputfield-border-width !default;
 $sage-textarea-box-shadow-size: $sage-inputfield-box-shadow-size !default;
 
 // Padding
-$sage-textarea-label-padding-top: rem(12px) !default;
-$sage-textarea-label-padding-bottom: rem(6px) !default;
-$sage-textarea-label-margin-bottom: 0 !default;
+$sage-textarea-label-padding: rem(3px) !default;
 $sage-textarea-padding: $sage-inputfield-padding !default;
-$sage-textarea-padding-filled: $sage-body-font-size + $sage-textarea-label-padding-top + $sage-textarea-label-padding-bottom !default; // height of label
 
 // Sizing
 $sage-textarea-min-height: rem(130px) !default;
 $sage-textarea-height: 100% !default;
 $sage-textarea-width: 100% !default;
-$sage-textarea-label-width: calc(100% - #{$sage-textarea-padding} * 2) !default;
 
 // Spacing
 $sage-textarea-spacing: $sage-inputfield-spacing !default;

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -116,7 +116,7 @@ $sage-inputfield-border-width: rem(1px) !default;
 $sage-inputfield-box-shadow-size: 0 0 0 rem(1px) !default;
 
 // Sizing
-$sage-inputfield-height: rem(56px) !default;
+$sage-inputfield-height: rem(40px) !default;
 $sage-inputfield-padding: rem(18px) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
 $sage-inputfield-padding-filled: rem(4px) !default;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
@@ -29,7 +29,7 @@
 
   @extend %t-sage-body-xsmall-semi;
 
-  @media (min-width(sage-breakpoint(sm-min))) {
+  @media screen and (min-width: sage-breakpoint(sm-min)) {
     white-space: normal;
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
@@ -70,6 +70,7 @@
     }
   }
 
+  /* Separated so IE/Edge does not ignore focus styles. Note that Edge will not support these states */
   &:valid:not(:placeholder-shown),
   &:required:not(:placeholder-shown) {
     ~ .sage-input__label {
@@ -77,6 +78,7 @@
     }
   }
 
+  // TODO: add support for Simpleform classes
   &:valid:not(:placeholder-shown) {
     border-color: $sage-inputfield-color-success;
     box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-success;
@@ -86,6 +88,7 @@
     }
   }
 
+  // TODO: add support for Simpleform classes
   &:required:not(:placeholder-shown):not(:valid) {
     border-color: $sage-inputfield-color-error;
     box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-error;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
@@ -22,18 +22,22 @@
   padding-right: $sage-inputfield-padding-label;
   color: inherit;
   font-weight: sage-font-weight(semibold);
+  white-space: nowrap;
   background-color: $sage-inputfield-bg-label;
   pointer-events: none;
   opacity: 0;
 
   @extend %t-sage-body-xsmall-semi;
+
+  @media (min-width(sage-breakpoint(sm-min))) {
+    white-space: normal;
+  }
 }
 
 .sage-input__field {
   @mixin floating-label-active {
     transform: translateY(-($sage-body-font-size + $sage-inputfield-padding-filled * 2)); // IE doesn't support calc in transforms so we provide a fallback
     transform: translateY(calc(-50% - (#{$sage-body-font-size} + #{$sage-inputfield-padding-filled}))); // we calculate the centered position minus the offset of the text height plus the spacing height
-    // line-height: 1;
     transition: opacity 0.1s ease-in, transform 0.15s ease-in-out, color 0.15s ease-out;
     opacity: 1;
   }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
@@ -14,6 +14,8 @@
 }
 
 .sage-input__label {
+  @extend %t-sage-body-xsmall-semi;
+
   position: absolute;
   transform: translateY(calc(#{$sage-body-font-size} * -1));
   left: $sage-inputfield-padding-x;
@@ -26,8 +28,6 @@
   background-color: $sage-inputfield-bg-label;
   pointer-events: none;
   opacity: 0;
-
-  @extend %t-sage-body-xsmall-semi;
 
   @media screen and (min-width: sage-breakpoint(sm-min)) {
     white-space: normal;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_input.scss
@@ -16,9 +16,13 @@
 .sage-input__label {
   position: absolute;
   transform: translateY(calc(#{$sage-body-font-size} * -1));
-  left: $sage-inputfield-padding;
+  left: $sage-inputfield-padding-x;
   top: 50%;
+  padding-left: $sage-inputfield-padding-label;
+  padding-right: $sage-inputfield-padding-label;
   color: inherit;
+  font-weight: sage-font-weight(semibold);
+  background-color: $sage-inputfield-bg-label;
   pointer-events: none;
   opacity: 0;
 
@@ -26,11 +30,11 @@
 }
 
 .sage-input__field {
-  $-ie-label-offset: -($sage-body-font-size + $sage-inputfield-padding-filled);
-
-  @mixin floating-label {
-    transform: translateY($-ie-label-offset); // IE doesn't support calc in transforms
-    transform: translateY(calc(-50% - (#{$sage-body-font-size} - #{$sage-inputfield-padding-filled})));
+  @mixin floating-label-active {
+    transform: translateY(-($sage-body-font-size + $sage-inputfield-padding-filled * 2)); // IE doesn't support calc in transforms so we provide a fallback
+    transform: translateY(calc(-50% - (#{$sage-body-font-size} + #{$sage-inputfield-padding-filled}))); // we calculate the centered position minus the offset of the text height plus the spacing height
+    // line-height: 1;
+    transition: opacity 0.1s ease-in, transform 0.15s ease-in-out, color 0.15s ease-out;
     opacity: 1;
   }
 
@@ -38,7 +42,6 @@
   width: 100%;
   padding: $sage-inputfield-padding-offset $sage-inputfield-padding;
   color: $sage-inputfield-color-default;
-  line-height: 1;
   appearance: none;
   border: $sage-inputfield-border-width solid $sage-inputfield-border-color;
   border-radius: $sage-inputfield-border-radius;
@@ -51,7 +54,6 @@
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {
-    padding-bottom: $sage-inputfield-padding-filled;
     border-color: currentColor;
     outline: none;
 
@@ -59,29 +61,15 @@
       opacity: 0;
     }
 
-    .sage-input--no-label & {
-      padding-bottom: $sage-inputfield-padding;
-    }
-
     ~ .sage-input__label {
-      @include floating-label();
-
-      transition: opacity 0.15s ease-out, transform 0.15s ease-in-out, color 0.15s ease-out;
+      @include floating-label-active();
     }
   }
 
   &:valid:not(:placeholder-shown),
   &:required:not(:placeholder-shown) {
-    padding-bottom: $sage-inputfield-padding-filled;
-
     ~ .sage-input__label {
-      @include floating-label();
-
-      transition: opacity 0.15s ease-out, transform 0.15s ease-in-out, color 0.15s ease-out;
-    }
-
-    .sage-input--no-label & {
-      padding-bottom: $sage-inputfield-padding;
+      @include floating-label-active();
     }
   }
 
@@ -107,5 +95,13 @@
     color: $sage-inputfield-color-disabled;
     background-color: $sage-inputfield-bg-disabled;
     cursor: not-allowed;
+  }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+  .sage-input__label,
+  .sage-input__field {
+    transition: none !important; /* stylelint-disable-line declaration-no-important */
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_textarea.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_textarea.scss
@@ -18,21 +18,30 @@
   position: absolute;
   left: $sage-textarea-padding;
   top: $sage-textarea-border-width;
-  width: $sage-textarea-label-width;
-  margin-bottom: $sage-textarea-label-margin-bottom;
-  padding-top: $sage-textarea-label-padding-top;
-  padding-bottom: $sage-textarea-label-padding-bottom;
+  padding-left: $sage-textarea-label-padding;
+  padding-right: $sage-textarea-label-padding;
   color: inherit;
+  white-space: nowrap;
   background-color: $sage-textarea-label-bg-color;
   pointer-events: none;
   opacity: 0;
+
+  @media screen and (min-width: sage-breakpoint(sm-min)) {
+    white-space: normal;
+  }
 }
 
 .sage-textarea__field {
+  @mixin floating-label-textarea-active {
+    transform: translateY(-$sage-textarea-padding);
+    transition: opacity 0.1s ease-in, transform 0.15s ease-in-out, color 0.15s ease-out;
+    opacity: 1;
+  }
+
   min-height: $sage-textarea-min-height;
   height: $sage-textarea-height;
   width: $sage-textarea-width;
-  padding: $sage-textarea-padding $sage-textarea-padding $sage-textarea-padding;
+  padding: $sage-textarea-padding;
   color: $sage-textarea-color-default;
   appearance: none;
   border: $sage-textarea-border-width solid $sage-textarea-border-color;
@@ -46,7 +55,6 @@
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {
-    padding-top: $sage-textarea-padding-filled;
     border-color: currentColor;
     outline: none;
 
@@ -54,30 +62,20 @@
       opacity: 0;
     }
 
-    .sage-textarea--no-label & {
-      padding-top: $sage-textarea-padding;
-    }
-
     ~ .sage-textarea__label {
-      transition: opacity 0.15s ease-out, transform 0.15s ease-in-out, color 0.15s ease-out;
-      opacity: 1;
+      @include floating-label-textarea-active();
     }
   }
 
+  /* Separated so IE/Edge does not ignore focus styles. Note that Edge will not support these states */
   &:valid:not(:placeholder-shown),
   &:required:not(:placeholder-shown) {
-    padding-top: $sage-textarea-padding-filled;
-
     ~ .sage-textarea__label {
-      transition: opacity 0.15s ease-out, transform 0.15s ease-in-out, color 0.15s ease-out;
-      opacity: 1;
-    }
-
-    .sage-textarea--no-label & {
-      padding-top: $sage-textarea-padding;
+      @include floating-label-textarea-active();
     }
   }
 
+  // TODO: add support for Simpleform classes
   &:valid:not(:placeholder-shown) {
     border-color: $sage-textarea-color-success;
     box-shadow: $sage-textarea-box-shadow-size $sage-textarea-color-success;
@@ -87,6 +85,7 @@
     }
   }
 
+  // TODO: add support for Simpleform classes
   &:required:not(:placeholder-shown):not(:valid) {
     border-color: $sage-textarea-color-error;
     box-shadow: $sage-textarea-box-shadow-size $sage-textarea-color-error;

--- a/app/views/sage/examples/elements/form_input/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_input/_preview.html.erb
@@ -24,7 +24,7 @@
 
   <h3 class="t-sage-heading-6">Number</h3>
   <div class="sage-input">
-    <input class="sage-input__field" type="number" placeholder="Enter quantity (max 100)" id="form__num" name="form__num" max="100" required>
+    <input class="sage-input__field" type="number" placeholder="Enter quantity (max 100)" id="form__num" name="form__num" max="100" inputmode="numeric" required>
     <label for="form__num" class="sage-input__label">Enter quantity (max 100)</label>
   </div>
 

--- a/app/views/sage/examples/elements/form_input/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_input/_preview.html.erb
@@ -1,5 +1,5 @@
-<fieldset>
-  <p>Text (default)</p>
+<fieldset class="sage-type">
+  <h3 class="t-sage-heading-6">Text (default)</h3>
   <div class="sage-input">
     <input class="sage-input__field" type="text" placeholder="First name" id="form__fname" name="form__fname" required>
     <label for="form__fname" class="sage-input__label">First name</label>
@@ -10,16 +10,22 @@
     <label for="form__lname" class="sage-input__label">Last name</label>
   </div>
 
-  <p>Email</p>
+  <h3 class="t-sage-heading-6">Email</h3>
   <div class="sage-input">
     <input class="sage-input__field" type="email" placeholder="Email address" id="form__email" name="form__email" required>
     <label for="form__email" class="sage-input__label">Email address</label>
   </div>
 
-  <p>Password</p>
+  <h3 class="t-sage-heading-6">Password</h3>
   <div class="sage-input">
     <input class="sage-input__field" type="password" placeholder="Create a password (8 to 32 characters)" id="form__pw" name="form__pw" minlength="8" maxlength="32" required>
     <label for="form__pw" class="sage-input__label">Create a new password (8 to 32 characters)</label>
+  </div>
+
+  <h3 class="t-sage-heading-6">Number</h3>
+  <div class="sage-input">
+    <input class="sage-input__field" type="number" placeholder="Enter quantity (max 100)" id="form__num" name="form__num" max="100" required>
+    <label for="form__num" class="sage-input__label">Enter quantity (max 100)</label>
   </div>
 
 </fieldset>

--- a/app/views/sage/examples/elements/form_input/_props.html.erb
+++ b/app/views/sage/examples/elements/form_input/_props.html.erb
@@ -16,3 +16,9 @@
   <td>String</td>
   <td>null</td>
 </tr>
+<tr>
+  <td>Inputmode</td>
+  <td>Affects the type of data to be entered. For mobile devices, this can influence the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode" rel="nofollow">type of control displayed</a></td>
+  <td>String</td>
+  <td>null</td>
+</tr>

--- a/app/views/sage/examples/elements/form_input/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_do.html.erb
@@ -1,6 +1,7 @@
 <ul>
+  <li>Use of text inputs without a corresponding label is an option, but <strong>not recommended</strong></li>
   <li>Make sure that the label element follows the input in the HTML</li>
   <li>Use unique ID and name values for each field</li>
-  <li>Match the placeholder and label text for the "floating label" effect</li>
+  <li>Match the placeholder and label text precisely, or the "floating label" effect may appear jarring</li>
   <li>Take advantage of <a href="https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation" rel="nofollow">HTML client-side validation</a> for basic fields &ndash; baked-in with most browsers</li>
 </ul>

--- a/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/form_input/_rules_dont.html.erb
@@ -1,3 +1,4 @@
 <ul>
+  <li>Placeholders are <strong>not</strong> intended for detailed instructions &ndash; make use of adjacent text instead</li>
   <li>Do not rely on HTML client-side validation when complex and/or secure requirements are involved, such as password validation and generation</li>
 </ul>

--- a/app/views/sage/examples/elements/form_textarea/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_textarea/_preview.html.erb
@@ -1,16 +1,18 @@
-<p>Default</p>
-<div class="sage-textarea">
-  <textarea class="sage-textarea__field" id="txtarea-example" name="txtarea-example" placeholder="Your message"></textarea>
-  <label for="txtarea-example" class="sage-textarea__label">Your message</label>
-</div>
+<fieldset class="sage-type">
+  <h3 class="t-sage-heading-6">Default</h3>
+  <div class="sage-textarea">
+    <textarea class="sage-textarea__field" id="txtarea-example" name="txtarea-example" placeholder="Your message"></textarea>
+    <label for="txtarea-example" class="sage-textarea__label">Your message</label>
+  </div>
 
-<p>No label (placeholder only)</p>
-<div class="sage-textarea sage-textarea--no-label">
-  <textarea class="sage-textarea__field" id="txtarea-example-nolabel" name="txtarea-example-nolabel" placeholder="Your message"></textarea>
-</div>
+  <h3 class="t-sage-heading-6">No label (placeholder only)</h3>
+  <div class="sage-textarea sage-textarea--no-label">
+    <textarea class="sage-textarea__field" id="txtarea-example-nolabel" name="txtarea-example-nolabel" placeholder="Your message"></textarea>
+  </div>
 
-<p>Disabled</p>
-<div class="sage-textarea">
-  <textarea class="sage-textarea__field" id="txtarea-example-disabled" name="txtarea-example-disabled" placeholder="Your message" disabled>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</textarea>
-  <label for="txtarea-example-disabled" class="sage-textarea__label">Your message</label>
-</div>
+  <h3 class="t-sage-heading-6">Disabled</h3>
+  <div class="sage-textarea">
+    <textarea class="sage-textarea__field" id="txtarea-example-disabled" name="txtarea-example-disabled" placeholder="Your message" disabled>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</textarea>
+    <label for="txtarea-example-disabled" class="sage-textarea__label">Your message</label>
+  </div>
+</fieldset>


### PR DESCRIPTION
## Description
Following discussions with design, the focused/floating label styles will be tweaked to resemble the Material Design "outlined" appearance, as can be seen here: https://material.io/components/text-fields/

In addition, input fields will be reduced in height to better align when displayed inline alongside buttons (corrected in #143).

Both text input fields and text areas will be updated to match.

Revised design:
![text-fields](https://user-images.githubusercontent.com/816579/78292080-58851d00-74db-11ea-9d38-899132ad6a76.png)
