### PR TITLE
Bugfix to option menu

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_option_menu.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_option_menu.scss
@@ -13,6 +13,10 @@ $-live-option-menu-width: rem(224px);
 .sage-live-option-menu-anchor {
   position: relative;
 
+  &:focus {
+    outline: none;
+  }
+
   // Fill the window to create active space to click off of to turn off menu
   &[aria-expanded="true"]::before {
     content: "";
@@ -48,7 +52,7 @@ $-live-option-menu-width: rem(224px);
 .sage-live-option-menu {
   position: absolute;
   top: $-live-option-menu-offset-block;
-  z-index: sage-z-index(modal);
+  z-index: sage-z-index(default, -1);
   transform: rotate3d(1, 0, 0, -90deg);
   transform-origin: top center;
   min-width: min-content;
@@ -57,7 +61,7 @@ $-live-option-menu-width: rem(224px);
   background-color: sage-color(white);
   box-shadow: sage-shadow(md);
   transition: $sage-transition;
-  transition-property: transform;
+  transition-property: transform, z-index;
 
   &:not(.sage-live-option-menu--anchored-left) {
     right: $-live-option-menu-offset-inline;
@@ -65,6 +69,7 @@ $-live-option-menu-width: rem(224px);
 
   [aria-expanded="true"] & {
     transform: rotate3d(0, 0, 0, 0);
+    z-index: sage-z-index(modal);
   }
 }
 

--- a/app/views/sage/examples/objects/live_option_menu/_preview.html.erb
+++ b/app/views/sage/examples/objects/live_option_menu/_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-live-option-menu-anchor" aria-has-popup="true" aria-expanded="false">
+<div class="sage-live-option-menu-anchor" aria-has-popup="true" aria-expanded="false" tabindex="0">
   <ul class="sage-live-option-menu" role="menu" aria-label="Participant options">
     <li role="none" class="sage-live-option-menu__item">
       <button role="menuitem" class="sage-live-option-menu__command">

--- a/app/views/sage/examples/objects/live_option_menu/_preview.html.erb
+++ b/app/views/sage/examples/objects/live_option_menu/_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-live-option-menu-anchor" aria-has-popup="true" aria-expanded="false" tabindex="0">
+<div class="sage-live-option-menu-anchor" aria-has-popup="true" aria-expanded="false" tabindex="0" role="button">
   <ul class="sage-live-option-menu" role="menu" aria-label="Participant options">
     <li role="none" class="sage-live-option-menu__item">
       <button role="menuitem" class="sage-live-option-menu__command">


### PR DESCRIPTION
Closes #134 

- [x] Removes focus ring from interactive div that has additional accessibility attributes.
- [x] Further hides the non-active menu