### PR TITLE
[mobile] Loading examples overlapping

### DIFF
--- a/app/assets/stylesheets/sage/docs/_example.scss
+++ b/app/assets/stylesheets/sage/docs/_example.scss
@@ -33,16 +33,16 @@
 .example__block {
   margin-top: sage-spacing(sm);
   margin-bottom: sage-spacing(sm);
+}
 
-  &--md {
-    margin-top: sage-spacing(md);
-    margin-bottom: sage-spacing(md);
-  }
+.example__block--md {
+  margin-top: sage-spacing(md);
+  margin-bottom: sage-spacing(md);
+}
 
-  &--lg {
-    margin-top: sage-spacing(lg);
-    margin-bottom: sage-spacing(lg);
-  }
+.example__block--lg {
+  margin-top: sage-spacing(lg);
+  margin-bottom: sage-spacing(lg);
 }
 
 .example__code {

--- a/app/assets/stylesheets/sage/docs/_example.scss
+++ b/app/assets/stylesheets/sage/docs/_example.scss
@@ -4,38 +4,51 @@
   For Sage documentation use
 ================================================== */
 
-.example {
-  &__title {
-    color: sage-color(charcoal, 500);
-    text-transform: capitalize;
+.example__title {
+  color: sage-color(charcoal, 500);
+  text-transform: capitalize;
+}
+
+.example__ink {
+  color: sage-color(charcoal, 500);
+  font-size: sage-font-size(lg);
+}
+
+.example__label {
+  display: inline-block;
+  min-width: rem(100px);
+  margin: sage-spacing() 0;
+  padding: sage-spacing(xs) sage-spacing();
+  color: sage-color(charcoal, 500);
+  text-align: center;
+  background: sage-color(white);
+  box-shadow: sage-shadow();
+  border-radius: rem(20px);
+}
+
+.example__preview {
+  margin: sage-spacing() 0;
+}
+
+.example__block {
+  margin-top: sage-spacing(sm);
+  margin-bottom: sage-spacing(sm);
+
+  &--md {
+    margin-top: sage-spacing(md);
+    margin-bottom: sage-spacing(md);
   }
 
-  &__ink {
-    color: sage-color(charcoal, 500);
-    font-size: sage-font-size(lg);
+  &--lg {
+    margin-top: sage-spacing(lg);
+    margin-bottom: sage-spacing(lg);
   }
+}
 
-  &__label {
-    display: inline-block;
-    min-width: rem(100px);
-    margin: sage-spacing() 0;
-    padding: sage-spacing(xs) sage-spacing();
-    color: sage-color(charcoal, 500);
-    text-align: center;
-    background: sage-color(white);
-    box-shadow: sage-shadow();
-    border-radius: rem(20px);
-  }
+.example__code {
+  margin: sage-spacing() 0;
 
-  &__preview {
-    margin: sage-spacing() 0;
-  }
-
-  &__code {
-    margin: sage-spacing() 0;
-
-    .prettyprint {
-      margin-bottom: 0;
-    }
+  .prettyprint {
+    margin-bottom: 0;
   }
 }

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -251,6 +251,7 @@ $sage-switch-focus-outline-color: sage-color(primary) !default;
 $sage-loading-bar-bg-color: sage-color(grey) !default;
 $sage-loading-bar-height: rem(10px) !default;
 $sage-loading-bar-width: rem(300px) !default;
+$sage-loading-bar-speed: 2s !default;
 
 $sage-loading-spinner-size: rem(48px) !default;
 $sage-loading-spinner-speed: 0.9s !default;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_loader.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_loader.scss
@@ -18,31 +18,36 @@
     background-position: center center;
     transition: opacity 0.25s ease-in-out;
     pointer-events: none;
+    opacity: 0;
   }
 
-  // visibility of the loader is toggled by setting data attribute "data-loading" to true.
-  &[data-loading*="true"] {
-    &::before {
-      opacity: 1;
-    }
+  // visibility of the loader is toggled by setting data attribute "data-loading" to "true".
+  &[data-loading*="true"]::before {
+    opacity: 1;
   }
 
-  &--bar {
-    &::before {
-      height: $sage-loading-bar-height;
-      width: 100%;
-      max-width: $sage-loading-bar-width;
-      background-color: $sage-loading-bar-bg-color;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 225.7 8' class='sage-svg-loader'%3E%3Cstyle%3E .loader-blob %7B animation: movingBlobs 2s linear infinite %7D @keyframes movingBlobs %7B 20%25 %7B transform: translateX(40%25) %7D 60%25 %7B transform: translateX(215%25) %7D 78%25 %7B opacity: 1; transform: translateX(250%25) %7D 79%25 %7B opacity: 0; transform: translateX(250%25) %7D 80%25 %7B opacity: 0; transform: none %7D 81%25 %7B opacity: 1; transform: none %7D %7D %3C/style%3E%3Cpath class='loader-blob' fill='%230072ef' d='M-187.3,0h53c2.2,0,4,1.8,4,4s-1.8,4-4,4h-53c-2.2,0-4-1.8-4-4C-191.3,1.8-189.5,0-187.3,0z'/%3E%3Cpath class='loader-blob' fill='%230072ef' d='M-234,0h26c2.2,0,4,1.8,4,4s-1.8,4-4,4h-26c-2.2,0-4-1.8-4-4S-236.2,0-234,0z'/%3E%3Cpath class='loader-blob' fill='%230072ef' d='M-113.5,0H-4c2.2,0,4,1.8,4,4s-1.8,4-4,4h-109.5c-2.2,0-4-1.8-4-4S-115.7,0-113.5,0z'/%3E%3C/svg%3E");
-      border-radius: $sage-loading-bar-height;
+  @media (prefers-reduced-motion: reduce) {
+    &[data-loading*="true"]::before {
+      opacity: 0 !important; /* stylelint-disable-line declaration-no-important */
     }
   }
+}
 
-  &--spinner {
-    &::before {
-      height: $sage-loading-spinner-size;
-      width: $sage-loading-spinner-size;
-      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg' class='sage-svg-spinner'%3E%3Cstyle%3E .spinner-circle %7B transform-origin: center; animation: rotateSpinr #{$sage-loading-spinner-speed} linear infinite %7D @keyframes rotateSpinr %7B 100%25 %7B transform: rotate(360deg) %7D %7D %3C/style%3E%3Cpath class='spinner-circle' d='M14.3434 45.9716C9.30821 43.7586 5.03752 39.8062 2.64097 34.8206C2.09869 33.8176 2.5302 32.5873 3.49292 32.1365C4.49588 31.5943 5.72624 32.0258 6.17698 32.9885C8.26566 37.1834 11.7416 40.4588 15.9528 42.3096C26.0231 46.7355 37.8837 42.1174 42.3096 32.0471C46.7355 21.9767 42.1173 10.1162 32.047 5.69029C21.9767 1.26438 10.1161 5.88253 5.69022 15.9529C4.52339 18.6078 3.98632 21.321 3.94723 24.1438C4.00262 25.2605 3.06205 26.1579 1.98562 26.1217C0.868963 26.1771 -0.0284391 25.2365 0.00772265 24.1601C-0.0266529 20.7588 0.660281 17.4561 2.02829 14.3434C7.33938 2.25905 21.572 -3.28274 33.6564 2.02835C45.7408 7.33944 51.2826 21.5721 45.9715 33.6565C40.6604 45.7409 26.4278 51.2827 14.3434 45.9716Z' fill='%230072ef'/%3E%3C/svg%3E");
-    }
+.sage-loading--bar {
+  &::before {
+    height: $sage-loading-bar-height;
+    width: 100%;
+    max-width: $sage-loading-bar-width;
+    background-color: $sage-loading-bar-bg-color;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 225.7 8' class='sage-svg-loader'%3E%3Cstyle%3E .loader-blob %7B animation: movingBlobs #{$sage-loading-bar-speed} linear infinite %7D @keyframes movingBlobs %7B 20%25 %7B transform: translateX(40%25) %7D 60%25 %7B transform: translateX(215%25) %7D 78%25 %7B opacity: 1; transform: translateX(250%25) %7D 79%25 %7B opacity: 0; transform: translateX(250%25) %7D 80%25 %7B opacity: 0; transform: none %7D 81%25 %7B opacity: 1; transform: none %7D %7D %3C/style%3E%3Cpath class='loader-blob' fill='%230072ef' d='M-187.3,0h53c2.2,0,4,1.8,4,4s-1.8,4-4,4h-53c-2.2,0-4-1.8-4-4C-191.3,1.8-189.5,0-187.3,0z'/%3E%3Cpath class='loader-blob' fill='%230072ef' d='M-234,0h26c2.2,0,4,1.8,4,4s-1.8,4-4,4h-26c-2.2,0-4-1.8-4-4S-236.2,0-234,0z'/%3E%3Cpath class='loader-blob' fill='%230072ef' d='M-113.5,0H-4c2.2,0,4,1.8,4,4s-1.8,4-4,4h-109.5c-2.2,0-4-1.8-4-4S-115.7,0-113.5,0z'/%3E%3C/svg%3E");
+    border-radius: $sage-loading-bar-height;
+  }
+}
+
+.sage-loading--spinner {
+  &::before {
+    height: $sage-loading-spinner-size;
+    width: $sage-loading-spinner-size;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg' class='sage-svg-spinner'%3E%3Cstyle%3E .spinner-circle %7B transform-origin: center; animation: rotateSpinr #{$sage-loading-spinner-speed} linear infinite %7D @keyframes rotateSpinr %7B 100%25 %7B transform: rotate(360deg) %7D %7D %3C/style%3E%3Cpath class='spinner-circle' d='M14.3434 45.9716C9.30821 43.7586 5.03752 39.8062 2.64097 34.8206C2.09869 33.8176 2.5302 32.5873 3.49292 32.1365C4.49588 31.5943 5.72624 32.0258 6.17698 32.9885C8.26566 37.1834 11.7416 40.4588 15.9528 42.3096C26.0231 46.7355 37.8837 42.1174 42.3096 32.0471C46.7355 21.9767 42.1173 10.1162 32.047 5.69029C21.9767 1.26438 10.1161 5.88253 5.69022 15.9529C4.52339 18.6078 3.98632 21.321 3.94723 24.1438C4.00262 25.2605 3.06205 26.1579 1.98562 26.1217C0.868963 26.1771 -0.0284391 25.2365 0.00772265 24.1601C-0.0266529 20.7588 0.660281 17.4561 2.02829 14.3434C7.33938 2.25905 21.572 -3.28274 33.6564 2.02835C45.7408 7.33944 51.2826 21.5721 45.9715 33.6565C40.6604 45.7409 26.4278 51.2827 14.3434 45.9716Z' fill='%230072ef'/%3E%3C/svg%3E");
   }
 }

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -15,7 +15,7 @@ module Sage
         # Sage Generated Elements
         {
           title: "live_stream_wrapper",
-          description: "A simple wrapper element for the Live stream application", 
+          description: "A simple wrapper element for the Live stream application",
           scss_design:  "done",
           scss_dev:     "done",
           scss_doc:     "done",
@@ -94,15 +94,15 @@ module Sage
         {
           title: "loader",
           description: "Stylized loading animations for use with elements or objects",
-          scss_design:  "todo",
-          scss_dev:     "todo",
-          scss_doc:     "todo",
-          rails_design: "todo",
-          rails_dev:    "todo",
-          rails_doc:    "todo",
-          react_design: "todo",
-          react_dev:    "todo",
-          react_doc:    "todo"
+          scss_design:  "done",
+          scss_dev:     "done",
+          scss_doc:     "done",
+          rails_design: "no",
+          rails_dev:    "no",
+          rails_doc:    "no",
+          react_design: "no",
+          react_dev:    "no",
+          react_doc:    "no"
         },
         {
           title: "checkbox",

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -28,7 +28,7 @@ module Sage
         },
         {
           title: "description",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", 
+          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
           scss_design:  "done",
           scss_dev:     "done",
           scss_doc:     "todo",
@@ -41,7 +41,7 @@ module Sage
         },
         {
           title: "label",
-          description: "Labels show concise metadata or indicate status in a compact format.", 
+          description: "Labels show concise metadata or indicate status in a compact format.",
           scss_design:  "done",
           scss_dev:     "done",
           scss_doc:     "done",
@@ -93,7 +93,7 @@ module Sage
         },
         {
           title: "loader",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+          description: "Stylized loading animations for use with elements or objects",
           scss_design:  "todo",
           scss_dev:     "todo",
           scss_doc:     "todo",
@@ -106,7 +106,7 @@ module Sage
         },
         {
           title: "checkbox",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+          description: "Base checkbox styling",
           scss_design:  "done",
           scss_dev:     "done",
           scss_doc:     "done",

--- a/app/views/sage/examples/elements/loader/_preview.html.erb
+++ b/app/views/sage/examples/elements/loader/_preview.html.erb
@@ -1,4 +1,8 @@
 <div class="sage-row">
-  <div class="sage-col--md-6 example__block--lg sage-loading sage-loading--bar" data-loading="true"></div>
-  <div class="sage-col--md-6 example__block--lg sage-loading sage-loading--spinner" data-loading="true"></div>
+  <div class="sage-col--md-6 example__block--lg">
+    <div class="sage-loading sage-loading--bar" data-loading="true"></div>
+  </div>
+  <div class="sage-col--md-6 example__block--lg">
+    <div class="sage-loading sage-loading--spinner" data-loading="true"></div>
+  </div>
 </div>

--- a/app/views/sage/examples/elements/loader/_preview.html.erb
+++ b/app/views/sage/examples/elements/loader/_preview.html.erb
@@ -1,4 +1,4 @@
 <div class="sage-row">
-  <div class="sage-col--md-6 sage-loading sage-loading--bar" data-loading="true"></div>
-  <div class="sage-col--md-6 sage-loading sage-loading--spinner" data-loading="true"></div>
+  <div class="sage-col--md-6 example__block--lg sage-loading sage-loading--bar" data-loading="true"></div>
+  <div class="sage-col--md-6 example__block--lg sage-loading sage-loading--spinner" data-loading="true"></div>
 </div>

--- a/app/views/sage/examples/elements/loader/_props.html.erb
+++ b/app/views/sage/examples/elements/loader/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td>Prop Name</td>
-  <td>The description of the property goes here.</td>
-  <td>String</td>
-  <td>Default</td>
+  <td>data-loading</td>
+  <td>Determines visibility. Loader will not display/animate unless this value is set to "true"</td>
+  <td>Boolean</td>
+  <td>false</td>
 </tr>

--- a/app/views/sage/examples/elements/loader/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/loader/_rules_do.html.erb
@@ -1,3 +1,4 @@
 <ul>
-  <li>Rules for what you should do with this element go here.</li>
+  <li>Toggle the loader's active state using the "data-loading" attribute</li>
+  <li>Take note that by design, a "reduced motion" <a href="https://web.dev/prefers-reduced-motion/" rel="nofollow">OS-level setting</a> will prevent either loader from appearing</li>
 </ul>

--- a/app/views/sage/examples/elements/loader/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/loader/_rules_dont.html.erb
@@ -1,3 +1,3 @@
 <ul>
-  <li>Rules for what you should not do with this element go here.</li>
+  <li>Loader animations can be easily overused. Consider setting a loader or spinner on the parent container, instead of on multiple elements.</li>
 </ul>


### PR DESCRIPTION
## Description
- Fix for loading bar and spinner containers collapsing in mobile/small viewports.
- Disabled animation for reduced motion user settings
- Updated documentation for loader use
- Flattened nesting structure in `_example.scss` and `_loader.scss`

### Screenshots
|  Before   |  After  |
|--------|--------|
|![ios-loading](https://user-images.githubusercontent.com/816579/77708963-d058c200-6f86-11ea-8587-972d1f856225.png)|<img alt="after" src="https://user-images.githubusercontent.com/816579/78592259-abbbe000-77f9-11ea-8072-1926cb9f19b7.png">|

