### PR TITLE
[mobile] Tables overflowing container

### DIFF
--- a/app/assets/stylesheets/sage/docs/_status_key.scss
+++ b/app/assets/stylesheets/sage/docs/_status_key.scss
@@ -18,6 +18,7 @@
   }
 
   &__icon {
+    display: inline-block;
     flex: 0 0 $status-key-icon-size;
     width: $status-key-icon-size;
     height: $status-key-icon-size;

--- a/app/assets/stylesheets/sage/docs/_status_key.scss
+++ b/app/assets/stylesheets/sage/docs/_status_key.scss
@@ -7,13 +7,13 @@
 .status-key {
   display: flex;
   align-items: center;
-
-  + .status-key {
-    margin-left: sage-spacing();
-  }
+  flex-wrap: wrap;
+  flex-grow: 1;
+  margin-right: sage-spacing(sm);
 
   &__wrapper {
     display: flex;
+    flex-wrap: wrap;
     margin-bottom: sage-spacing();
   }
 
@@ -53,5 +53,13 @@
     font-size: sage-font-size(sm);
     font-weight: sage-font-weight(semibold);
     color: sage-color(charcoal, 200);
+  }
+
+  @media screen and (min-width: sage-breakpoint(lg-min)) {
+    flex-grow: 0;
+  }
+
+  @media screen and (min-width: sage-breakpoint(xl-min)) {
+    margin-right: sage-spacing(lg);
   }
 }

--- a/app/assets/stylesheets/sage/docs/_status_table.scss
+++ b/app/assets/stylesheets/sage/docs/_status_table.scss
@@ -4,7 +4,7 @@
   For Sage documentation use
 ================================================== */
 
-$-status-table-border: 2px solid sage-color(grey);
+$-status-table-border: rem(2px) solid sage-color(grey);
 $-status-table-cell-padding: sage-spacing(xs) sage-spacing(sm);
 $-status-table-heading-font-size: sage-font-size(sm);
 $-status-table-heading-padding: sage-spacing(xs) sage-spacing(sm);

--- a/app/assets/stylesheets/sage/docs/_status_table.scss
+++ b/app/assets/stylesheets/sage/docs/_status_table.scss
@@ -17,6 +17,10 @@ $-status-table-heading-padding: sage-spacing(xs) sage-spacing(sm);
   }
 
   tbody {
+    tr {
+      border-bottom: 0;
+    }
+
     tr:nth-child(3n) {
       border-bottom: $-status-table-border;
     }

--- a/app/assets/stylesheets/sage/docs/_status_table.scss
+++ b/app/assets/stylesheets/sage/docs/_status_table.scss
@@ -4,36 +4,60 @@
   For Sage documentation use
 ================================================== */
 
-.status-table {
+$-status-table-border: 2px solid sage-color(grey);
+$-status-table-cell-padding: sage-spacing(xs) sage-spacing(sm);
+$-status-table-heading-font-size: sage-font-size(sm);
+$-status-table-heading-padding: sage-spacing(xs) sage-spacing(sm);
+
+.sage-table--status {
   width: 100%;
 
-  th {
-    padding: sage-spacing(xs) sage-spacing(sm);
-    font-size: sage-font-size(sm);
-    border-bottom: 2px solid sage-color(grey);
+  thead {
+    font-size: $-status-table-heading-font-size;
+  }
 
-    &:nth-child(1) {
-      padding-left: 0;
+  tbody {
+    tr:nth-child(3n) {
+      border-bottom: $-status-table-border;
     }
-    &:nth-child(5) {
+
+    tr:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  th {
+    padding: $-status-table-heading-padding;
+    text-align: center;
+    border-bottom: $-status-table-border;
+
+    &:first-child {
+      padding-left: 0;
+      text-align: left;
+      text-align: inline-start;
+    }
+
+    &:nth-child(2) {
+      text-align: left;
+      text-align: inline-start;
+    }
+
+    &:last-child {
       padding-right: 0;
     }
   }
 
   td {
-    padding: sage-spacing(xs) sage-spacing(sm);
-    vertical-align: top;
+    padding: $-status-table-cell-padding;
+    vertical-align: middle;
 
-    &:nth-child(1) {
-      // TODO: refactor fixed width block
-      width: 10000px;
+    &:first-child {
       padding-left: 0;
+      vertical-align: top;
       font-weight: sage-font-weight(semibold);
     }
 
     &:nth-child(2) {
-      // TODO: refactor fixed width block
-      width: 4000px;
       border-bottom: sage-border();
     }
 
@@ -44,18 +68,8 @@
       border-bottom: sage-border();
     }
 
-    &:nth-child(5) {
-      padding-right: 0;
-    }
-  }
-
-  tr {
-    &:nth-child(3n + 1) {
-      border-bottom: 2px solid sage-color(grey);
-    }
-
     &:last-child {
-      border-bottom: 0;
+      padding-right: 0;
     }
   }
 }

--- a/app/assets/stylesheets/sage/docs/_status_table.scss
+++ b/app/assets/stylesheets/sage/docs/_status_table.scss
@@ -6,6 +6,7 @@
 
 $-status-table-border: rem(2px) solid sage-color(grey);
 $-status-table-cell-padding: sage-spacing(xs) sage-spacing(sm);
+$-status-table-heading-color: sage-color(charcoal, 100);
 $-status-table-heading-font-size: sage-font-size(sm);
 $-status-table-heading-padding: sage-spacing(xs) sage-spacing(sm);
 
@@ -13,6 +14,7 @@ $-status-table-heading-padding: sage-spacing(xs) sage-spacing(sm);
   width: 100%;
 
   thead {
+    color: $-status-table-heading-color;
     font-size: $-status-table-heading-font-size;
   }
 

--- a/app/assets/stylesheets/sage/docs/_table.scss
+++ b/app/assets/stylesheets/sage/docs/_table.scss
@@ -1,0 +1,11 @@
+/* ==================================================
+  ** _table.scss
+
+  For Sage documentation use
+================================================== */
+
+.sage-table {
+  .example__preview & {
+    margin-bottom: sage-spacing();
+  }
+}

--- a/app/assets/stylesheets/sage/sage_docs.css.scss
+++ b/app/assets/stylesheets/sage/sage_docs.css.scss
@@ -33,4 +33,5 @@
 @import "docs/sidebar";
 @import "docs/status_key";
 @import "docs/status_table";
+@import "docs/table";
 @import "docs/theme";

--- a/app/assets/stylesheets/sage/sage_system.css.scss
+++ b/app/assets/stylesheets/sage/sage_system.css.scss
@@ -56,6 +56,7 @@
 @import "system/patterns/elements/checkbox";
 @import "system/patterns/elements/radio";
 @import "system/patterns/elements/switch";
+@import "system/patterns/elements/table";
 @import "system/patterns/elements/loader";
 @import "system/patterns/elements/overlay";
 

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -247,13 +247,19 @@ $sage-switch-focus-outline-color: sage-color(primary) !default;
 // ==================================================
 // TABLES
 // ==================================================
+
 // Borders and sizing
 $sage-table-border: rem(1px) solid sage-color(grey);
 $sage-table-cell-padding: sage-spacing(sm) sage-spacing(xs);
 $sage-table-max-width: none;
 
-$sage-table-heading-text-color: sage-color(grey, 400);
-$sage-table-cell-text-color: sage-color(charcoal);
+// Text
+$sage-table-caption-font-size: "%t-sage-body-small";
+$sage-table-caption-alignment: center;
+$sage-table-heading-font-color: sage-color(grey, 400);
+$sage-table-heading-font-size: "%t-sage-heading-6";
+$sage-table-cell-font-color: sage-color(charcoal);
+$sage-table-cell-font-size: "%t-sage-body-small";
 
 // Overflow gradient
 $sage-table-overflow-indicator-width: sage-spacing(md);

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -245,6 +245,26 @@ $sage-switch-focus-outline-color: sage-color(primary) !default;
 
 
 // ==================================================
+// TABLES
+// ==================================================
+// Borders and sizing
+$sage-table-border: rem(1px) solid sage-color(grey);
+$sage-table-cell-padding: sage-spacing(sm) sage-spacing(xs);
+$sage-table-max-width: none;
+
+$sage-table-heading-text-color: sage-color(grey, 400);
+$sage-table-cell-text-color: sage-color(charcoal);
+
+// Overflow gradient
+$sage-table-overflow-indicator-width: sage-spacing(md);
+$sage-table-overflow-indicator-color-start: rgba(255, 255, 255, 0);
+$sage-table-overflow-indicator-color-end: sage-color(white);
+$sage-table-overflow-indicator-opacity: 0.95;
+$sage-table-overflow-indicator-gradient: linear-gradient(90deg, $sage-table-overflow-indicator-color-start 0%, rgba($sage-table-overflow-indicator-color-end, $sage-table-overflow-indicator-opacity) 100%);
+
+
+
+// ==================================================
 // LOADERS AND SPINNERS
 // ==================================================
 

--- a/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
@@ -7,21 +7,25 @@
 .sage-table {
   --table-cell-padding: #{sage-spacing(sm)} #{sage-spacing(xs)};
 
-  table-layout: initial;
   width: 100%;
   max-width: $sage-table-max-width;
 
+  caption {
+    @extend #{$sage-table-caption-font-size};
+    text-align: $sage-table-caption-alignment;
+  }
+
   thead {
-    color: $sage-table-heading-text-color;
+    color: $sage-table-heading-font-color;
     border-bottom: $sage-table-border;
 
     td {
-      @extend %t-sage-heading-6;
+      @extend #{$sage-table-heading-font-size};
     }
   }
 
   tbody {
-    color: $sage-table-cell-text-color;
+    color: $sage-table-cell-font-color;
 
     tr {
       border-bottom: $sage-table-border;
@@ -29,7 +33,7 @@
   }
 
   td {
-    @extend %t-sage-body-small;
+    @extend #{$sage-table-cell-font-size};
 
     padding: $sage-table-cell-padding;
     padding: var(--table-cell-padding);
@@ -58,9 +62,17 @@
   }
 }
 
-// Allows overflow scrolling when content exceeds container width
-.sage-table--responsive {
+// Wrapper div required for responsive tables
+.sage-table-wrapper {
   position: relative;
+}
+
+// Allows overflow scrolling when content exceeds container width
+.sage-table-wrapper--overflow {
+  overflow: hidden;
+  overflow-x: auto;
+  padding-right: ($sage-table-overflow-indicator-width / 2);
+  -webkit-overflow-scrolling: touch;
 
   &::after {
     content: "";
@@ -71,16 +83,6 @@
     height: 100%;
     width: $sage-table-overflow-indicator-width;
     background: $sage-table-overflow-indicator-gradient;
-  }
-}
-
-// Additional wrapper div required for responsive tables
-.sage-table__wrapper {
-  .sage-table--responsive & {
-    overflow: hidden;
-    overflow-x: auto;
-    padding-right: ($sage-table-overflow-indicator-width / 2);
-    -webkit-overflow-scrolling: touch;
   }
 }
 

--- a/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
@@ -1,0 +1,37 @@
+/* ==================================================
+  ** sage_table
+  type: element
+
+================================================== */
+
+$-table-overflow-indicator-width: 1rem;
+$-table-overflow-indicator-color: sage-color(white);
+$-table-overflow-indicator-opacity: 0.9;
+
+.sage-table {
+  table-layout: initial;
+}
+
+.sage-table__wrapper {
+  .sage-table--responsive & {
+    overflow: hidden;
+    overflow-x: auto;
+    padding-right: ($-table-overflow-indicator-width / 2);
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+.sage-table--responsive {
+  position: relative;
+
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: $-table-overflow-indicator-width;
+    background: linear-gradient(90deg, transparent 0%, rgba($-table-overflow-indicator-color, $-table-overflow-indicator-opacity) 100%);
+  }
+}

--- a/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
@@ -4,23 +4,66 @@
 
 ================================================== */
 
+$-table-border: rem(1px) solid sage-color(grey);
+$-table-heading-color: sage-color(grey, 400);
+$-table-cell-padding: sage-spacing(xs) sage-spacing(sm);
 $-table-overflow-indicator-width: 1rem;
 $-table-overflow-indicator-color: sage-color(white);
 $-table-overflow-indicator-opacity: 0.9;
 
-.sage-table {
-  table-layout: initial;
+:root {
+  --table-cell-padding: #{sage-spacing(xs)} #{sage-spacing(sm)};
 }
 
-.sage-table__wrapper {
-  .sage-table--responsive & {
-    overflow: hidden;
-    overflow-x: auto;
-    padding-right: ($-table-overflow-indicator-width / 2);
-    -webkit-overflow-scrolling: touch;
+.sage-table {
+  table-layout: initial;
+  width: 100%;
+
+  thead {
+    color: $-table-heading-color;
+    border-bottom: $-table-border;
+
+    td {
+      @extend %t-sage-heading-6;
+    }
+  }
+
+  tbody {
+    tr {
+      border-bottom: $-table-border;
+    }
+  }
+
+  td {
+    @extend %t-sage-body-small;
+
+    padding: $-table-cell-padding;
+    padding: var(--table-cell-padding);
+    line-height: sage-line-height(md);
+
+    &:first-child {
+      padding-left: 0;
+    }
+
+    &:last-child {
+      padding-right: 0;
+    }
+  }
+
+  @media screen and (min-width: sage-breakpoint(md-min)) {
+    --table-cell-padding: #{sage-spacing(sm)} #{sage-spacing(md)};
   }
 }
 
+.sage-table--striped {
+  tbody {
+    tr:nth-child(odd) {
+      background-color: sage-color(grey, 100);
+    }
+  }
+}
+
+// Allows overflow scrolling when content exceeds container width
 .sage-table--responsive {
   position: relative;
 
@@ -35,3 +78,14 @@ $-table-overflow-indicator-opacity: 0.9;
     background: linear-gradient(90deg, transparent 0%, rgba($-table-overflow-indicator-color, $-table-overflow-indicator-opacity) 100%);
   }
 }
+
+// Additional wrapper div required for responsive tables
+.sage-table__wrapper {
+  .sage-table--responsive & {
+    overflow: hidden;
+    overflow-x: auto;
+    padding-right: ($-table-overflow-indicator-width / 2);
+    -webkit-overflow-scrolling: touch;
+  }
+}
+

--- a/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
@@ -4,24 +4,16 @@
 
 ================================================== */
 
-$-table-border: rem(1px) solid sage-color(grey);
-$-table-heading-color: sage-color(grey, 400);
-$-table-cell-padding: sage-spacing(xs) sage-spacing(sm);
-$-table-overflow-indicator-width: 1rem;
-$-table-overflow-indicator-color: sage-color(white);
-$-table-overflow-indicator-opacity: 0.9;
-
-:root {
-  --table-cell-padding: #{sage-spacing(xs)} #{sage-spacing(sm)};
-}
-
 .sage-table {
+  --table-cell-padding: #{sage-spacing(sm)} #{sage-spacing(xs)};
+
   table-layout: initial;
   width: 100%;
+  max-width: $sage-table-max-width;
 
   thead {
-    color: $-table-heading-color;
-    border-bottom: $-table-border;
+    color: $sage-table-heading-text-color;
+    border-bottom: $sage-table-border;
 
     td {
       @extend %t-sage-heading-6;
@@ -29,16 +21,19 @@ $-table-overflow-indicator-opacity: 0.9;
   }
 
   tbody {
+    color: $sage-table-cell-text-color;
+
     tr {
-      border-bottom: $-table-border;
+      border-bottom: $sage-table-border;
     }
   }
 
   td {
     @extend %t-sage-body-small;
 
-    padding: $-table-cell-padding;
+    padding: $sage-table-cell-padding;
     padding: var(--table-cell-padding);
+    color: inherit;
     line-height: sage-line-height(md);
 
     &:first-child {
@@ -51,7 +46,7 @@ $-table-overflow-indicator-opacity: 0.9;
   }
 
   @media screen and (min-width: sage-breakpoint(md-min)) {
-    --table-cell-padding: #{sage-spacing(sm)} #{sage-spacing(md)};
+    --table-cell-padding: #{sage-spacing(md)} #{sage-spacing(sm)};
   }
 }
 
@@ -74,8 +69,8 @@ $-table-overflow-indicator-opacity: 0.9;
     top: 0;
     right: 0;
     height: 100%;
-    width: $-table-overflow-indicator-width;
-    background: linear-gradient(90deg, transparent 0%, rgba($-table-overflow-indicator-color, $-table-overflow-indicator-opacity) 100%);
+    width: $sage-table-overflow-indicator-width;
+    background: $sage-table-overflow-indicator-gradient;
   }
 }
 
@@ -84,7 +79,7 @@ $-table-overflow-indicator-opacity: 0.9;
   .sage-table--responsive & {
     overflow: hidden;
     overflow-x: auto;
-    padding-right: ($-table-overflow-indicator-width / 2);
+    padding-right: ($sage-table-overflow-indicator-width / 2);
     -webkit-overflow-scrolling: touch;
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
@@ -68,7 +68,7 @@
 }
 
 // Allows overflow scrolling when content exceeds container width
-.sage-table-wrapper--overflow {
+.sage-table-wrapper__overflow {
   overflow: hidden;
   overflow-x: auto;
   padding-right: ($sage-table-overflow-indicator-width / 2);

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -182,6 +182,19 @@ module Sage
           react_dev:    "no",
           react_doc:    "no"
         },
+        {
+          title: "table",
+          description: "Basic table element",
+          scss_design:  "done",
+          scss_dev:     "done",
+          scss_doc:     "done",
+          rails_design: "no",
+          rails_dev:    "no",
+          rails_doc:    "no",
+          react_design: "no",
+          react_dev:    "no",
+          react_doc:    "no"
+        }
       ]
     end
 

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -185,15 +185,15 @@ module Sage
         {
           title: "table",
           description: "Basic table element",
-          scss_design:  "done",
-          scss_dev:     "done",
-          scss_doc:     "done",
-          rails_design: "no",
-          rails_dev:    "no",
-          rails_doc:    "no",
-          react_design: "no",
-          react_dev:    "no",
-          react_doc:    "no"
+          scss_design:  "doing",
+          scss_dev:     "doing",
+          scss_doc:     "doing",
+          rails_design: "todo",
+          rails_dev:    "todo",
+          rails_doc:    "todo",
+          react_design: "todo",
+          react_dev:    "todo",
+          react_doc:    "todo"
         }
       ]
     end

--- a/app/views/sage/examples/elements/table/_preview.html.erb
+++ b/app/views/sage/examples/elements/table/_preview.html.erb
@@ -1,1 +1,62 @@
-<table class="sage-table"></table>
+<h3 class="t-sage-heading-6">Default table</h3>
+
+<div class="sage-table--responsive">
+  <div class="sage-table__wrapper">
+    <table class="sage-table">
+      <thead>
+        <tr>
+          <td>Cras Porta</td>
+          <td>Dapibus Ridiculus</td>
+          <td>Purus</td>
+          <td>Mollis Ridiculus</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Venenatis Condimentum</td>
+          <td>Ridiculus</td>
+          <td>Sem Elit</td>
+          <td>Nibh Aenean</td>
+        </tr>
+        <tr>
+          <td>Sollicitudin Ridiculus</td>
+          <td>Cras Malesuada</td>
+          <td>Commodo</td>
+          <td>Pellentesque Fringilla</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<h3 class="t-sage-heading-6">Table with row striping</h3>
+<div class="sage-table--responsive">
+  <div class="sage-table__wrapper">
+    <table class="sage-table sage-table--striped">
+      <thead>
+        <tr>
+          <td>Consectetur</td>
+          <td>Dapibus Ridiculus</td>
+          <td>Ullamcorper</td>
+          <td>Porta</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Nullam Porta</td>
+          <td>Adipiscing Ligula</td>
+          <td>Euismod Etiam</td>
+          <td>Malesuada</td>
+        </tr>
+        <tr>
+          <td>Sollicitudin Ridiculus</td>
+          <td>Cras Malesuada</td>
+          <td>Commodo</td>
+          <td>Nibh Aenean</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+

--- a/app/views/sage/examples/elements/table/_preview.html.erb
+++ b/app/views/sage/examples/elements/table/_preview.html.erb
@@ -1,7 +1,8 @@
 <h3 class="t-sage-heading-6">Responsive table</h3>
-<div class="sage-table--responsive">
-  <div class="sage-table__wrapper">
+<div class="sage-table-wrapper">
+  <div class="sage-table-wrapper--overflow">
     <table class="sage-table">
+      <caption>Responsive table requires two parent containers</caption>
       <thead>
         <tr>
           <td>Cras Porta</td>
@@ -46,8 +47,8 @@
 </div>
 
 <h3 class="t-sage-heading-6">Table with row striping</h3>
-<div class="sage-table--responsive">
-  <div class="sage-table__wrapper">
+<div class="sage-table-wrapper">
+  <div class="sage-table-wrapper--overflow">
     <table class="sage-table sage-table--striped">
       <thead>
         <tr>

--- a/app/views/sage/examples/elements/table/_preview.html.erb
+++ b/app/views/sage/examples/elements/table/_preview.html.erb
@@ -1,5 +1,4 @@
-<h3 class="t-sage-heading-6">Default table</h3>
-
+<h3 class="t-sage-heading-6">Responsive table</h3>
 <div class="sage-table--responsive">
   <div class="sage-table__wrapper">
     <table class="sage-table">
@@ -8,7 +7,8 @@
           <td>Cras Porta</td>
           <td>Dapibus Ridiculus</td>
           <td>Purus</td>
-          <td>Mollis Ridiculus</td>
+          <td>Mollis</td>
+          <td>Ridiculus</td>
         </tr>
       </thead>
       <tbody>
@@ -17,12 +17,28 @@
           <td>Ridiculus</td>
           <td>Sem Elit</td>
           <td>Nibh Aenean</td>
+          <td>Sem Elit</td>
         </tr>
         <tr>
-          <td>Sollicitudin Ridiculus</td>
+          <td>Nullam Porta</td>
+          <td>Adipiscing Ligula</td>
+          <td>Euismod Etiam</td>
+          <td>Malesuada</td>
+          <td>Etiam</td>
+        </tr>
+        <tr>
+          <td>Ridiculus</td>
           <td>Cras Malesuada</td>
           <td>Commodo</td>
-          <td>Pellentesque Fringilla</td>
+          <td>Cursus Pharetra</td>
+          <td>Fringilla</td>
+        </tr>
+        <tr>
+          <td>Pharetra Mattis</td>
+          <td>Magna</td>
+          <td>Elit Inceptos</td>
+          <td>Cursus Pharetra</td>
+          <td>Dolor Fringilla</td>
         </tr>
       </tbody>
     </table>
@@ -54,9 +70,20 @@
           <td>Commodo</td>
           <td>Nibh Aenean</td>
         </tr>
+        <tr>
+          <td>Venenatis Condimentum</td>
+          <td>Ridiculus</td>
+          <td>Sem Elit</td>
+          <td>Quam Dapibus</td>
+        </tr>
+        <tr>
+          <td>Consectetur</td>
+          <td>Dapibus Ridiculus</td>
+          <td>Ullamcorper</td>
+          <td>Porta</td>
+        </tr>
       </tbody>
     </table>
   </div>
 </div>
-
 

--- a/app/views/sage/examples/elements/table/_preview.html.erb
+++ b/app/views/sage/examples/elements/table/_preview.html.erb
@@ -1,6 +1,6 @@
 <h3 class="t-sage-heading-6">Responsive table</h3>
 <div class="sage-table-wrapper">
-  <div class="sage-table-wrapper--overflow">
+  <div class="sage-table-wrapper__overflow">
     <table class="sage-table">
       <caption>Responsive table requires two parent containers</caption>
       <thead>
@@ -48,7 +48,7 @@
 
 <h3 class="t-sage-heading-6">Table with row striping</h3>
 <div class="sage-table-wrapper">
-  <div class="sage-table-wrapper--overflow">
+  <div class="sage-table-wrapper__overflow">
     <table class="sage-table sage-table--striped">
       <thead>
         <tr>

--- a/app/views/sage/examples/elements/table/_preview.html.erb
+++ b/app/views/sage/examples/elements/table/_preview.html.erb
@@ -1,0 +1,1 @@
+<table class="sage-table"></table>

--- a/app/views/sage/examples/elements/table/_props.html.erb
+++ b/app/views/sage/examples/elements/table/_props.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td>Prop Name</td>
+  <td>The description of the property goes here.</td>
+  <td>String</td>
+  <td>Default</td>
+</tr>

--- a/app/views/sage/examples/elements/table/_props.html.erb
+++ b/app/views/sage/examples/elements/table/_props.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td>.sage-table--striped</td>
-  <td>This class adds a background color to odd rows, making the content easier to read</td>
+  <td>Striped tables</td>
+  <td>Adding the class `.sage-table--striped` gives a background color to odd rows</td>
   <td>String</td>
   <td>null</td>
 </tr>
 <tr>
-  <td>.sage-table--responsive</td>
-  <td>Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: a parent with class ".sage-table--responsive", and a child with class ".sage-table__wrapper".</td>
+  <td>Responsive tables</td>
+  <td>Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: the parent with class `.sage-table-wrapper`, and a child with class `.sage-table-wrapper--responsive`</td>
   <td>String</td>
   <td>null</td>
 </tr>

--- a/app/views/sage/examples/elements/table/_props.html.erb
+++ b/app/views/sage/examples/elements/table/_props.html.erb
@@ -1,6 +1,12 @@
 <tr>
-  <td>Prop Name</td>
-  <td>The description of the property goes here.</td>
+  <td>.sage-table--striped</td>
+  <td>This class adds a background color to odd rows, making the content easier to read</td>
   <td>String</td>
-  <td>Default</td>
+  <td>null</td>
+</tr>
+<tr>
+  <td>.sage-table--responsive</td>
+  <td>Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: a parent with class ".sage-table--responsive", and a child with class ".sage-table__wrapper".</td>
+  <td>String</td>
+  <td>null</td>
 </tr>

--- a/app/views/sage/examples/elements/table/_props.html.erb
+++ b/app/views/sage/examples/elements/table/_props.html.erb
@@ -6,7 +6,7 @@
 </tr>
 <tr>
   <td>Responsive tables</td>
-  <td>Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: the parent with class `.sage-table-wrapper`, and a child with class `.sage-table-wrapper--responsive`</td>
+  <td>Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: the parent with class `.sage-table-wrapper`, and a child with class `.sage-table-wrapper__overflow`</td>
   <td>String</td>
   <td>null</td>
 </tr>

--- a/app/views/sage/examples/elements/table/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/table/_rules_do.html.erb
@@ -1,2 +1,3 @@
 <ul>
+  <li>Use the <code><caption></code> element to <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption" rel="nofollow">provide additional description to the table</a></li>
 </ul>

--- a/app/views/sage/examples/elements/table/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/table/_rules_do.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should do with this element go here.</li>
+</ul>

--- a/app/views/sage/examples/elements/table/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/table/_rules_do.html.erb
@@ -1,3 +1,2 @@
 <ul>
-  <li>Rules for what you should do with this element go here.</li>
 </ul>

--- a/app/views/sage/examples/elements/table/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/table/_rules_dont.html.erb
@@ -1,2 +1,3 @@
 <ul>
+  <li>Don't forget to add <strong>both</strong> wrappers for a responsive table.</li>
 </ul>

--- a/app/views/sage/examples/elements/table/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/table/_rules_dont.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should not do with this element go here.</li>
+</ul>

--- a/app/views/sage/examples/elements/table/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/table/_rules_dont.html.erb
@@ -1,3 +1,2 @@
 <ul>
-  <li>Rules for what you should not do with this element go here.</li>
 </ul>

--- a/app/views/sage/pages/status.html.erb
+++ b/app/views/sage/pages/status.html.erb
@@ -48,7 +48,7 @@
 <div class="sage-panel">
   <h2 class="t-sage-heading-2">Objects</h2>
   <div class="sage-table-wrapper">
-    <div class="sage-table-wrapper--overflow">
+    <div class="sage-table-wrapper__overflow">
       <table class="sage-table sage-table--status">
         <thead>
           <tr>

--- a/app/views/sage/pages/status.html.erb
+++ b/app/views/sage/pages/status.html.erb
@@ -26,31 +26,43 @@
 <% end %>
 <div class="sage-panel">
   <h2 class="t-sage-heading-2">Elements</h2>
-  <table class="status-table">
-    <tr>
-      <th>Element</th>
-      <th>Platforms</th>
-      <th>Design</th>
-      <th>Development</th>
-      <th>Documentation</th>
-    </tr>
-    <% sorted_sage_elements.each do |element| %>
-      <%= render "status_item", item: element %>
-    <% end %>
-  </table>
+  <div class="sage-table--responsive">
+    <div class="sage-table__wrapper">
+      <table class="sage-table sage-table--status">
+        <thead>
+          <tr>
+            <th>Element</th>
+            <th>Platforms</th>
+            <th>Design</th>
+            <th>Development</th>
+            <th>Documentation</th>
+          </tr>
+        </thead>
+        <% sorted_sage_elements.each do |element| %>
+          <%= render "status_item", item: element %>
+        <% end %>
+      </table>
+    </div>
+  </div>
 </div>
 <div class="sage-panel">
   <h2 class="t-sage-heading-2">Objects</h2>
-  <table class="status-table">
-    <tr>
-      <th>Object</th>
-      <th>Platforms</th>
-      <th>Design</th>
-      <th>Development</th>
-      <th>Documentation</th>
-    </tr>
-    <% sorted_sage_objects.each do |object| %>
-      <%= render "status_item", item: object %>
-    <% end %>
-  </table>
+  <div class="sage-table--responsive">
+    <div class="sage-table__wrapper">
+      <table class="sage-table sage-table--status">
+        <thead>
+          <tr>
+            <th>Object</th>
+            <th>Platforms</th>
+            <th>Design</th>
+            <th>Development</th>
+            <th>Documentation</th>
+          </tr>
+        </thead>
+        <% sorted_sage_objects.each do |object| %>
+          <%= render "status_item", item: object %>
+        <% end %>
+      </table>
+    </div>
+  </div>
 </div>

--- a/app/views/sage/pages/status.html.erb
+++ b/app/views/sage/pages/status.html.erb
@@ -26,8 +26,8 @@
 <% end %>
 <div class="sage-panel">
   <h2 class="t-sage-heading-2">Elements</h2>
-  <div class="sage-table--responsive">
-    <div class="sage-table__wrapper">
+  <div class="sage-table-wrapper">
+    <div class="sage-table-wrapper--overflow">
       <table class="sage-table sage-table--status">
         <thead>
           <tr>
@@ -47,8 +47,8 @@
 </div>
 <div class="sage-panel">
   <h2 class="t-sage-heading-2">Objects</h2>
-  <div class="sage-table--responsive">
-    <div class="sage-table__wrapper">
+  <div class="sage-table-wrapper">
+    <div class="sage-table-wrapper--overflow">
       <table class="sage-table sage-table--status">
         <thead>
           <tr>

--- a/app/views/sage/pages/status.html.erb
+++ b/app/views/sage/pages/status.html.erb
@@ -27,7 +27,7 @@
 <div class="sage-panel">
   <h2 class="t-sage-heading-2">Elements</h2>
   <div class="sage-table-wrapper">
-    <div class="sage-table-wrapper--overflow">
+    <div class="sage-table-wrapper__overflow">
       <table class="sage-table sage-table--status">
         <thead>
           <tr>


### PR DESCRIPTION
## Description
- Fixes status table overflowing page container and breaking layout on iOS
- Fixes status table key overflow
- Adds base styles for tables, including row striping and responsive options

### Screenshots
|  Before   |  After  |
|--------|--------|
![ios-table-scroll](https://user-images.githubusercontent.com/816579/77709231-a48a0c00-6f87-11ea-8393-f1ee89806a90.gif)|<img alt="table-fix" src="https://user-images.githubusercontent.com/816579/78953678-8e537400-7a8e-11ea-875f-a51f87001db5.png">|

Adapted styling from Figma playground
![figma-table](https://user-images.githubusercontent.com/816579/79005185-2b53f280-7b0b-11ea-9d0d-839aa8fd00a6.png)
