### PR TITLE
Revise tables in documentation to use `.sage-table` styling

### DIFF
--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -250,7 +250,10 @@ $sage-switch-focus-outline-color: sage-color(primary) !default;
 
 // Borders and sizing
 $sage-table-border: rem(1px) solid sage-color(grey);
-$sage-table-cell-padding: sage-spacing(sm) sage-spacing(xs);
+$sage-table-cell-padding-sm: sage-spacing(sm) sage-spacing(xs);
+$sage-table-cell-padding-lg: sage-spacing(md) sage-spacing(sm);
+$sage-table-heading-padding-sm: sage-spacing(sm) sage-spacing(xs);
+$sage-table-heading-padding-lg: sage-spacing(md) sage-spacing(sm);
 $sage-table-max-width: none;
 
 // Text

--- a/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
@@ -5,7 +5,8 @@
 ================================================== */
 
 .sage-table {
-  --table-cell-padding: #{sage-spacing(sm)} #{sage-spacing(xs)};
+  --table-cell-padding: #{$sage-table-cell-padding-sm};
+  --table-heading-padding: #{$sage-table-heading-padding-sm};
 
   width: 100%;
   max-width: $sage-table-max-width;
@@ -15,12 +16,25 @@
     text-align: $sage-table-caption-alignment;
   }
 
-  thead {
+  thead,
+  tfoot {
     color: $sage-table-heading-font-color;
     border-bottom: $sage-table-border;
 
-    td {
+    td,
+    th {
       @extend #{$sage-table-heading-font-size};
+
+      padding: $sage-table-heading-padding-sm;
+      padding: var(--table-heading-padding);
+
+      &:first-child {
+        padding-left: 0;
+      }
+
+      &:last-child {
+        padding-right: 0;
+      }
     }
   }
 
@@ -35,7 +49,7 @@
   td {
     @extend #{$sage-table-cell-font-size};
 
-    padding: $sage-table-cell-padding;
+    padding: $sage-table-cell-padding-sm;
     padding: var(--table-cell-padding);
     color: inherit;
     line-height: sage-line-height(md);
@@ -50,7 +64,8 @@
   }
 
   @media screen and (min-width: sage-breakpoint(md-min)) {
-    --table-cell-padding: #{sage-spacing(md)} #{sage-spacing(sm)};
+    --table-cell-padding: #{$sage-table-cell-padding-lg};
+    --table-heading-padding: #{$sage-table-heading-padding-lg};
   }
 }
 

--- a/app/views/sage/application/_status_item.html.erb
+++ b/app/views/sage/application/_status_item.html.erb
@@ -1,21 +1,21 @@
 <tr id="<%= item[:title] %>">
   <td><%= item[:title].titleize %></td>
   <td>SCSS</td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:scss_design] %>"></div></td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:scss_dev] %>"></div></td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:scss_doc] %>"></div></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:scss_design] %>"><span class="visually-hidden"><%= item[:scss_design].titleize %></span></span></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:scss_dev] %>"><span class="visually-hidden"><%= item[:scss_dev].titleize %></span></span></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:scss_doc] %>"><span class="visually-hidden"><%= item[:scss_doc].titleize %></span></span></td>
 </tr>
 <tr>
   <td></td>
   <td>Rails</td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:rails_design] %>"></div></td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:rails_dev] %>"></div></td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:rails_doc] %>"></div></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:rails_design] %>"><span class="visually-hidden"><%= item[:rails_design].titleize %></span></span></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:rails_dev] %>"><span class="visually-hidden"><%= item[:rails_dev].titleize %></span></span></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:rails_doc] %>"><span class="visually-hidden"><%= item[:rails_doc].titleize %></span></span></td>
 </tr>
 <tr>
   <td></td>
   <td>React</td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:react_design] %>"></div></td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:react_dev] %>"></div></td>
-  <td><div class="status-key__icon status-key__icon--<%= item[:react_doc] %>"></div></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:react_design] %>"><span class="visually-hidden"><%= item[:react_design].titleize %></span></span></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:react_dev] %>"><span class="visually-hidden"><%= item[:react_dev].titleize %></span></span></td>
+  <td><span class="status-key__icon status-key__icon--<%= item[:react_doc] %>"><span class="visually-hidden"><%= item[:react_doc].titleize %></span></span></td>
 </tr>

--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -39,15 +39,21 @@
 </div>
 <div id="<%= @title %>-example-props" class="sage-panel sage-type">
   <h2 class="t-sage-heading-2 example__title">Properties</h2>
-  <table>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-      <th>Type</th>
-      <th>Default</th>
-    </tr>
-    <%= render "sage/examples/elements/#{@title}/props" %>
-  </table>
+  <div class="sage-table-wrapper">
+    <div class="sage-table-wrapper__overflow">
+      <table class="sage-table sage-table--properties">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <%= render "sage/examples/elements/#{@title}/props" %>
+      </table>
+    </div>
+  </div>
 </div>
 <div id="<%= @title %>-example-best-practices" class="sage-panel sage-type">
   <h2 class="t-sage-heading-2 example__title">Best Practices</h2>

--- a/app/views/sage/examples/objects/_object.html.erb
+++ b/app/views/sage/examples/objects/_object.html.erb
@@ -39,15 +39,21 @@
 </div>
 <div id="<%= @title %>-example-props" class="sage-panel sage-type">
   <h2 class="t-sage-heading-2 example__title">Properties</h2>
-  <table>
-    <tr>
-      <th>Property</th>
-      <th>Description</th>
-      <th>Type</th>
-      <th>Default</th>
-    </tr>
-    <%= render "sage/examples/objects/#{@title}/props" %>
-  </table>
+  <div class="sage-table-wrapper">
+    <div class="sage-table-wrapper__overflow">
+      <table class="sage-table sage-table--properties">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <%= render "sage/examples/objects/#{@title}/props" %>
+      </table>
+    </div>
+  </div>
 </div>
 <div id="<%= @title %>-example-best-practices" class="sage-panel sage-type">
   <h2 class="t-sage-heading-2 example__title">Best Practices</h2>


### PR DESCRIPTION
## Description
- Revised documentation and generators to use new table styling
- Addresses accessibility of status table labels
- Slight refactor of table CSS and variable cleanup

### Screenshots
|  Before   |  After  |
|--------|--------|
|![table-old](https://user-images.githubusercontent.com/816579/79012954-77f3f980-7b1c-11ea-9a5b-1bdb07458417.png)|![table-new](https://user-images.githubusercontent.com/816579/79012958-7c201700-7b1c-11ea-9ccc-f55ecc965d14.png)|

## Related issues
- #127 