### PR TITLE
Tighten icon use and documentation.

### DIFF
--- a/app/assets/stylesheets/sage/system/core/_mixins.scss
+++ b/app/assets/stylesheets/sage/system/core/_mixins.scss
@@ -117,7 +117,9 @@
   Sets up an element to implement the sage icon font and basic settings related
   to displaying the icon. Usually implemented on a pseudo-element.
 
-  If an `$icon` is passed in this mixin also
+  If an `$icon` is passed in this mixin also displays the icon as content for the
+  element. 
+  
   arguments: $icon | null|[string]
 ================================================== */
 

--- a/app/views/sage/examples/objects/live_user_control/_preview.html.erb
+++ b/app/views/sage/examples/objects/live_user_control/_preview.html.erb
@@ -1,11 +1,9 @@
 <!-- Showing default/active state -->
 <button class="sage-live-user-control">
-  <i class="sage-live-user-control__icon sage-icon-video-on"></i>
-  <span class="visually-hidden">Toggle Camera</span>
+  <i class="sage-live-user-control__icon sage-icon-video-on" aria-label="Toggle Camera"></i>
 </button>
 
 <!-- Showing inactive state -->
 <button class="sage-live-user-control sage-live-user-control--inactive">
-  <i class="sage-live-user-control__icon sage-icon-microphone-off"></i>
-  <span class="visually-hidden">Toggle Microphone</span>
+  <i class="sage-live-user-control__icon sage-icon-microphone-off" aria-label="Toggle Microphone"></i>
 </button>

--- a/app/views/sage/examples/objects/page_heading/_preview.html.erb
+++ b/app/views/sage/examples/objects/page_heading/_preview.html.erb
@@ -1,6 +1,6 @@
 <div class="sage-page-heading">
   <a href="#" class="sage-page-heading__back">
-    <i class="sage-page-heading__icon sage-icon-caret-left"></i> 
+    <i class="sage-page-heading__icon sage-icon-caret-left" aria-hidden="true"></i> 
     Back To Something
   </a>
   <h1 class="sage-page-heading__title">Page Title</h1>

--- a/app/views/sage/pages/icon.html.erb
+++ b/app/views/sage/pages/icon.html.erb
@@ -1,295 +1,306 @@
 <%= render "sidebar_styles" %>
 <%= content_for :heading do %>
 <h1>Icons</h1>
+<p>
+  Our icon set includes those shown below. The typical pattern for 
+  these is to use an <code>&lt;i&gt;</code> tag with a class as indicated below.
+</p>
+<p>
+  Note as well for accessibility that if the icon should have an 
+  <code>aria-label</code> attribute that describes the icon's 
+  purpose in context. However, if the icon is immediately surrounded by 
+  text that describes the icon, such as where the icon is purely decorative 
+  then <code>aria-hidden="true"</code> can be used instead.
+</p>
 <% end %>
 <div class="sage-panel">
 <ul class="sage-icon__wrapper">
   <li>
-    <i class="sage-icon-menu"></i>
+    <i class="sage-icon-menu" aria-hidden="true"></i>
     <p>sage-icon-menu</p>
   </li>
   <li>
-    <i class="sage-icon-launch"></i>
+    <i class="sage-icon-launch" aria-hidden="true"></i>
     <p>sage-icon-launch</p>
   </li>
   <li>
-    <i class="sage-icon-search"></i>
+    <i class="sage-icon-search" aria-hidden="true"></i>
     <p>sage-icon-search</p>
   </li>
   <li>
-    <i class="sage-icon-monitor"></i>
+    <i class="sage-icon-monitor" aria-hidden="true"></i>
     <p>sage-icon-monitor</p>
   </li>
   <li>
-    <i class="sage-icon-tag"></i>
+    <i class="sage-icon-tag" aria-hidden="true"></i>
     <p>sage-icon-tag</p>
   </li>
   <li>
-    <i class="sage-icon-megaphone"></i>
+    <i class="sage-icon-megaphone" aria-hidden="true"></i>
     <p>sage-icon-megaphone</p>
   </li>
   <li>
-    <i class="sage-icon-user-circle"></i>
+    <i class="sage-icon-user-circle" aria-hidden="true"></i>
     <p>sage-icon-user-circle</p>
   </li>
   <li>
-    <i class="sage-icon-gear"></i>
+    <i class="sage-icon-gear" aria-hidden="true"></i>
     <p>sage-icon-gear</p>
   </li>
   <li>
-    <i class="sage-icon-pen"></i>
+    <i class="sage-icon-pen" aria-hidden="true"></i>
     <p>sage-icon-pen</p>
   </li>
   <li>
-    <i class="sage-icon-file"></i>
+    <i class="sage-icon-file" aria-hidden="true"></i>
     <p>sage-icon-file</p>
   </li>
   <li>
-    <i class="sage-icon-image"></i>
+    <i class="sage-icon-image" aria-hidden="true"></i>
     <p>sage-icon-image</p>
   </li>
   <li>
-    <i class="sage-icon-folder"></i>
+    <i class="sage-icon-folder" aria-hidden="true"></i>
     <p>sage-icon-folder</p>
   </li>
   <li>
-    <i class="sage-icon-users"></i>
+    <i class="sage-icon-users" aria-hidden="true"></i>
     <p>sage-icon-users</p>
   </li>
   <li>
-    <i class="sage-icon-chart"></i>
+    <i class="sage-icon-chart" aria-hidden="true"></i>
     <p>sage-icon-chart</p>
   </li>
   <li>
-    <i class="sage-icon-preview-on"></i>
+    <i class="sage-icon-preview-on" aria-hidden="true"></i>
     <p>sage-icon-preview-on</p>
   </li>
   <li>
-    <i class="sage-icon-preview-off"></i>
+    <i class="sage-icon-preview-off" aria-hidden="true"></i>
     <p>sage-icon-preview-off</p>
   </li>
   <li>
-    <i class="sage-icon-comment"></i>
+    <i class="sage-icon-comment" aria-hidden="true"></i>
     <p>sage-icon-comment</p>
   </li>
   <li>
-    <i class="sage-icon-conversation"></i>
+    <i class="sage-icon-conversation" aria-hidden="true"></i>
     <p>sage-icon-conversation</p>
   </li>
   <li>
-    <i class="sage-icon-add"></i>
+    <i class="sage-icon-add" aria-hidden="true"></i>
     <p>sage-icon-add</p>
   </li>
   <li>
-    <i class="sage-icon-remove"></i>
+    <i class="sage-icon-remove" aria-hidden="true"></i>
     <p>sage-icon-remove</p>
   </li>
   <li>
-    <i class="sage-icon-3-dot-menu"></i>
+    <i class="sage-icon-3-dot-menu" aria-hidden="true"></i>
     <p>sage-icon-3-dot-menu</p>
   </li>
   <li>
-    <i class="sage-icon-url"></i>
+    <i class="sage-icon-url" aria-hidden="true"></i>
     <p>sage-icon-url</p>
   </li>
   <li>
-    <i class="sage-icon-trash"></i>
+    <i class="sage-icon-trash" aria-hidden="true"></i>
     <p>sage-icon-trash</p>
   </li>
   <li>
-    <i class="sage-icon-cart"></i>
+    <i class="sage-icon-cart" aria-hidden="true"></i>
     <p>sage-icon-cart</p>
   </li>
   <li>
-    <i class="sage-icon-delete-key"></i>
+    <i class="sage-icon-delete-key" aria-hidden="true"></i>
     <p>sage-icon-delete-key</p>
   </li>
   <li>
-    <i class="sage-icon-delete-x"></i>
+    <i class="sage-icon-delete-x" aria-hidden="true"></i>
     <p>sage-icon-delete-x</p>
   </li>
   <li>
-    <i class="sage-icon-send-message"></i>
+    <i class="sage-icon-send-message" aria-hidden="true"></i>
     <p>sage-icon-send-message</p>
   </li>
   <li>
-    <i class="sage-icon-mail"></i>
+    <i class="sage-icon-mail" aria-hidden="true"></i>
     <p>sage-icon-mail</p>
   </li>
   <li>
-    <i class="sage-icon-loop"></i>
+    <i class="sage-icon-loop" aria-hidden="true"></i>
     <p>sage-icon-loop</p>
   </li>
   <li>
-    <i class="sage-icon-restore"></i>
+    <i class="sage-icon-restore" aria-hidden="true"></i>
     <p>sage-icon-restore</p>
   </li>
   <li>
-    <i class="sage-icon-clock"></i>
+    <i class="sage-icon-clock" aria-hidden="true"></i>
     <p>sage-icon-clock</p>
   </li>
   <li>
-    <i class="sage-icon-calendar-date"></i>
+    <i class="sage-icon-calendar-date" aria-hidden="true"></i>
     <p>sage-icon-calendar-date</p>
   </li>
   <li>
-    <i class="sage-icon-calendar-schedule"></i>
+    <i class="sage-icon-calendar-schedule" aria-hidden="true"></i>
     <p>sage-icon-calendar-schedule</p>
   </li>
   <li>
-    <i class="sage-icon-drop"></i>
+    <i class="sage-icon-drop" aria-hidden="true"></i>
     <p>sage-icon-drop</p>
   </li>
   <li>
-    <i class="sage-icon-lock"></i>
+    <i class="sage-icon-lock" aria-hidden="true"></i>
     <p>sage-icon-lock</p>
   </li>
   <li>
-    <i class="sage-icon-user"></i>
+    <i class="sage-icon-user" aria-hidden="true"></i>
     <p>sage-icon-user</p>
   </li>
   <li>
-    <i class="sage-icon-user-star"></i>
+    <i class="sage-icon-user-star" aria-hidden="true"></i>
     <p>sage-icon-user-star</p>
   </li>
   <li>
-    <i class="sage-icon-favorite"></i>
+    <i class="sage-icon-favorite" aria-hidden="true"></i>
     <p>sage-icon-favorite</p>
   </li>
   <li>
-    <i class="sage-icon-star"></i>
+    <i class="sage-icon-star" aria-hidden="true"></i>
     <p>sage-icon-star</p>
   </li>
   <li>
-    <i class="sage-icon-check"></i>
+    <i class="sage-icon-check" aria-hidden="true"></i>
     <p>sage-icon-check</p>
   </li>
   <li>
-    <i class="sage-icon-check-circle"></i>
+    <i class="sage-icon-check-circle" aria-hidden="true"></i>
     <p>sage-icon-check-circle</p>
   </li>
   <li>
-    <i class="sage-icon-remove-circle"></i>
+    <i class="sage-icon-remove-circle" aria-hidden="true"></i>
     <p>sage-icon-remove-circle</p>
   </li>
   <li>
-    <i class="sage-icon-add-circle"></i>
+    <i class="sage-icon-add-circle" aria-hidden="true"></i>
     <p>sage-icon-add-circle</p>
   </li>
   <li>
-    <i class="sage-icon-delete-circle"></i>
+    <i class="sage-icon-delete-circle" aria-hidden="true"></i>
     <p>sage-icon-delete-circle</p>
   </li>
   <li>
-    <i class="sage-icon-info-circle"></i>
+    <i class="sage-icon-info-circle" aria-hidden="true"></i>
     <p>sage-icon-info-circle</p>
   </li>
   <li>
-    <i class="sage-icon-question-circle"></i>
+    <i class="sage-icon-question-circle" aria-hidden="true"></i>
     <p>sage-icon-question-circle</p>
   </li>
   <li>
-    <i class="sage-icon-warning"></i>
+    <i class="sage-icon-warning" aria-hidden="true"></i>
     <p>sage-icon-warning</p>
   </li>
   <li>
-    <i class="sage-icon-download"></i>
+    <i class="sage-icon-download" aria-hidden="true"></i>
     <p>sage-icon-download</p>
   </li>
   <li>
-    <i class="sage-icon-enlarge-vertical"></i>
+    <i class="sage-icon-enlarge-vertical" aria-hidden="true"></i>
     <p>sage-icon-enlarge-vertical</p>
   </li>
   <li>
-    <i class="sage-icon-enlarge"></i>
+    <i class="sage-icon-enlarge" aria-hidden="true"></i>
     <p>sage-icon-enlarge</p>
   </li>
   <li>
-    <i class="sage-icon-arrow-up"></i>
+    <i class="sage-icon-arrow-up" aria-hidden="true"></i>
     <p>sage-icon-arrow-up</p>
   </li>
   <li>
-    <i class="sage-icon-arrow-right"></i>
+    <i class="sage-icon-arrow-right" aria-hidden="true"></i>
     <p>sage-icon-arrow-right</p>
   </li>
   <li>
-    <i class="sage-icon-arrow-left"></i>
+    <i class="sage-icon-arrow-left" aria-hidden="true"></i>
     <p>sage-icon-arrow-left</p>
   </li>
   <li>
-    <i class="sage-icon-arrow-down"></i>
+    <i class="sage-icon-arrow-down" aria-hidden="true"></i>
     <p>sage-icon-arrow-down</p>
   </li>
   <li>
-    <i class="sage-icon-caret-up"></i>
+    <i class="sage-icon-caret-up" aria-hidden="true"></i>
     <p>sage-icon-caret-up</p>
   </li>
   <li>
-    <i class="sage-icon-caret-right"></i>
+    <i class="sage-icon-caret-right" aria-hidden="true"></i>
     <p>sage-icon-caret-right</p>
   </li>
   <li>
-    <i class="sage-icon-caret-down"></i>
+    <i class="sage-icon-caret-down" aria-hidden="true"></i>
     <p>sage-icon-caret-down</p>
   </li>
   <li>
-    <i class="sage-icon-caret-left"></i>
+    <i class="sage-icon-caret-left" aria-hidden="true"></i>
     <p>sage-icon-caret-left</p>
   </li>
   <li>
-    <i class="sage-icon-search-small"></i>
+    <i class="sage-icon-search-small" aria-hidden="true"></i>
     <p>sage-icon-search-small</p>
   </li>
   <li>
-    <i class="sage-icon-add-small"></i>
+    <i class="sage-icon-add-small" aria-hidden="true"></i>
     <p>sage-icon-add-small</p>
   </li>
   <li>
-    <i class="sage-icon-up-small"></i>
+    <i class="sage-icon-up-small" aria-hidden="true"></i>
     <p>sage-icon-up-small</p>
   </li>
   <li>
-    <i class="sage-icon-right-small"></i>
+    <i class="sage-icon-right-small" aria-hidden="true"></i>
     <p>sage-icon-right-small</p>
   </li>
   <li>
-    <i class="sage-icon-down-small"></i>
+    <i class="sage-icon-down-small" aria-hidden="true"></i>
     <p>sage-icon-down-small</p>
   </li>
   <li>
-    <i class="sage-icon-left-small"></i>
+    <i class="sage-icon-left-small" aria-hidden="true"></i>
     <p>sage-icon-left-small</p>
   </li>
   <li>
-    <i class="sage-icon-microphone"></i>
+    <i class="sage-icon-microphone" aria-hidden="true"></i>
     <p>sage-icon-microphone</p>
   </li>
   <li>
-    <i class="sage-icon-microphone-off"></i>
+    <i class="sage-icon-microphone-off" aria-hidden="true"></i>
     <p>sage-icon-microphone-off</p>
   </li>
   <li>
-    <i class="sage-icon-video-on"></i>
+    <i class="sage-icon-video-on" aria-hidden="true"></i>
     <p>sage-icon-video-on</p>
   </li>
   <li>
-    <i class="sage-icon-video-off"></i>
+    <i class="sage-icon-video-off" aria-hidden="true"></i>
     <p>sage-icon-video-off</p>
   </li>
   <li>
-    <i class="sage-icon-screen-share-on"></i>
+    <i class="sage-icon-screen-share-on" aria-hidden="true"></i>
     <p>sage-icon-screen-share-on</p>
   </li>
   <li>
-    <i class="sage-icon-screen-share-off"></i>
+    <i class="sage-icon-screen-share-off" aria-hidden="true"></i>
     <p>sage-icon-screen-share-off</p>
   </li>
   <li>
-    <i class="sage-icon-play"></i>
+    <i class="sage-icon-play" aria-hidden="true"></i>
     <p>sage-icon-play</p>
   </li>
   <li>
-    <i class="sage-icon-stop"></i>
+    <i class="sage-icon-stop" aria-hidden="true"></i>
     <p>sage-icon-stop</p>
   </li>
 </ul>


### PR DESCRIPTION
Closes #156 

- [x] Audit and improve use of `sage-icon-` to include a11y attributes.
- [x] Improve documentation regarding use of these attributes.