### PR TITLE
Stylelint fixes and updated generator comment styles

### DIFF
--- a/app/assets/stylesheets/sage/docs/_colors.scss
+++ b/app/assets/stylesheets/sage/docs/_colors.scss
@@ -10,7 +10,7 @@
   border-radius: sage-border(radius);
 }
 
-.color {
+%color {
   padding: sage-spacing(sm) sage-spacing();
   font-size: sage-font-size(sm);
   font-weight: sage-font-weight(simibold);
@@ -20,13 +20,14 @@
     float: right;
     text-transform: uppercase;
   }
+}
 
-  // TODO: flatten into mixin or function
+.color {
   @each $name, $color in $sage-colors {
     &-#{$name} {
       @each $tone, $hex in $color {
         &-#{$tone} {
-          @extend .color;
+          @extend %color;
           background: $hex;
 
           @if (lightness($hex) > 50) {
@@ -40,6 +41,7 @@
       }
     }
   }
+
   &-grey {
     &-100,
     &-200,
@@ -49,6 +51,7 @@
       color: sage-color(charcoal, 500);
     }
   }
+
   &-white {
     &-100,
     &-200,
@@ -60,6 +63,7 @@
       border-radius: sage-border(radius);
     }
   }
+
   &-black {
     &-100,
     &-200,

--- a/app/assets/stylesheets/sage/docs/_icon.scss
+++ b/app/assets/stylesheets/sage/docs/_icon.scss
@@ -4,26 +4,18 @@
   For Sage documentation use
 ================================================== */
 
-.sage-icon__example-list {
+.sage-icon-block {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
-  padding-left: sage-spacing();
-  list-style-type: none;
-}
-
-.sage-icon__example {
-  flex: 1;
-  min-width: 30%;
   margin-bottom: sage-spacing();
-  margin-right: sage-spacing();
-  padding: sage-spacing();
+  padding: sage-spacing(lg) sage-spacing(sm);
   text-align: center;
   border: sage-border();
 }
 
-.sage-icon__label {
+.sage-icon-block__label {
   margin-bottom: 0;
   font-size: sage-font-size(sm);
   font-weight: sage-font-weight(semibold);
-  white-space: nowrap;
 }

--- a/app/assets/stylesheets/sage/docs/_icon.scss
+++ b/app/assets/stylesheets/sage/docs/_icon.scss
@@ -4,36 +4,26 @@
   For Sage documentation use
 ================================================== */
 
-.sage-icon {
-  &__wrapper {
-    display: flex;
-    flex-wrap: wrap;
-    padding-left: sage-spacing();
-    list-style-type: none;
+.sage-icon__example-list {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: sage-spacing();
+  list-style-type: none;
+}
 
-    /*
-      TODO: use classes over element selectors
-      eventually we'll want to refactor this whole block
-    */
-    li {
-      flex: 1;
-      min-width: 30%;
-      margin-bottom: sage-spacing();
-      margin-right: sage-spacing();
-      padding: sage-spacing();
-      text-align: center;
-      border: sage-border();
+.sage-icon__example {
+  flex: 1;
+  min-width: 30%;
+  margin-bottom: sage-spacing();
+  margin-right: sage-spacing();
+  padding: sage-spacing();
+  text-align: center;
+  border: sage-border();
+}
 
-      i {
-        font-size: sage-font-size(xl);
-      }
-
-      p {
-        margin-bottom: 0;
-        font-size: sage-font-size(sm);
-        font-weight: sage-font-weight(semibold);
-        white-space: nowrap;
-      }
-    }
-  }
+.sage-icon__label {
+  margin-bottom: 0;
+  font-size: sage-font-size(sm);
+  font-weight: sage-font-weight(semibold);
+  white-space: nowrap;
 }

--- a/app/assets/stylesheets/sage/system/core/_variables.scss
+++ b/app/assets/stylesheets/sage/system/core/_variables.scss
@@ -272,7 +272,6 @@ $sage-table-overflow-indicator-opacity: 0.95;
 $sage-table-overflow-indicator-gradient: linear-gradient(90deg, $sage-table-overflow-indicator-color-start 0%, rgba($sage-table-overflow-indicator-color-end, $sage-table-overflow-indicator-opacity) 100%);
 
 
-
 // ==================================================
 // LOADERS AND SPINNERS
 // ==================================================

--- a/app/assets/stylesheets/sage/system/layout/_grid.scss
+++ b/app/assets/stylesheets/sage/system/layout/_grid.scss
@@ -2,14 +2,13 @@
   ** sage grid
   type: style
 
-
 ================================================== */
 
 // ============================================
 // Rows
 // ============================================
 
-.sage-row {
+@mixin sage-row {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -17,60 +16,70 @@
   margin-right: calc(#{$sage-grid-gap-md} / -2);
 }
 
+.sage-row {
+  @include sage-row();
+}
+
 // ============================================
 // Columns
 // ============================================
 
-%sage-col {
+@mixin sage-col {
   flex: 1 1 auto;
   max-width: 100%;
   padding: 0 calc(#{$sage-grid-gap-md} / 2);
 }
 
-.sage-col {
-  // TODO: refactor this to replace extend
-  @extend %sage-col;
-
-  @for $sage-i from 1 through $sage-grid-columns {
-    &--sm-#{$sage-i},
-    &--md-#{$sage-i},
-    &--lg-#{$sage-i} {
-      // TODO: refactor this to replace extend
-      @extend %sage-col;
-      flex: 0 0 100%;
-    }
+@for $sage-i from 1 through $sage-grid-columns {
+  .sage-col--sm-#{$sage-i},
+  .sage-col--md-#{$sage-i},
+  .sage-col--lg-#{$sage-i} {
+    @include sage-col();
+    flex: 0 0 100%;
   }
 }
 
 @media (min-width: sage-breakpoint(sm-min)) {
-  .sage-col {
-    @for $sage-i from 1 through $sage-grid-columns {
-      &--sm-#{$sage-i} {
-        flex: 0 1 auto;
-        width: percentage($sage-i / $sage-grid-columns);
-      }
+  @for $sage-i from 1 through $sage-grid-columns {
+    .sage-col--sm-#{$sage-i} {
+      flex: 0 1 auto;
+      width: percentage($sage-i / $sage-grid-columns);
     }
+  }
+}
+
+@media (max-width: sage-breakpoint(sm-max)) {
+  .sage-col--sm-hide {
+    display: none;
   }
 }
 
 @media (min-width: sage-breakpoint(md-min)) {
-  .sage-col {
-    @for $sage-i from 1 through $sage-grid-columns {
-      &--md-#{$sage-i} {
-        flex: 0 1 auto;
-        width: percentage($sage-i / $sage-grid-columns);
-      }
+  @for $sage-i from 1 through $sage-grid-columns {
+    .sage-col--md-#{$sage-i} {
+      flex: 0 1 auto;
+      width: percentage($sage-i / $sage-grid-columns);
     }
   }
 }
 
+@media (max-width: sage-breakpoint(md-max)) {
+  .sage-col--md-hide {
+    display: none;
+  }
+}
+
 @media (min-width: sage-breakpoint(lg-min)) {
-  .sage-col {
-    @for $sage-i from 1 through $sage-grid-columns {
-      &--lg-#{$sage-i} {
-        flex: 0 1 auto;
-        width: percentage($sage-i / $sage-grid-columns);
-      }
+  @for $sage-i from 1 through $sage-grid-columns {
+    .sage-col--lg-#{$sage-i} {
+      flex: 0 1 auto;
+      width: percentage($sage-i / $sage-grid-columns);
     }
+  }
+}
+
+@media (max-width: sage-breakpoint(lg-max)) {
+  .sage-col--lg-hide {
+    display: none;
   }
 }

--- a/app/assets/stylesheets/sage/system/layout/_page.scss
+++ b/app/assets/stylesheets/sage/system/layout/_page.scss
@@ -8,9 +8,9 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+}
 
-  &__icon {
-    height: 60px;
-    margin-bottom: sage-spacing();
-  }
+.sage-page__icon {
+  height: 60px;
+  margin-bottom: sage-spacing();
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_checkbox.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_checkbox.scss
@@ -89,13 +89,9 @@
     }
   }
 
-  &:hover {
-    &:not(:checked) {
-      &:not(:disabled) {
-        border-color: sage-color(grey, 500);
-        box-shadow: sage-shadow(sm);
-      }
-    }
+  &:hover:not(:checked):not(:disabled) {
+    border-color: sage-color(grey, 500);
+    box-shadow: sage-shadow(sm);
   }
 
   &:focus:not(:disabled),
@@ -121,10 +117,10 @@
       border-color: $sage-checkbox-color-disabled-checked;
       box-shadow: none;
       opacity: 1;
+    }
 
-      &::before {
-        display: none;
-      }
+    &:checked::before {
+      display: none;
     }
   }
 

--- a/app/assets/stylesheets/sage/system/patterns/elements/_description.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_description.scss
@@ -2,12 +2,11 @@
   ** description
   type: element
 
-
-
 ================================================== */
 
 .sage-description {
   margin-bottom: sage-spacing();
+
   &:last-of-type {
     margin-bottom: 0;
   }
@@ -20,5 +19,5 @@
 }
 
 .sage-description__data {
-  @extend %t-sage-body
+  @extend %t-sage-body;
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_live_stream_wrapper.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_live_stream_wrapper.scss
@@ -2,13 +2,11 @@
   ** live_stream_wrapper
   type: object
 
-
-
 ================================================== */
 
 .sage-live-stream-wrapper {
   position: absolute;
-  // These are set to ensure video and controls are visible 
+  // These are set to ensure video and controls are visible
   // but should adjust once responsive is fully considered
   min-width: rem(460px);
   min-height: rem(320px);

--- a/app/assets/stylesheets/sage/system/patterns/elements/_menu_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_menu_button.scss
@@ -44,28 +44,24 @@
       content: "";
     }
 
-    &:focus {
-      &::after {
-        transform: translate3d(-50%, -50%, 0) scale(1);
-        border-color: sage-color(charcoal, 100);
-        opacity: 1;
-      }
+    &:focus::after {
+      transform: translate3d(-50%, -50%, 0) scale(1);
+      border-color: sage-color(charcoal, 100);
+      opacity: 1;
     }
 
     &:active {
       color: sage-color(grey, 400);
-
-      &::after {
-        border-color: sage-color(charcoal, 200);
-      }
     }
 
-    &[aria-expanded="true"] {
-      &::after {
-        transform: translate3d(-50%, -50%, 0) scale(1);
-        border-color: sage-color(sage);
-        opacity: 1;
-      }
+    &:active::after {
+      border-color: sage-color(charcoal, 200);
+    }
+
+    &[aria-expanded="true"]::after {
+      transform: translate3d(-50%, -50%, 0) scale(1);
+      border-color: sage-color(sage);
+      opacity: 1;
     }
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -11,110 +11,110 @@
   align-items: center;
   margin-bottom: $sage-form-element-spacing;
   color: $sage-switch-color-default-text;
+}
 
-  .sage-switch__input {
+.sage-switch__input {
+  display: inline-block;
+  position: relative;
+  height: $sage-switch-height;
+  width: $sage-switch-width;
+  margin: 0;
+  vertical-align: top;
+  appearance: none;
+  color: $sage-switch-color-default;
+  background: $sage-switch-color-default;
+  border: 0;
+  border-radius: $sage-switch-border-radius;
+  outline: none;
+  transition: background 0.3s ease-out;
+  cursor: pointer;
+
+  + .sage-switch__label {
     display: inline-block;
-    position: relative;
-    height: $sage-switch-height;
-    width: $sage-switch-width;
-    margin: 0;
+    margin-left: sage-spacing(sm);
     vertical-align: top;
-    appearance: none;
-    color: $sage-switch-color-default;
-    background: $sage-switch-color-default;
-    border: 0;
-    border-radius: $sage-switch-border-radius;
-    outline: none;
-    transition: background 0.3s ease-out;
     cursor: pointer;
 
+    @extend %t-sage-body;
+  }
+
+  &::before,
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+  }
+
+  &::before { // switch background
+    transform: translate3d(-50%, -50%, 0) scale(0.94);
+    width: calc(100% + (#{$sage-switch-focus-outline-width * 1px} + #{$sage-switch-focus-outline-spacing * 2}));
+    height: calc(100% + (#{$sage-switch-focus-outline-width * 1px} + #{$sage-switch-focus-outline-spacing * 2}));
+    border: ($sage-switch-focus-outline-width * 1px) solid $sage-switch-focus-outline-color;
+    border-radius: $sage-switch-border-radius;
+    transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  &::after {  // switch toggle
+    transform: translate3d(-100%, -50%, 0);
+    height: $sage-switch-toggle-size;
+    width: $sage-switch-toggle-size;
+    background: sage-color(white);
+    border-radius: sage-border(radius-round);
+    box-shadow: sage-shadow(sm);
+    transition: transform 0.2s ease-in-out;
+  }
+
+  &:invalid {
+    background-color: sage-color(red);
+
     + .sage-switch__label {
-      display: inline-block;
-      margin-left: sage-spacing(sm);
-      vertical-align: top;
-      cursor: pointer;
-
-      @extend %t-sage-body;
+      color: sage-color(red);
     }
+  }
 
-    &::before,
+  // checked
+  &:checked {
+    color: $sage-switch-color-checked;
+    background: $sage-switch-color-checked;
+
     &::after {
-      content: "";
-      display: block;
-      position: absolute;
-      left: 50%;
-      top: 50%;
+      transform: translate3d(0, -50%, 0);
+    }
+  }
+
+  // disabled
+  &:disabled {
+    background: $sage-switch-color-disabled;
+    cursor: not-allowed;
+
+    &::after {
+      box-shadow: none;
     }
 
-    &::before { // switch background
-      transform: translate3d(-50%, -50%, 0) scale(0.94);
-      width: calc(100% + (#{$sage-switch-focus-outline-width * 1px} + #{$sage-switch-focus-outline-spacing * 2}));
-      height: calc(100% + (#{$sage-switch-focus-outline-width * 1px} + #{$sage-switch-focus-outline-spacing * 2}));
-      border: ($sage-switch-focus-outline-width * 1px) solid $sage-switch-focus-outline-color;
-      border-radius: $sage-switch-border-radius;
-      transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
-      pointer-events: none;
-      opacity: 0;
+    + .sage-switch__label {
+      color: $sage-switch-color-disabled-text;
+      cursor: inherit;
     }
 
-    &::after {  // switch toggle
-      transform: translate3d(-100%, -50%, 0);
-      height: $sage-switch-toggle-size;
-      width: $sage-switch-toggle-size;
-      background: sage-color(white);
-      border-radius: sage-border(radius-round);
-      box-shadow: sage-shadow(sm);
-      transition: transform 0.2s ease-in-out;
-    }
-
-    &:invalid {
-      background-color: sage-color(red);
+    // disabled & checked
+    &:checked {
+      background: $sage-switch-color-disabled-checked;
 
       + .sage-switch__label {
-        color: sage-color(red);
+        color: $sage-switch-color-disabled-checked-text;
       }
     }
+  }
 
-    // checked
-    &:checked {
-      color: $sage-switch-color-checked;
-      background: $sage-switch-color-checked;
-
-      &::after {
-        transform: translate3d(0, -50%, 0);
-      }
-    }
-
-    // disabled
-    &:disabled {
-      background: $sage-switch-color-disabled;
-      cursor: not-allowed;
-
-      &::after {
-        box-shadow: none;
-      }
-
-      + label {
-        color: $sage-switch-color-disabled-text;
-        cursor: inherit;
-      }
-
-      // disabled & checked
-      &:checked {
-        background: $sage-switch-color-disabled-checked;
-
-        + label {
-          color: $sage-switch-color-disabled-checked-text;
-        }
-      }
-    }
-
-    &:focus:not(:disabled),
-    &:active:not(:disabled) {
-      &::before {
-        transform: translate3d(-50%, -50%, 0);
-        opacity: 1;
-      }
+  &:focus:not(:disabled),
+  &:active:not(:disabled) {
+    &::before {
+      transform: translate3d(-50%, -50%, 0);
+      opacity: 1;
     }
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_switch.scss
@@ -103,10 +103,10 @@
     // disabled & checked
     &:checked {
       background: $sage-switch-color-disabled-checked;
+    }
 
-      + .sage-switch__label {
-        color: $sage-switch-color-disabled-checked-text;
-      }
+    &:checked + .sage-switch__label {
+      color: $sage-switch-color-disabled-checked-text;
     }
   }
 

--- a/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_table.scss
@@ -27,14 +27,16 @@
 
       padding: $sage-table-heading-padding-sm;
       padding: var(--table-heading-padding);
+    }
 
-      &:first-child {
-        padding-left: 0;
-      }
+    td:first-child,
+    th:first-child {
+      padding-left: 0;
+    }
 
-      &:last-child {
-        padding-right: 0;
-      }
+    td:last-child,
+    th:last-child {
+      padding-right: 0;
     }
   }
 

--- a/app/assets/stylesheets/sage/system/patterns/objects/_assistant.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_assistant.scss
@@ -11,34 +11,34 @@
   height: $sage-assistant-height;
   padding: sage-spacing(xs) sage-spacing();
   background: sage-color(primary, 500);
+}
 
-  &__branding {
-    height: $sage-assistant-branding-height;
-  }
+.sage-assistant__branding {
+  height: $sage-assistant-branding-height;
+}
 
-  &__body {
-    flex: 1;
-  }
+.sage-assistant__body {
+  flex: 1;
+}
 
-  &__search {
-    @include placeholder {
-      color: $sage-assistant-search-placeholder-color;
-      transition: $sage-assistant-search-placeholder-transition;
-    }
-
-    width: 100%;
-    height: $sage-assistant-search-height;
-    padding: sage-spacing(xs);
+.sage-assistant__search {
+  @include placeholder {
     color: $sage-assistant-search-placeholder-color;
-    background: rgba($sage-assistant-search-bg-color, $sage-assistant-search-bg-opacity);
-    border: 0;
-    border-radius: sage-border(radius);
+    transition: $sage-assistant-search-placeholder-transition;
+  }
 
-    &:focus,
-    &:active {
-      @include placeholder {
-        opacity: 0.2;
-      }
+  width: 100%;
+  height: $sage-assistant-search-height;
+  padding: sage-spacing(xs);
+  color: $sage-assistant-search-placeholder-color;
+  background: rgba($sage-assistant-search-bg-color, $sage-assistant-search-bg-opacity);
+  border: 0;
+  border-radius: sage-border(radius);
+
+  &:focus,
+  &:active {
+    @include placeholder {
+      opacity: 0.2;
     }
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_form_section.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_form_section.scss
@@ -7,25 +7,25 @@
 .sage-form_section {
   @include sage-row();
   margin-bottom: sage-spacing();
+}
 
-  // TODO: refactor extends following final design of form section
-  &__info {
-    @extend .sage-col--md-4;
-  }
+// TODO: refactor extends following final design of form section
+.sage-form_section__info {
+  @extend .sage-col--md-4;
+}
 
-  &__title {
-    margin-bottom: sage-spacing(xs);
-  }
+.sage-form_section__title {
+  margin-bottom: sage-spacing(xs);
+}
 
-  &__subtitle {
-    color: sage-color(charcoal, 200);
-  }
+.sage-form_section__subtitle {
+  color: sage-color(charcoal, 200);
+}
 
-  &__content {
-    @extend .sage-col--md-8;
-  }
+.sage-form_section__content {
+  @extend .sage-col--md-8;
+}
 
-  &__panel {
-    @extend .sage-panel;
-  }
+.sage-form_section__panel {
+  @extend .sage-panel;
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_form_section.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_form_section.scss
@@ -4,11 +4,11 @@
 
 ================================================== */
 
-// TODO: refactor @extend
 .sage-form_section {
-  @extend .sage-row;
+  @include sage-row();
   margin-bottom: sage-spacing();
 
+  // TODO: refactor extends following final design of form section
   &__info {
     @extend .sage-col--md-4;
   }
@@ -27,9 +27,5 @@
 
   &__panel {
     @extend .sage-panel;
-  }
-
-  @media (max-width: sage-breakpoint()) {
-    /* form_section responsive styles */
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
@@ -2,8 +2,6 @@
   ** live_stream_control
   type: element
 
-
-
 ================================================== */
 
 $-live-stream-control-size: rem(40px);
@@ -36,7 +34,7 @@ $-live-stream-control-ring-offset: rem(5px);
   background-color: $-live-stream-control-background-color;
   transition: $sage-transition;
   transition-property: background-color, color;
-  
+
   &::after {
     content: "";
     position: absolute;
@@ -49,7 +47,7 @@ $-live-stream-control-ring-offset: rem(5px);
 
     @include position-full(-$-live-stream-control-ring-offset);
   }
-  
+
   &:hover {
     transform: scale($-live-stream-control-hover-scale);
   }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_footer.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_footer.scss
@@ -42,9 +42,9 @@
   width: 25%;
   min-width: max-content;
   margin-right: auto;
-  opacity: 0;
   transition: $sage-transition;
   transition-property: opacity;
+  opacity: 0;
 
   .sage-live-stream-wrapper--awake & {
     opacity: 1;
@@ -57,14 +57,14 @@
   justify-content: center;
   min-width: max-content;
   padding: 0 sage-spacing(sm);
-  opacity: 0;
   transition: $sage-transition;
   transition-property: opacity;
+  opacity: 0;
 
   .sage-live-stream-wrapper--awake & {
     opacity: 1;
   }
-} 
+}
 
 .sage-live-stream-footer__chat-controls {
   display: flex;

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_header.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_header.scss
@@ -56,11 +56,11 @@ $-live-stream-header-recording-marker-size: 8px;
   &::before {
     content: "";
     display: inline-block;
-    background-color: sage-color(red, 300);
+    transform: translateY(-1px);
     width: $-live-stream-header-recording-marker-size;
     height: $-live-stream-header-recording-marker-size;
-    border-radius: sage-border(radius-round);
     margin-right: sage-spacing(2xs);
-    transform: translateY(-1px);
+    background-color: sage-color(red, 300);
+    border-radius: sage-border(radius-round);
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_video_grid.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_video_grid.scss
@@ -69,7 +69,7 @@ $-live-stream-tile-gapper: calc(100% / 6);
   overflow: hidden;
   position: relative;
   border-radius: sage-border(radius);
-  
+
   @for $i from 1 through 6 {
     &:nth-child(#{$i}) {
       grid-area: t#{$i};

--- a/app/assets/stylesheets/sage/system/patterns/objects/_page_heading.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_page_heading.scss
@@ -2,8 +2,6 @@
   ** page_heading
   type: object
 
-
-
 ================================================== */
 
 .sage-page-heading {
@@ -20,6 +18,6 @@
 }
 
 .sage-page-heading__icon {
-  transform: translateY(2px);
   display: inline-block;
+  transform: translateY(rem(2px));
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_panel.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_panel.scss
@@ -11,13 +11,13 @@
   border-radius: $sage-panel-border-radius;
   box-shadow: $sage-panel-box-shadow;
 
-  &__img {
-    display: block;
-    max-width: 100%;
-    margin-bottom: sage-spacing();
-  }
-
   > :last-child {
     margin-bottom: 0;
   }
+}
+
+.sage-panel__img {
+  display: block;
+  max-width: 100%;
+  margin-bottom: sage-spacing();
 }

--- a/app/assets/stylesheets/sage/system/vendor/_reboot.scss
+++ b/app/assets/stylesheets/sage/system/vendor/_reboot.scss
@@ -56,7 +56,8 @@ h6 {
   margin-bottom: 0;
 }
 
-p, li {
+p,
+li {
   margin-top: 0;
   margin-bottom: 0;
 }

--- a/app/views/layouts/sage/application.html.erb
+++ b/app/views/layouts/sage/application.html.erb
@@ -21,7 +21,7 @@
             <div class="sage-col--lg-9">
               <%= yield %>
             </div>
-            <div class="sage-col--lg-3"><%= yield :quick_links %></div>
+            <div class="sage-col--lg-3 sage-col--md-hide"><%= yield :quick_links %></div>
           </div>
         </div>
       </div>

--- a/app/views/sage/pages/icon.html.erb
+++ b/app/views/sage/pages/icon.html.erb
@@ -14,294 +14,438 @@
 </p>
 <% end %>
 <div class="sage-panel">
-<ul class="sage-icon__example-list">
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-menu"></i>
-    <p class="sage-icon__label">sage-icon-menu</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-launch"></i>
-    <p class="sage-icon__label">sage-icon-launch</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-search"></i>
-    <p class="sage-icon__label">sage-icon-search</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-monitor"></i>
-    <p class="sage-icon__label">sage-icon-monitor</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-tag"></i>
-    <p class="sage-icon__label">sage-icon-tag</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-megaphone"></i>
-    <p class="sage-icon__label">sage-icon-megaphone</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-user-circle"></i>
-    <p class="sage-icon__label">sage-icon-user-circle</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-gear"></i>
-    <p class="sage-icon__label">sage-icon-gear</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-pen"></i>
-    <p class="sage-icon__label">sage-icon-pen</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-file"></i>
-    <p class="sage-icon__label">sage-icon-file</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-image"></i>
-    <p class="sage-icon__label">sage-icon-image</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-folder"></i>
-    <p class="sage-icon__label">sage-icon-folder</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-users"></i>
-    <p class="sage-icon__label">sage-icon-users</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-chart"></i>
-    <p class="sage-icon__label">sage-icon-chart</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-preview-on"></i>
-    <p class="sage-icon__label">sage-icon-preview-on</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-preview-off"></i>
-    <p class="sage-icon__label">sage-icon-preview-off</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-comment"></i>
-    <p class="sage-icon__label">sage-icon-comment</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-conversation"></i>
-    <p class="sage-icon__label">sage-icon-conversation</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-add"></i>
-    <p class="sage-icon__label">sage-icon-add</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-remove"></i>
-    <p class="sage-icon__label">sage-icon-remove</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-3-dot-menu"></i>
-    <p class="sage-icon__label">sage-icon-3-dot-menu</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-url"></i>
-    <p class="sage-icon__label">sage-icon-url</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-trash"></i>
-    <p class="sage-icon__label">sage-icon-trash</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-cart"></i>
-    <p class="sage-icon__label">sage-icon-cart</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-delete-key"></i>
-    <p class="sage-icon__label">sage-icon-delete-key</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-delete-x"></i>
-    <p class="sage-icon__label">sage-icon-delete-x</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-send-message"></i>
-    <p class="sage-icon__label">sage-icon-send-message</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-mail"></i>
-    <p class="sage-icon__label">sage-icon-mail</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-loop"></i>
-    <p class="sage-icon__label">sage-icon-loop</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-restore"></i>
-    <p class="sage-icon__label">sage-icon-restore</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-clock"></i>
-    <p class="sage-icon__label">sage-icon-clock</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-calendar-date"></i>
-    <p class="sage-icon__label">sage-icon-calendar-date</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-calendar-schedule"></i>
-    <p class="sage-icon__label">sage-icon-calendar-schedule</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-drop"></i>
-    <p class="sage-icon__label">sage-icon-drop</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-lock"></i>
-    <p class="sage-icon__label">sage-icon-lock</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-user"></i>
-    <p class="sage-icon__label">sage-icon-user</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-user-star"></i>
-    <p class="sage-icon__label">sage-icon-user-star</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-favorite"></i>
-    <p class="sage-icon__label">sage-icon-favorite</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-star"></i>
-    <p class="sage-icon__label">sage-icon-star</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-check"></i>
-    <p class="sage-icon__label">sage-icon-check</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-check-circle"></i>
-    <p class="sage-icon__label">sage-icon-check-circle</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-remove-circle"></i>
-    <p class="sage-icon__label">sage-icon-remove-circle</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-add-circle"></i>
-    <p class="sage-icon__label">sage-icon-add-circle</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-delete-circle"></i>
-    <p class="sage-icon__label">sage-icon-delete-circle</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-info-circle"></i>
-    <p class="sage-icon__label">sage-icon-info-circle</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-question-circle"></i>
-    <p class="sage-icon__label">sage-icon-question-circle</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-warning"></i>
-    <p class="sage-icon__label">sage-icon-warning</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-download"></i>
-    <p class="sage-icon__label">sage-icon-download</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-enlarge-vertical"></i>
-    <p class="sage-icon__label">sage-icon-enlarge-vertical</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-enlarge"></i>
-    <p class="sage-icon__label">sage-icon-enlarge</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-arrow-up"></i>
-    <p class="sage-icon__label">sage-icon-arrow-up</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-arrow-right"></i>
-    <p class="sage-icon__label">sage-icon-arrow-right</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-arrow-left"></i>
-    <p class="sage-icon__label">sage-icon-arrow-left</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-arrow-down"></i>
-    <p class="sage-icon__label">sage-icon-arrow-down</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-caret-up"></i>
-    <p class="sage-icon__label">sage-icon-caret-up</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-caret-right"></i>
-    <p class="sage-icon__label">sage-icon-caret-right</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-caret-down"></i>
-    <p class="sage-icon__label">sage-icon-caret-down</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-caret-left"></i>
-    <p class="sage-icon__label">sage-icon-caret-left</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-search-small"></i>
-    <p class="sage-icon__label">sage-icon-search-small</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-add-small"></i>
-    <p class="sage-icon__label">sage-icon-add-small</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-up-small"></i>
-    <p class="sage-icon__label">sage-icon-up-small</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-right-small"></i>
-    <p class="sage-icon__label">sage-icon-right-small</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-down-small"></i>
-    <p class="sage-icon__label">sage-icon-down-small</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-left-small"></i>
-    <p class="sage-icon__label">sage-icon-left-small</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-microphone"></i>
-    <p class="sage-icon__label">sage-icon-microphone</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-microphone-off"></i>
-    <p class="sage-icon__label">sage-icon-microphone-off</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-video-on"></i>
-    <p class="sage-icon__label">sage-icon-video-on</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-video-off"></i>
-    <p class="sage-icon__label">sage-icon-video-off</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-screen-share-on"></i>
-    <p class="sage-icon__label">sage-icon-screen-share-on</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-screen-share-off"></i>
-    <p class="sage-icon__label">sage-icon-screen-share-off</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-play"></i>
-    <p class="sage-icon__label">sage-icon-play</p>
-  </li>
-  <li class="sage-icon__example">
-    <i class="sage-icon__glyph sage-icon-stop"></i>
-    <p class="sage-icon__label">sage-icon-stop</p>
-  </li>
+<div class="sage-row">
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-menu"></i>
+      <p class="sage-icon-block__label">sage-icon-menu</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-launch"></i>
+      <p class="sage-icon-block__label">sage-icon-launch</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-search"></i>
+      <p class="sage-icon-block__label">sage-icon-search</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-monitor"></i>
+      <p class="sage-icon-block__label">sage-icon-monitor</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-tag"></i>
+      <p class="sage-icon-block__label">sage-icon-tag</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-megaphone"></i>
+      <p class="sage-icon-block__label">sage-icon-megaphone</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-user-circle"></i>
+      <p class="sage-icon-block__label">sage-icon-user-circle</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-gear"></i>
+      <p class="sage-icon-block__label">sage-icon-gear</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-pen"></i>
+      <p class="sage-icon-block__label">sage-icon-pen</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-file"></i>
+      <p class="sage-icon-block__label">sage-icon-file</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-image"></i>
+      <p class="sage-icon-block__label">sage-icon-image</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-folder"></i>
+      <p class="sage-icon-block__label">sage-icon-folder</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-users"></i>
+      <p class="sage-icon-block__label">sage-icon-users</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-chart"></i>
+      <p class="sage-icon-block__label">sage-icon-chart</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-preview-on"></i>
+      <p class="sage-icon-block__label">sage-icon-preview-on</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-preview-off"></i>
+      <p class="sage-icon-block__label">sage-icon-preview-off</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-comment"></i>
+      <p class="sage-icon-block__label">sage-icon-comment</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-conversation"></i>
+      <p class="sage-icon-block__label">sage-icon-conversation</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-add"></i>
+      <p class="sage-icon-block__label">sage-icon-add</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-remove"></i>
+      <p class="sage-icon-block__label">sage-icon-remove</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-3-dot-menu"></i>
+      <p class="sage-icon-block__label">sage-icon-3-dot-menu</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-url"></i>
+      <p class="sage-icon-block__label">sage-icon-url</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-trash"></i>
+      <p class="sage-icon-block__label">sage-icon-trash</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-cart"></i>
+      <p class="sage-icon-block__label">sage-icon-cart</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-delete-key"></i>
+      <p class="sage-icon-block__label">sage-icon-delete-key</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-delete-x"></i>
+      <p class="sage-icon-block__label">sage-icon-delete-x</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-send-message"></i>
+      <p class="sage-icon-block__label">sage-icon-send-message</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-mail"></i>
+      <p class="sage-icon-block__label">sage-icon-mail</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-loop"></i>
+      <p class="sage-icon-block__label">sage-icon-loop</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-restore"></i>
+      <p class="sage-icon-block__label">sage-icon-restore</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-clock"></i>
+      <p class="sage-icon-block__label">sage-icon-clock</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-calendar-date"></i>
+      <p class="sage-icon-block__label">sage-icon-calendar-date</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-calendar-schedule"></i>
+      <p class="sage-icon-block__label">sage-icon-calendar-schedule</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-drop"></i>
+      <p class="sage-icon-block__label">sage-icon-drop</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-lock"></i>
+      <p class="sage-icon-block__label">sage-icon-lock</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-user"></i>
+      <p class="sage-icon-block__label">sage-icon-user</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-user-star"></i>
+      <p class="sage-icon-block__label">sage-icon-user-star</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-favorite"></i>
+      <p class="sage-icon-block__label">sage-icon-favorite</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-star"></i>
+      <p class="sage-icon-block__label">sage-icon-star</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-check"></i>
+      <p class="sage-icon-block__label">sage-icon-check</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-check-circle"></i>
+      <p class="sage-icon-block__label">sage-icon-check-circle</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-remove-circle"></i>
+      <p class="sage-icon-block__label">sage-icon-remove-circle</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-add-circle"></i>
+      <p class="sage-icon-block__label">sage-icon-add-circle</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-delete-circle"></i>
+      <p class="sage-icon-block__label">sage-icon-delete-circle</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-info-circle"></i>
+      <p class="sage-icon-block__label">sage-icon-info-circle</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-question-circle"></i>
+      <p class="sage-icon-block__label">sage-icon-question-circle</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-warning"></i>
+      <p class="sage-icon-block__label">sage-icon-warning</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-download"></i>
+      <p class="sage-icon-block__label">sage-icon-download</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-enlarge-vertical"></i>
+      <p class="sage-icon-block__label">sage-icon-enlarge-vertical</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-enlarge"></i>
+      <p class="sage-icon-block__label">sage-icon-enlarge</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-arrow-up"></i>
+      <p class="sage-icon-block__label">sage-icon-arrow-up</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-arrow-right"></i>
+      <p class="sage-icon-block__label">sage-icon-arrow-right</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-arrow-left"></i>
+      <p class="sage-icon-block__label">sage-icon-arrow-left</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-arrow-down"></i>
+      <p class="sage-icon-block__label">sage-icon-arrow-down</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-caret-up"></i>
+      <p class="sage-icon-block__label">sage-icon-caret-up</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-caret-right"></i>
+      <p class="sage-icon-block__label">sage-icon-caret-right</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-caret-down"></i>
+      <p class="sage-icon-block__label">sage-icon-caret-down</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-caret-left"></i>
+      <p class="sage-icon-block__label">sage-icon-caret-left</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-search-small"></i>
+      <p class="sage-icon-block__label">sage-icon-search-small</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-add-small"></i>
+      <p class="sage-icon-block__label">sage-icon-add-small</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-up-small"></i>
+      <p class="sage-icon-block__label">sage-icon-up-small</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-right-small"></i>
+      <p class="sage-icon-block__label">sage-icon-right-small</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-down-small"></i>
+      <p class="sage-icon-block__label">sage-icon-down-small</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-left-small"></i>
+      <p class="sage-icon-block__label">sage-icon-left-small</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-microphone"></i>
+      <p class="sage-icon-block__label">sage-icon-microphone</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-microphone-off"></i>
+      <p class="sage-icon-block__label">sage-icon-microphone-off</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-video-on"></i>
+      <p class="sage-icon-block__label">sage-icon-video-on</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-video-off"></i>
+      <p class="sage-icon-block__label">sage-icon-video-off</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-screen-share-on"></i>
+      <p class="sage-icon-block__label">sage-icon-screen-share-on</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-screen-share-off"></i>
+      <p class="sage-icon-block__label">sage-icon-screen-share-off</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-play"></i>
+      <p class="sage-icon-block__label">sage-icon-play</p>
+    </div>
+  </div>
+  <div class="sage-col--md-4 sage-col--sm-6">
+    <div class="sage-icon-block">
+      <i class="sage-icon-stop"></i>
+      <p class="sage-icon-block__label">sage-icon-stop</p>
+    </div>
+  </div>
 </ul>
 </div>

--- a/app/views/sage/pages/icon.html.erb
+++ b/app/views/sage/pages/icon.html.erb
@@ -17,433 +17,433 @@
 <div class="sage-row">
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-menu"></i>
+      <i class="sage-icon-menu" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-menu</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-launch"></i>
+      <i class="sage-icon-launch" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-launch</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-search"></i>
+      <i class="sage-icon-search" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-search</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-monitor"></i>
+      <i class="sage-icon-monitor" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-monitor</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-tag"></i>
+      <i class="sage-icon-tag" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-tag</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-megaphone"></i>
+      <i class="sage-icon-megaphone" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-megaphone</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-user-circle"></i>
+      <i class="sage-icon-user-circle" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-user-circle</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-gear"></i>
+      <i class="sage-icon-gear" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-gear</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-pen"></i>
+      <i class="sage-icon-pen" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-pen</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-file"></i>
+      <i class="sage-icon-file" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-file</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-image"></i>
+      <i class="sage-icon-image" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-image</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-folder"></i>
+      <i class="sage-icon-folder" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-folder</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-users"></i>
+      <i class="sage-icon-users" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-users</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-chart"></i>
+      <i class="sage-icon-chart" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-chart</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-preview-on"></i>
+      <i class="sage-icon-preview-on" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-preview-on</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-preview-off"></i>
+      <i class="sage-icon-preview-off" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-preview-off</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-comment"></i>
+      <i class="sage-icon-comment" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-comment</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-conversation"></i>
+      <i class="sage-icon-conversation" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-conversation</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-add"></i>
+      <i class="sage-icon-add" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-add</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-remove"></i>
+      <i class="sage-icon-remove" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-remove</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-3-dot-menu"></i>
+      <i class="sage-icon-3-dot-menu" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-3-dot-menu</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-url"></i>
+      <i class="sage-icon-url" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-url</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-trash"></i>
+      <i class="sage-icon-trash" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-trash</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-cart"></i>
+      <i class="sage-icon-cart" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-cart</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-delete-key"></i>
+      <i class="sage-icon-delete-key" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-delete-key</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-delete-x"></i>
+      <i class="sage-icon-delete-x" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-delete-x</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-send-message"></i>
+      <i class="sage-icon-send-message" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-send-message</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-mail"></i>
+      <i class="sage-icon-mail" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-mail</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-loop"></i>
+      <i class="sage-icon-loop" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-loop</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-restore"></i>
+      <i class="sage-icon-restore" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-restore</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-clock"></i>
+      <i class="sage-icon-clock" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-clock</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-calendar-date"></i>
+      <i class="sage-icon-calendar-date" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-calendar-date</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-calendar-schedule"></i>
+      <i class="sage-icon-calendar-schedule" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-calendar-schedule</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-drop"></i>
+      <i class="sage-icon-drop" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-drop</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-lock"></i>
+      <i class="sage-icon-lock" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-lock</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-user"></i>
+      <i class="sage-icon-user" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-user</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-user-star"></i>
+      <i class="sage-icon-user-star" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-user-star</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-favorite"></i>
+      <i class="sage-icon-favorite" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-favorite</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-star"></i>
+      <i class="sage-icon-star" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-star</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-check"></i>
+      <i class="sage-icon-check" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-check</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-check-circle"></i>
+      <i class="sage-icon-check-circle" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-check-circle</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-remove-circle"></i>
+      <i class="sage-icon-remove-circle" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-remove-circle</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-add-circle"></i>
+      <i class="sage-icon-add-circle" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-add-circle</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-delete-circle"></i>
+      <i class="sage-icon-delete-circle" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-delete-circle</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-info-circle"></i>
+      <i class="sage-icon-info-circle" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-info-circle</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-question-circle"></i>
+      <i class="sage-icon-question-circle" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-question-circle</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-warning"></i>
+      <i class="sage-icon-warning" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-warning</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-download"></i>
+      <i class="sage-icon-download" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-download</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-enlarge-vertical"></i>
+      <i class="sage-icon-enlarge-vertical" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-enlarge-vertical</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-enlarge"></i>
+      <i class="sage-icon-enlarge" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-enlarge</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-arrow-up"></i>
+      <i class="sage-icon-arrow-up" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-arrow-up</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-arrow-right"></i>
+      <i class="sage-icon-arrow-right" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-arrow-right</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-arrow-left"></i>
+      <i class="sage-icon-arrow-left" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-arrow-left</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-arrow-down"></i>
+      <i class="sage-icon-arrow-down" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-arrow-down</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-caret-up"></i>
+      <i class="sage-icon-caret-up" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-caret-up</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-caret-right"></i>
+      <i class="sage-icon-caret-right" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-caret-right</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-caret-down"></i>
+      <i class="sage-icon-caret-down" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-caret-down</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-caret-left"></i>
+      <i class="sage-icon-caret-left" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-caret-left</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-search-small"></i>
+      <i class="sage-icon-search-small" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-search-small</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-add-small"></i>
+      <i class="sage-icon-add-small" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-add-small</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-up-small"></i>
+      <i class="sage-icon-up-small" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-up-small</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-right-small"></i>
+      <i class="sage-icon-right-small" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-right-small</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-down-small"></i>
+      <i class="sage-icon-down-small" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-down-small</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-left-small"></i>
+      <i class="sage-icon-left-small" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-left-small</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-microphone"></i>
+      <i class="sage-icon-microphone" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-microphone</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-microphone-off"></i>
+      <i class="sage-icon-microphone-off" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-microphone-off</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-video-on"></i>
+      <i class="sage-icon-video-on" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-video-on</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-video-off"></i>
+      <i class="sage-icon-video-off" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-video-off</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-screen-share-on"></i>
+      <i class="sage-icon-screen-share-on" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-screen-share-on</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-screen-share-off"></i>
+      <i class="sage-icon-screen-share-off" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-screen-share-off</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-play"></i>
+      <i class="sage-icon-play" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-play</p>
     </div>
   </div>
   <div class="sage-col--md-4 sage-col--sm-6">
     <div class="sage-icon-block">
-      <i class="sage-icon-stop"></i>
+      <i class="sage-icon-stop" aria-hidden="true"></i>
       <p class="sage-icon-block__label">sage-icon-stop</p>
     </div>
   </div>

--- a/app/views/sage/pages/icon.html.erb
+++ b/app/views/sage/pages/icon.html.erb
@@ -2,306 +2,306 @@
 <%= content_for :heading do %>
 <h1>Icons</h1>
 <p>
-  Our icon set includes those shown below. The typical pattern for 
+  Our icon set includes those shown below. The typical pattern for
   these is to use an <code>&lt;i&gt;</code> tag with a class as indicated below.
 </p>
 <p>
-  Note as well for accessibility that if the icon should have an 
-  <code>aria-label</code> attribute that describes the icon's 
-  purpose in context. However, if the icon is immediately surrounded by 
-  text that describes the icon, such as where the icon is purely decorative 
+  Note as well for accessibility that if the icon should have an
+  <code>aria-label</code> attribute that describes the icon's
+  purpose in context. However, if the icon is immediately surrounded by
+  text that describes the icon, such as where the icon is purely decorative
   then <code>aria-hidden="true"</code> can be used instead.
 </p>
 <% end %>
 <div class="sage-panel">
-<ul class="sage-icon__wrapper">
-  <li>
-    <i class="sage-icon-menu" aria-hidden="true"></i>
-    <p>sage-icon-menu</p>
-  </li>
-  <li>
-    <i class="sage-icon-launch" aria-hidden="true"></i>
-    <p>sage-icon-launch</p>
-  </li>
-  <li>
-    <i class="sage-icon-search" aria-hidden="true"></i>
-    <p>sage-icon-search</p>
-  </li>
-  <li>
-    <i class="sage-icon-monitor" aria-hidden="true"></i>
-    <p>sage-icon-monitor</p>
-  </li>
-  <li>
-    <i class="sage-icon-tag" aria-hidden="true"></i>
-    <p>sage-icon-tag</p>
-  </li>
-  <li>
-    <i class="sage-icon-megaphone" aria-hidden="true"></i>
-    <p>sage-icon-megaphone</p>
-  </li>
-  <li>
-    <i class="sage-icon-user-circle" aria-hidden="true"></i>
-    <p>sage-icon-user-circle</p>
-  </li>
-  <li>
-    <i class="sage-icon-gear" aria-hidden="true"></i>
-    <p>sage-icon-gear</p>
-  </li>
-  <li>
-    <i class="sage-icon-pen" aria-hidden="true"></i>
-    <p>sage-icon-pen</p>
-  </li>
-  <li>
-    <i class="sage-icon-file" aria-hidden="true"></i>
-    <p>sage-icon-file</p>
-  </li>
-  <li>
-    <i class="sage-icon-image" aria-hidden="true"></i>
-    <p>sage-icon-image</p>
-  </li>
-  <li>
-    <i class="sage-icon-folder" aria-hidden="true"></i>
-    <p>sage-icon-folder</p>
-  </li>
-  <li>
-    <i class="sage-icon-users" aria-hidden="true"></i>
-    <p>sage-icon-users</p>
-  </li>
-  <li>
-    <i class="sage-icon-chart" aria-hidden="true"></i>
-    <p>sage-icon-chart</p>
-  </li>
-  <li>
-    <i class="sage-icon-preview-on" aria-hidden="true"></i>
-    <p>sage-icon-preview-on</p>
-  </li>
-  <li>
-    <i class="sage-icon-preview-off" aria-hidden="true"></i>
-    <p>sage-icon-preview-off</p>
-  </li>
-  <li>
-    <i class="sage-icon-comment" aria-hidden="true"></i>
-    <p>sage-icon-comment</p>
-  </li>
-  <li>
-    <i class="sage-icon-conversation" aria-hidden="true"></i>
-    <p>sage-icon-conversation</p>
-  </li>
-  <li>
-    <i class="sage-icon-add" aria-hidden="true"></i>
-    <p>sage-icon-add</p>
-  </li>
-  <li>
-    <i class="sage-icon-remove" aria-hidden="true"></i>
-    <p>sage-icon-remove</p>
-  </li>
-  <li>
-    <i class="sage-icon-3-dot-menu" aria-hidden="true"></i>
-    <p>sage-icon-3-dot-menu</p>
-  </li>
-  <li>
-    <i class="sage-icon-url" aria-hidden="true"></i>
-    <p>sage-icon-url</p>
-  </li>
-  <li>
-    <i class="sage-icon-trash" aria-hidden="true"></i>
-    <p>sage-icon-trash</p>
-  </li>
-  <li>
-    <i class="sage-icon-cart" aria-hidden="true"></i>
-    <p>sage-icon-cart</p>
-  </li>
-  <li>
-    <i class="sage-icon-delete-key" aria-hidden="true"></i>
-    <p>sage-icon-delete-key</p>
-  </li>
-  <li>
-    <i class="sage-icon-delete-x" aria-hidden="true"></i>
-    <p>sage-icon-delete-x</p>
+<ul class="sage-icon__example-list">
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-menu"></i>
+    <p class="sage-icon__label">sage-icon-menu</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-launch"></i>
+    <p class="sage-icon__label">sage-icon-launch</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-search"></i>
+    <p class="sage-icon__label">sage-icon-search</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-monitor"></i>
+    <p class="sage-icon__label">sage-icon-monitor</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-tag"></i>
+    <p class="sage-icon__label">sage-icon-tag</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-megaphone"></i>
+    <p class="sage-icon__label">sage-icon-megaphone</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-user-circle"></i>
+    <p class="sage-icon__label">sage-icon-user-circle</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-gear"></i>
+    <p class="sage-icon__label">sage-icon-gear</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-pen"></i>
+    <p class="sage-icon__label">sage-icon-pen</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-file"></i>
+    <p class="sage-icon__label">sage-icon-file</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-image"></i>
+    <p class="sage-icon__label">sage-icon-image</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-folder"></i>
+    <p class="sage-icon__label">sage-icon-folder</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-users"></i>
+    <p class="sage-icon__label">sage-icon-users</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-chart"></i>
+    <p class="sage-icon__label">sage-icon-chart</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-preview-on"></i>
+    <p class="sage-icon__label">sage-icon-preview-on</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-preview-off"></i>
+    <p class="sage-icon__label">sage-icon-preview-off</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-comment"></i>
+    <p class="sage-icon__label">sage-icon-comment</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-conversation"></i>
+    <p class="sage-icon__label">sage-icon-conversation</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-add"></i>
+    <p class="sage-icon__label">sage-icon-add</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-remove"></i>
+    <p class="sage-icon__label">sage-icon-remove</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-3-dot-menu"></i>
+    <p class="sage-icon__label">sage-icon-3-dot-menu</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-url"></i>
+    <p class="sage-icon__label">sage-icon-url</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-trash"></i>
+    <p class="sage-icon__label">sage-icon-trash</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-cart"></i>
+    <p class="sage-icon__label">sage-icon-cart</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-delete-key"></i>
+    <p class="sage-icon__label">sage-icon-delete-key</p>
+  </li>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-delete-x"></i>
+    <p class="sage-icon__label">sage-icon-delete-x</p>
   </li>
-  <li>
-    <i class="sage-icon-send-message" aria-hidden="true"></i>
-    <p>sage-icon-send-message</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-send-message"></i>
+    <p class="sage-icon__label">sage-icon-send-message</p>
   </li>
-  <li>
-    <i class="sage-icon-mail" aria-hidden="true"></i>
-    <p>sage-icon-mail</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-mail"></i>
+    <p class="sage-icon__label">sage-icon-mail</p>
   </li>
-  <li>
-    <i class="sage-icon-loop" aria-hidden="true"></i>
-    <p>sage-icon-loop</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-loop"></i>
+    <p class="sage-icon__label">sage-icon-loop</p>
   </li>
-  <li>
-    <i class="sage-icon-restore" aria-hidden="true"></i>
-    <p>sage-icon-restore</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-restore"></i>
+    <p class="sage-icon__label">sage-icon-restore</p>
   </li>
-  <li>
-    <i class="sage-icon-clock" aria-hidden="true"></i>
-    <p>sage-icon-clock</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-clock"></i>
+    <p class="sage-icon__label">sage-icon-clock</p>
   </li>
-  <li>
-    <i class="sage-icon-calendar-date" aria-hidden="true"></i>
-    <p>sage-icon-calendar-date</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-calendar-date"></i>
+    <p class="sage-icon__label">sage-icon-calendar-date</p>
   </li>
-  <li>
-    <i class="sage-icon-calendar-schedule" aria-hidden="true"></i>
-    <p>sage-icon-calendar-schedule</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-calendar-schedule"></i>
+    <p class="sage-icon__label">sage-icon-calendar-schedule</p>
   </li>
-  <li>
-    <i class="sage-icon-drop" aria-hidden="true"></i>
-    <p>sage-icon-drop</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-drop"></i>
+    <p class="sage-icon__label">sage-icon-drop</p>
   </li>
-  <li>
-    <i class="sage-icon-lock" aria-hidden="true"></i>
-    <p>sage-icon-lock</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-lock"></i>
+    <p class="sage-icon__label">sage-icon-lock</p>
   </li>
-  <li>
-    <i class="sage-icon-user" aria-hidden="true"></i>
-    <p>sage-icon-user</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-user"></i>
+    <p class="sage-icon__label">sage-icon-user</p>
   </li>
-  <li>
-    <i class="sage-icon-user-star" aria-hidden="true"></i>
-    <p>sage-icon-user-star</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-user-star"></i>
+    <p class="sage-icon__label">sage-icon-user-star</p>
   </li>
-  <li>
-    <i class="sage-icon-favorite" aria-hidden="true"></i>
-    <p>sage-icon-favorite</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-favorite"></i>
+    <p class="sage-icon__label">sage-icon-favorite</p>
   </li>
-  <li>
-    <i class="sage-icon-star" aria-hidden="true"></i>
-    <p>sage-icon-star</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-star"></i>
+    <p class="sage-icon__label">sage-icon-star</p>
   </li>
-  <li>
-    <i class="sage-icon-check" aria-hidden="true"></i>
-    <p>sage-icon-check</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-check"></i>
+    <p class="sage-icon__label">sage-icon-check</p>
   </li>
-  <li>
-    <i class="sage-icon-check-circle" aria-hidden="true"></i>
-    <p>sage-icon-check-circle</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-check-circle"></i>
+    <p class="sage-icon__label">sage-icon-check-circle</p>
   </li>
-  <li>
-    <i class="sage-icon-remove-circle" aria-hidden="true"></i>
-    <p>sage-icon-remove-circle</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-remove-circle"></i>
+    <p class="sage-icon__label">sage-icon-remove-circle</p>
   </li>
-  <li>
-    <i class="sage-icon-add-circle" aria-hidden="true"></i>
-    <p>sage-icon-add-circle</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-add-circle"></i>
+    <p class="sage-icon__label">sage-icon-add-circle</p>
   </li>
-  <li>
-    <i class="sage-icon-delete-circle" aria-hidden="true"></i>
-    <p>sage-icon-delete-circle</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-delete-circle"></i>
+    <p class="sage-icon__label">sage-icon-delete-circle</p>
   </li>
-  <li>
-    <i class="sage-icon-info-circle" aria-hidden="true"></i>
-    <p>sage-icon-info-circle</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-info-circle"></i>
+    <p class="sage-icon__label">sage-icon-info-circle</p>
   </li>
-  <li>
-    <i class="sage-icon-question-circle" aria-hidden="true"></i>
-    <p>sage-icon-question-circle</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-question-circle"></i>
+    <p class="sage-icon__label">sage-icon-question-circle</p>
   </li>
-  <li>
-    <i class="sage-icon-warning" aria-hidden="true"></i>
-    <p>sage-icon-warning</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-warning"></i>
+    <p class="sage-icon__label">sage-icon-warning</p>
   </li>
-  <li>
-    <i class="sage-icon-download" aria-hidden="true"></i>
-    <p>sage-icon-download</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-download"></i>
+    <p class="sage-icon__label">sage-icon-download</p>
   </li>
-  <li>
-    <i class="sage-icon-enlarge-vertical" aria-hidden="true"></i>
-    <p>sage-icon-enlarge-vertical</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-enlarge-vertical"></i>
+    <p class="sage-icon__label">sage-icon-enlarge-vertical</p>
   </li>
-  <li>
-    <i class="sage-icon-enlarge" aria-hidden="true"></i>
-    <p>sage-icon-enlarge</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-enlarge"></i>
+    <p class="sage-icon__label">sage-icon-enlarge</p>
   </li>
-  <li>
-    <i class="sage-icon-arrow-up" aria-hidden="true"></i>
-    <p>sage-icon-arrow-up</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-arrow-up"></i>
+    <p class="sage-icon__label">sage-icon-arrow-up</p>
   </li>
-  <li>
-    <i class="sage-icon-arrow-right" aria-hidden="true"></i>
-    <p>sage-icon-arrow-right</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-arrow-right"></i>
+    <p class="sage-icon__label">sage-icon-arrow-right</p>
   </li>
-  <li>
-    <i class="sage-icon-arrow-left" aria-hidden="true"></i>
-    <p>sage-icon-arrow-left</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-arrow-left"></i>
+    <p class="sage-icon__label">sage-icon-arrow-left</p>
   </li>
-  <li>
-    <i class="sage-icon-arrow-down" aria-hidden="true"></i>
-    <p>sage-icon-arrow-down</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-arrow-down"></i>
+    <p class="sage-icon__label">sage-icon-arrow-down</p>
   </li>
-  <li>
-    <i class="sage-icon-caret-up" aria-hidden="true"></i>
-    <p>sage-icon-caret-up</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-caret-up"></i>
+    <p class="sage-icon__label">sage-icon-caret-up</p>
   </li>
-  <li>
-    <i class="sage-icon-caret-right" aria-hidden="true"></i>
-    <p>sage-icon-caret-right</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-caret-right"></i>
+    <p class="sage-icon__label">sage-icon-caret-right</p>
   </li>
-  <li>
-    <i class="sage-icon-caret-down" aria-hidden="true"></i>
-    <p>sage-icon-caret-down</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-caret-down"></i>
+    <p class="sage-icon__label">sage-icon-caret-down</p>
   </li>
-  <li>
-    <i class="sage-icon-caret-left" aria-hidden="true"></i>
-    <p>sage-icon-caret-left</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-caret-left"></i>
+    <p class="sage-icon__label">sage-icon-caret-left</p>
   </li>
-  <li>
-    <i class="sage-icon-search-small" aria-hidden="true"></i>
-    <p>sage-icon-search-small</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-search-small"></i>
+    <p class="sage-icon__label">sage-icon-search-small</p>
   </li>
-  <li>
-    <i class="sage-icon-add-small" aria-hidden="true"></i>
-    <p>sage-icon-add-small</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-add-small"></i>
+    <p class="sage-icon__label">sage-icon-add-small</p>
   </li>
-  <li>
-    <i class="sage-icon-up-small" aria-hidden="true"></i>
-    <p>sage-icon-up-small</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-up-small"></i>
+    <p class="sage-icon__label">sage-icon-up-small</p>
   </li>
-  <li>
-    <i class="sage-icon-right-small" aria-hidden="true"></i>
-    <p>sage-icon-right-small</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-right-small"></i>
+    <p class="sage-icon__label">sage-icon-right-small</p>
   </li>
-  <li>
-    <i class="sage-icon-down-small" aria-hidden="true"></i>
-    <p>sage-icon-down-small</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-down-small"></i>
+    <p class="sage-icon__label">sage-icon-down-small</p>
   </li>
-  <li>
-    <i class="sage-icon-left-small" aria-hidden="true"></i>
-    <p>sage-icon-left-small</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-left-small"></i>
+    <p class="sage-icon__label">sage-icon-left-small</p>
   </li>
-  <li>
-    <i class="sage-icon-microphone" aria-hidden="true"></i>
-    <p>sage-icon-microphone</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-microphone"></i>
+    <p class="sage-icon__label">sage-icon-microphone</p>
   </li>
-  <li>
-    <i class="sage-icon-microphone-off" aria-hidden="true"></i>
-    <p>sage-icon-microphone-off</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-microphone-off"></i>
+    <p class="sage-icon__label">sage-icon-microphone-off</p>
   </li>
-  <li>
-    <i class="sage-icon-video-on" aria-hidden="true"></i>
-    <p>sage-icon-video-on</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-video-on"></i>
+    <p class="sage-icon__label">sage-icon-video-on</p>
   </li>
-  <li>
-    <i class="sage-icon-video-off" aria-hidden="true"></i>
-    <p>sage-icon-video-off</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-video-off"></i>
+    <p class="sage-icon__label">sage-icon-video-off</p>
   </li>
-  <li>
-    <i class="sage-icon-screen-share-on" aria-hidden="true"></i>
-    <p>sage-icon-screen-share-on</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-screen-share-on"></i>
+    <p class="sage-icon__label">sage-icon-screen-share-on</p>
   </li>
-  <li>
-    <i class="sage-icon-screen-share-off" aria-hidden="true"></i>
-    <p>sage-icon-screen-share-off</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-screen-share-off"></i>
+    <p class="sage-icon__label">sage-icon-screen-share-off</p>
   </li>
-  <li>
-    <i class="sage-icon-play" aria-hidden="true"></i>
-    <p>sage-icon-play</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-play"></i>
+    <p class="sage-icon__label">sage-icon-play</p>
   </li>
-  <li>
-    <i class="sage-icon-stop" aria-hidden="true"></i>
-    <p>sage-icon-stop</p>
+  <li class="sage-icon__example">
+    <i class="sage-icon__glyph sage-icon-stop"></i>
+    <p class="sage-icon__label">sage-icon-stop</p>
   </li>
 </ul>
 </div>

--- a/lib/generators/sage_element/templates/style.scss
+++ b/lib/generators/sage_element/templates/style.scss
@@ -2,13 +2,8 @@
   ** <%= file_name %>
   type: element
 
-
-
 ================================================== */
 
 .sage-<%= file_name %> {
-
-  @media (max-width: sage-breakpoint()) {
-    /* <%= file_name %> responsive styles */
-  }
+  // Styles here
 }

--- a/lib/generators/sage_object/templates/style.scss
+++ b/lib/generators/sage_object/templates/style.scss
@@ -2,14 +2,8 @@
   ** <%= file_name %>
   type: object
 
-
-
 ================================================== */
 
 .sage-<%= file_name %> {
-
-  @media (max-width: sage-breakpoint()) {
-    /* <%= file_name %> responsive styles */
-
-  }
+  // Styles here
 }

--- a/lib/generators/sage_token/templates/style.scss
+++ b/lib/generators/sage_token/templates/style.scss
@@ -2,9 +2,7 @@
   ** <%= file_name %>
   type: token
 
-
 ================================================== */
-// TODO: refactor function block to avoid bypassing stylelint
 
 /* stylelint-disable */
 @function sage-<%= file_name %>($key: default) {

--- a/lib/generators/sage_utility/templates/style.scss
+++ b/lib/generators/sage_utility/templates/style.scss
@@ -2,14 +2,8 @@
   ** <%= file_name %>
   type: utility
 
-
-
 ================================================== */
 
 .sage-<%= file_name %> {
-
-  @media (max-width: sage-breakpoint()) {
-    /* <%= file_name %> responsive styles */
-
-  }
+  // Styles here
 }


### PR DESCRIPTION
## Description
Bunch of cleanup changes, primarily moving things around and flattening nested styles.

- Cleans up generated CSS file comment styles
- Fixes various stylelint alerts
  - down to 6 warnings from the previous 40+ (`npm run stylelint` in CLI)
  - `_colors.scss` to be addressed separately (#165)
  -  `_form_section.scss` will need additional work once this component is finalized
- Refactors grid column CSS iterator
- Adds class to hide columns, e.g. `.sage-col--md-hide`

## Related issues
- Resolves #107 
