### PR TITLE
Sage.init()

### DIFF
--- a/app/assets/javascripts/sage/sage_system.js
+++ b/app/assets/javascripts/sage/sage_system.js
@@ -5,26 +5,4 @@
 //= require sage/system/sidebar
 //= require sage/system/overlay
 
-
-// Conditional routing
-// NOTE: modules must be imported above to be initialized below
-(function() {
-  // Tooltips
-  if (document.querySelector('[data-tooltip]') !== null) {
-    Sage.tooltip();
-  }
-
-  // Sidebar
-  if (document.querySelector('.sage-sidebar') !== null) {
-    Sage.sidebar.init();
-  }
-
-  // Overlay
-  if (document.querySelector('.sage-overlay') !== null) {
-    Sage.overlay.init();
-  }
-
-
-})();
-
-
+//= require sage/system/init

--- a/app/assets/javascripts/sage/system/init.js
+++ b/app/assets/javascripts/sage/system/init.js
@@ -1,0 +1,20 @@
+Sage.init = function(elementNamesToInit) {
+  var shouldInit = function(elementName, selector) {
+    return elementNamesToInit.contains(elementName) && document.querySelector(selector) !== null;
+  };
+
+  // Initialize Tooltip
+  if ( shouldInit('tooltip', '[data-tooltip]') ) {
+    Sage.tooltip();
+  }
+
+  // Initialize Sidebar
+  if ( shouldInit('sidebar', '.sage-sidebar') ) {
+    Sage.sidebar.init();
+  }
+
+  // Initialize Overlay
+  if ( shouldInit('overlay', '.sage-overlay') ) {
+    Sage.overlay.init();
+  }
+}

--- a/app/views/layouts/sage/application.html.erb
+++ b/app/views/layouts/sage/application.html.erb
@@ -1,11 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Sage</title>
     <%= render "meta" %>
-    <%= stylesheet_link_tag "sage/sage_system", media: "all" %>
-    <%= stylesheet_link_tag "sage/sage_docs", media: "all" %>
-    <%= csrf_meta_tags %>
+    <%= render "styles" %>
   </head>
   <body class="sage-page sage-docs">
     <header class="sage-header">
@@ -30,8 +27,6 @@
       </div>
       <div class="sage-overlay" aria-hidden="true"></div>
     </div>
-    <script src="//cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
-    <%= javascript_include_tag "sage/sage_system", :cache => true %>
-    <%= javascript_include_tag "sage/sage_docs", :cache => true %>
+    <%= render "scripts" %>
   </body>
 </html>

--- a/app/views/layouts/sage/breakout.html.erb
+++ b/app/views/layouts/sage/breakout.html.erb
@@ -1,11 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Sage | <%= @title.titleize %></title>
     <%= render "meta" %>
-    <%= stylesheet_link_tag "sage/sage_system", media: "all" %>
-    <%= stylesheet_link_tag "sage/sage_docs", media: "all" %>
-    <%= csrf_meta_tags %>
+    <%= render "styles" %>
   </head>
   <body class="sage-page">
     <div class="sage-stage">
@@ -18,8 +15,6 @@
       </div>
     </div>
     <div class="sage-overlay" aria-hidden="true"></div>
-    <script src="//cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
-    <%= javascript_include_tag "sage/sage_system", :cache => true %>
-    <%= javascript_include_tag "sage/sage_docs", :cache => true %>
+    <%= render "scripts" %>
   </body>
 </html>

--- a/app/views/sage/application/_meta.html.erb
+++ b/app/views/sage/application/_meta.html.erb
@@ -1,6 +1,12 @@
+<title>
+  <%= defined?(@title) ? "Sage | #{@title.titleize}" : "Sage Design System" %>
+</title>
+
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <%= favicon_link_tag "sage/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180", type: "image/png" %>
 <%= favicon_link_tag "sage/favicon-32x32.png", rel: "icon", sizes: "32x32", type: "image/png" %>
 <%= favicon_link_tag "sage/favicon-16x16.png", rel: "icon", sizes: "16x16", type: "image/png" %>
 <%= favicon_link_tag "sage/favicon.ico", rel: "icon", type: "image/x-icon" %>
+
+<%= csrf_meta_tags %>

--- a/app/views/sage/application/_scripts.html.erb
+++ b/app/views/sage/application/_scripts.html.erb
@@ -1,0 +1,13 @@
+<%= javascript_include_tag "//cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js", cache: true %>
+<%= javascript_include_tag "sage/sage_system", cache: true %>
+<%= javascript_include_tag "sage/sage_docs", cache: true %>
+
+<script type="text/javascript">
+  window.addEventListener("DOMContentLoaded", function(){
+    Sage.init(
+      'tooltip',
+      'sidebar',
+      'overlay'
+    );
+  });
+</script>

--- a/app/views/sage/application/_styles.html.erb
+++ b/app/views/sage/application/_styles.html.erb
@@ -1,0 +1,2 @@
+<%= stylesheet_link_tag "sage/sage_system", media: "all" %>
+<%= stylesheet_link_tag "sage/sage_docs", media: "all" %>


### PR DESCRIPTION
### What this includes:
- DRY up Rails layouts (including partial includes for scripts & styles)
- Require explicit initialization for each Sage element script
  - This allows us to control script initialization individually on the `kajabi-products` side in the event a script:
    - is causing errors
    - is still in development
    - a smaller selection is needed for a specific `kajabi-products` view
    - a script is only required for the documentation side