### PR TITLE
Quick Fix: Duplicate max-widths for containers.

### DIFF
--- a/app/assets/stylesheets/sage/system/layout/_container.scss
+++ b/app/assets/stylesheets/sage/system/layout/_container.scss
@@ -1,11 +1,11 @@
 @mixin sage-container-default {
-  max-width: sage-container(md);
   margin: 0 auto;
   padding: 0 sage-spacing(md);
 }
 
 .sage-container {
   @include sage-container-default();
+  max-width: sage-container(md);
 }
 
 .sage-container--xs {
@@ -27,4 +27,3 @@
   @include sage-container-default();
   max-width: sage-container(fluid);
 }
-


### PR DESCRIPTION
Update` _container.scss` to remove duplicate max-widths from being applied to the different `.sage-container` sizes.

![Screen Shot 2020-04-09 at 11 40 51 AM](https://user-images.githubusercontent.com/1175111/78931289-8ed21780-7a5a-11ea-96cb-7a5dcaab29ae.png)
