### PR TITLE
Clean up `_colors.scss` CSS

### DIFF
--- a/app/assets/stylesheets/sage/docs/_colors.scss
+++ b/app/assets/stylesheets/sage/docs/_colors.scss
@@ -13,8 +13,8 @@
 %color {
   padding: sage-spacing(sm) sage-spacing();
   font-size: sage-font-size(sm);
-  font-weight: sage-font-weight(simibold);
-  color: #fff;
+  font-weight: sage-font-weight(semibold);
+  color: sage-color(white);
 
   &::after {
     float: right;
@@ -30,7 +30,11 @@
           @extend %color;
           background: $hex;
 
-          @if (lightness($hex) > 50) {
+          @if (($name == grey) or ($name == white)) {
+            color: sage-color(charcoal, 500);
+          }
+
+          @else if (lightness($hex) > 50) {
             color: sage-color($name, 500);
           }
 
@@ -41,38 +45,16 @@
       }
     }
   }
+}
 
-  &-grey {
-    &-100,
-    &-200,
-    &-300,
-    &-400,
-    &-500 {
-      color: sage-color(charcoal, 500);
-    }
-  }
+[class^="color-white-"] {
+  box-shadow: inset 0 0 rem(1px) sage-color(charcoal);
+}
 
-  &-white {
-    &-100,
-    &-200,
-    &-300,
-    &-400,
-    &-500 {
-      color: sage-color(charcoal, 500);
-      box-shadow: inset 0 0 1px sage-color(charcoal);
-      border-radius: sage-border(radius);
-    }
-  }
+[class^="color-black-"] {
+  color: sage-color(white);
+}
 
-  &-black {
-    &-100,
-    &-200,
-    &-300,
-    &-400,
-    &-500 {
-      color: sage-color(white);
-      box-shadow: inset 0 0 1px sage-color(charcoal);
-      border-radius: sage-border(radius);
-    }
-  }
+[class^="color-"]:only-child {
+  border-radius: sage-border(radius);
 }

--- a/app/assets/stylesheets/sage/docs/_colors.scss
+++ b/app/assets/stylesheets/sage/docs/_colors.scss
@@ -4,57 +4,76 @@
   For Sage documentation use
 ================================================== */
 
+// ==================================================
+// MIXINS
+// ==================================================
+
+@mixin color-block-output {
+  padding: sage-spacing(sm) sage-spacing();
+  font-size: sage-font-size(sm);
+  color: sage-color(white);
+
+  &::after {
+    text-transform: uppercase;
+  }
+}
+
+@mixin generate-color-tones($color, $tone, $hex) {
+  &-#{$tone} {
+    @include color-block-output();
+    background: $hex;
+
+    @if (($color == grey) or ($color == white)) {
+      color: sage-color(charcoal, 500);
+    }
+
+    @else if (lightness($hex) > 60) {
+      color: sage-color($color, 500);
+    }
+
+    &::after {
+      content: "#{$hex}";
+      padding-left: sage-spacing(xs);
+      font-weight: sage-font-weight(semibold);
+    }
+  }
+}
+
+// color block groupings
 .colors {
   overflow: hidden;
   margin-bottom: sage-spacing();
   border-radius: sage-border(radius);
 }
 
-%color {
-  padding: sage-spacing(sm) sage-spacing();
-  font-size: sage-font-size(sm);
-  font-weight: sage-font-weight(semibold);
-  color: sage-color(white);
+.colors__block {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: space-between;
 
-  &::after {
-    float: right;
-    text-transform: uppercase;
+  @media screen and (min-width: sage-breakpoint(lg-min)) {
+    flex-direction: row;
   }
 }
 
-.color {
-  @each $name, $color in $sage-colors {
-    &-#{$name} {
-      @each $tone, $hex in $color {
-        &-#{$tone} {
-          @extend %color;
-          background: $hex;
-
-          @if (($name == grey) or ($name == white)) {
-            color: sage-color(charcoal, 500);
-          }
-
-          @else if (lightness($hex) > 50) {
-            color: sage-color($name, 500);
-          }
-
-          &::after {
-            content: "#{$hex}";
-          }
-        }
-      }
+// build individual color blocks
+@each $name, $color in $sage-colors {
+  .color-#{$name} {
+    @each $tone, $hex in $color {
+      @include generate-color-tones($name, $tone, $hex);
     }
   }
 }
 
-[class^="color-white-"] {
+[class*="color-"]:only-child {
+  border-radius: sage-border(radius);
+}
+
+[class*="color-white-"] {
   box-shadow: inset 0 0 rem(1px) sage-color(charcoal);
 }
 
-[class^="color-black-"] {
+[class*="color-black-"] {
   color: sage-color(white);
-}
-
-[class^="color-"]:only-child {
-  border-radius: sage-border(radius);
 }

--- a/app/views/sage/pages/_color_values.html.erb
+++ b/app/views/sage/pages/_color_values.html.erb
@@ -1,8 +1,8 @@
 <div class="colors">
-  <div class="color-<%= color %>-300">sage-color(<%= color %>)</div>
+  <div class="colors__block color-<%= color %>-300">sage-color(<%= color %>)</div>
 </div>
 <div class="colors">
   <% (1..5).each do |i| %>
-    <div class="color-<%= color %>-<%= i %>00">sage-color(<%= color %>, <%= i %>00)</div>
+    <div class="colors__block color-<%= color %>-<%= i %>00">sage-color(<%= color %>, <%= i %>00)</div>
   <% end %>
 </div>

--- a/app/views/sage/pages/color.html.erb
+++ b/app/views/sage/pages/color.html.erb
@@ -94,14 +94,14 @@
       <div class="sage-col--md-6">
         <h3 id="white">White</h3>
         <div class="colors">
-          <div class="color-white-300">sage-color(white)</div>
+          <div class="colors__block color-white-300">sage-color(white)</div>
         </div>
         <div class="sage-type">
           <p>All values passed for white will return the same value.</p>
         </div>
         <h3 id="black">Black</h3>
         <div class="colors">
-          <div class="color-black-300">sage-color(black)</div>
+          <div class="colors__block color-black-300">sage-color(black)</div>
         </div>
         <div class="sage-type">
           <p>All values passed for black will return the same value.</p>


### PR DESCRIPTION
## Description
- Flattens nested structure of color output in documentation
- Fixes broken color display layout in small/medium viewports (see screenshot)
- Adjusts text color lightness detection

|  before   |  after  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/79171754-c1a44480-7da7-11ea-933a-3fd33ad5beea.png)|![after](https://user-images.githubusercontent.com/816579/79171765-c832bc00-7da7-11ea-9cdd-0b8a95fff777.png)|
