### PR TITLE
Remove default `sage-btn` margins

### DIFF
--- a/app/assets/stylesheets/sage/docs/_button.scss
+++ b/app/assets/stylesheets/sage/docs/_button.scss
@@ -8,6 +8,7 @@
 .sage-btn {
   .example__preview:not(.example__preview--page) & {
     margin-bottom: sage-spacing(sm);
-    margin-left: sage-spacing(xs);
+    margin-left: 0;
+    margin-right: sage-spacing(xs);
   }
 }

--- a/app/assets/stylesheets/sage/docs/_button.scss
+++ b/app/assets/stylesheets/sage/docs/_button.scss
@@ -6,8 +6,8 @@
 
 
 .sage-btn {
-  .example__preview & {
+  .example__preview:not(.example__preview--page) & {
     margin-bottom: sage-spacing(sm);
-    margin-left: sage-spacing(sm);
+    margin-left: sage-spacing(xs);
   }
 }

--- a/app/assets/stylesheets/sage/docs/_button.scss
+++ b/app/assets/stylesheets/sage/docs/_button.scss
@@ -1,0 +1,13 @@
+/* ==================================================
+  ** _button.scss
+
+  For Sage documentation use
+================================================== */
+
+
+.sage-btn {
+  .example__preview & {
+    margin-bottom: sage-spacing(sm);
+    margin-left: sage-spacing(sm);
+  }
+}

--- a/app/assets/stylesheets/sage/sage_docs.css.scss
+++ b/app/assets/stylesheets/sage/sage_docs.css.scss
@@ -45,6 +45,7 @@
 @import "docs/quick_links";
 @import "docs/token";
 @import "docs/example";
+@import "docs/button";
 @import "docs/sidebar";
 @import "docs/status_key";
 @import "docs/status_table";

--- a/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
@@ -96,10 +96,9 @@ input[type="search"] {
 }
 
 .sage-btn--small {
-  @extend %t-sage-body-small-med;
-
   padding-top: rem(9px); // add 1px to offset odd line-height #
   padding-bottom: sage-spacing(xs);
+  font-size: sage-font-size(sm);
 }
 
 .sage-btn--full-width {

--- a/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
@@ -68,12 +68,6 @@ input[type="search"] {
     opacity: 0;
   }
 
-  &:hover,
-  &:focus,
-  &:active {
-    color: sage-color(charcoal, 200);
-  }
-
   &:focus {
     box-shadow: $sage-btn-shadow-base;
     outline: none;
@@ -104,7 +98,7 @@ input[type="search"] {
 .sage-btn--small {
   @extend %t-sage-body-small-med;
 
-  padding-top: sage-spacing(xs);
+  padding-top: rem(9px); // add 1px to offset odd line-height #
   padding-bottom: sage-spacing(xs);
 }
 

--- a/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
@@ -249,6 +249,16 @@ input[type="search"] {
   }
 }
 
+.sage-btn--link {
+  box-shadow: none;
+
+  &:focus,
+  &:active,
+  &:hover {
+    box-shadow: none;
+  }
+}
+
 @mixin button-icon-generator($direction) {
   $right: null;
 

--- a/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
@@ -15,8 +15,7 @@
 
   position: relative;
   padding: rem(12px) sage-spacing(sm);
-  margin-bottom: sage-spacing(sm);
-  margin-right: sage-spacing(2xs);
+  margin-left: sage-spacing(2xs);
   letter-spacing: $sage-btn-letter-spacing;
   color: sage-color(charcoal, 500);
   border: 0;
@@ -49,9 +48,8 @@ input[type="search"] {
 .sage-btn {
   @include button-style-base;
 
-  // add space between adjacent buttons
-  + .sage-btn {
-    margin-left: sage-spacing(xs);
+  &:first-of-type {
+    margin-left: 0;
   }
 
   &::after {
@@ -101,6 +99,17 @@ input[type="search"] {
     color: sage-color(grey);
     background-color: sage-color(grey, 100);
   }
+}
+
+.sage-btn--small {
+  @extend %t-sage-body-small-med;
+
+  padding-top: sage-spacing(xs);
+  padding-bottom: sage-spacing(xs);
+}
+
+.sage-btn--full-width {
+  width: 100%;
 }
 
 .sage-btn--primary {

--- a/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_button.scss
@@ -96,7 +96,7 @@ input[type="search"] {
 }
 
 .sage-btn--small {
-  padding-top: rem(9px); // add 1px to offset odd line-height #
+  padding-top: calc(#{sage-spacing(xs)} + #{rem(1px)}); // adds 1px to offset odd line-height #
   padding-bottom: sage-spacing(xs);
   font-size: sage-font-size(sm);
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_banner.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_banner.scss
@@ -63,14 +63,3 @@ $-banner-colors: (
   text-decoration: none;
 }
 
-.sage-banner__close {
-  box-shadow: none;
-
-  &:focus,
-  &:active,
-  &:hover {
-    color: inherit;
-    box-shadow: none;
-  }
-}
-

--- a/app/assets/stylesheets/sage/system/patterns/objects/_banner.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_banner.scss
@@ -41,6 +41,7 @@ $-banner-colors: (
 .sage-banner__text {
   display: inline-flex;
   align-items: center;
+  margin-right: sage-spacing(xs);
   color: inherit;
 }
 
@@ -54,7 +55,6 @@ $-banner-colors: (
 
 .sage-banner__link,
 .sage-banner__close {
-  margin: 0 0 0 sage-spacing(2xs);
   color: inherit;
   text-decoration: underline;
 }
@@ -65,11 +65,7 @@ $-banner-colors: (
   }
 }
 
-.sage-banner__btn {
-  // TODO: may replace with new .sage-btn styles
-  padding: sage-spacing(xs) sage-spacing(sm);
-  font-size: sage-font-size(sm);
-  font-weight: inherit;
+.sage-banner__close {
   box-shadow: none;
 
   &:focus,
@@ -79,3 +75,4 @@ $-banner-colors: (
     box-shadow: none;
   }
 }
+

--- a/app/assets/stylesheets/sage/system/patterns/objects/_banner.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_banner.scss
@@ -59,10 +59,8 @@ $-banner-colors: (
   text-decoration: underline;
 }
 
-.sage-banner__link {
-  &.sage-banner__btn {
-    text-decoration: none;
-  }
+.sage-banner__link--btn {
+  text-decoration: none;
 }
 
 .sage-banner__close {

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -171,13 +171,13 @@ module Sage
         },
         {
           title: "button",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+          description: "Standard button styling with multiple display options. Can be applied on both button and link elements.",
           scss_design:  "done",
           scss_dev:     "done",
-          scss_doc:     "todo",
-          rails_design: "no",
-          rails_dev:    "no",
-          rails_doc:    "no",
+          scss_doc:     "done",
+          rails_design: "done",
+          rails_dev:    "done",
+          rails_doc:    "done",
           react_design: "no",
           react_dev:    "no",
           react_doc:    "no"

--- a/app/views/sage/examples/elements/button/_markup.html.erb
+++ b/app/views/sage/examples/elements/button/_markup.html.erb
@@ -1,0 +1,9 @@
+<% if is_link_btn %>
+  <a href=<%= link_url != "" ? link_url : "#" %> class="sage-btn<% if style_small %> sage-btn--small<% end %><% if style_primary %> sage-btn--primary <% elsif style_secondary %> sage-btn--secondary <% elsif style_tertiary %> sage-btn--tertiary <% end %><%= sage_icon_name %><% if is_disabled %> disabled<% end %>"<% if is_disabled %> aria-disabled="true"<%end%>>
+    <%= text -%>
+  </a>
+<% else %>
+  <button class="sage-btn<% if style_small %> sage-btn--small<% end %><% if style_primary %> sage-btn--primary <% elsif style_secondary %> sage-btn--secondary <% elsif style_tertiary %> sage-btn--tertiary <% end %> <%= sage_icon_name %>"<% if is_disabled %> disabled<%end%>>
+    <%= text -%>
+  </button>
+<% end %>

--- a/app/views/sage/examples/elements/button/_preview.html.erb
+++ b/app/views/sage/examples/elements/button/_preview.html.erb
@@ -1,65 +1,384 @@
 <h3 class="t-sage-heading-6">Primary</h3>
 
 <!-- Primary button -->
-<button class="sage-btn sage-btn--primary">Primary</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Primary button (link) -->
-<a href="#" class="sage-btn sage-btn--primary">Primary Link</a>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link",
+  is_link_btn: true,
+  link_url: "#element-button",
+  is_disabled: false,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Primary button (icon-left) -->
-<button class="sage-btn sage-btn--primary sage-btn--icon-left-menu">Primary (icon-left)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link (icon-left)",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: false,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-left-menu"
+%>
+
 <!-- Primary button (icon-right) -->
-<button class="sage-btn sage-btn--primary sage-btn--icon-right-add">Primary (icon-right)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button (icon-right)",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
 
 <br>
+<h3 class="t-sage-heading-6">Primary (disabled)</h3>
 
 <!-- Primary button (disabled) -->
-<button class="sage-btn sage-btn--primary" disabled>Primary</button>
-<!-- Primary button link (disabled) -->
-<a href="#" class="sage-btn sage-btn--primary disabled" aria-disabled="true">Primary Link</a>
-<!-- Primary button (icon-left, disabled) -->
-<button class="sage-btn sage-btn--primary sage-btn--icon-left-users" disabled>Primary (icon-left)</button>
-<!-- Primary button (icon-right, disabled) -->
-<button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" disabled>Primary (icon-right)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: true,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
 
+<!-- Primary button link (disabled) -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Button Link",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
+<!-- Primary button (icon-left, disabled) -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Button (icon-left)",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: true,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-left-users"
+%>
+
+<!-- Primary button (icon-right, disabled) -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Link (icon-right)",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-right-launch"
+%>
+
+<br><br>
 <h3 class="t-sage-heading-6">Secondary</h3>
 
 <!-- Secondary button -->
-<button class="sage-btn sage-btn--secondary">Secondary</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Secondary button (link) -->
-<a href="#" class="sage-btn sage-btn--secondary" role="button">Secondary Link</a>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Secondary button (icon-left) -->
-<button class="sage-btn sage-btn--secondary sage-btn--icon-left-gear">Secondary (icon-left)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button (icon-left)",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-left-gear"
+%>
+
 <!-- Secondary button (icon-right) -->
-<button class="sage-btn sage-btn--secondary sage-btn--icon-right-search">Secondary (icon-right)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link (icon-right)",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-right-search"
+%>
 
 <br>
+<h3 class="t-sage-heading-6">Secondary (disabled)</h3>
 
 <!-- Secondary button (disabled) -->
-<button class="sage-btn sage-btn--secondary" disabled>Secondary</button>
-<!-- Secondary button link (disabled) -->
-<a href="#" class="sage-btn sage-btn--secondary disabled" aria-disabled="true">Secondary Link</a>
-<!-- Secondary button (icon-left, disabled) -->
-<button class="sage-btn sage-btn--secondary sage-btn--icon-left-send-message" disabled>Secondary (icon-left)</button>
-<!-- Secondary button (icon-right, disabled) -->
-<button class="sage-btn sage-btn--secondary sage-btn--icon-right-arrow-right" disabled>Secondary (icon-right)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
 
+<!-- Secondary button link (disabled) -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Link",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
+<!-- Secondary button (icon-left, disabled) -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Link (icon-left)",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-left-send-message"
+%>
+
+<!-- Secondary button (icon-right, disabled) -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Button (icon-right)",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-right-arrow-right"
+%>
+
+<br><br>
 <h3 class="t-sage-heading-6">Tertiary</h3>
 
 <!-- Tertiary button -->
-<button class="sage-btn sage-btn--tertiary">Tertiary</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Tertiary button (link) -->
-<a href="#" class="sage-btn sage-btn--tertiary" role="button">Tertiary Link</a>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Tertiary button (icon-left) -->
-<button class="sage-btn sage-btn--tertiary sage-btn--icon-left-3-dot-menu">Tertiary (icon-left)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button (icon-left)",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-left-3-dot-menu"
+%>
+
 <!-- Tertiary button (icon-right) -->
-<button class="sage-btn sage-btn--tertiary sage-btn--icon-right-microphone">Tertiary (icon-right)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button (icon-right)",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-right-microphone"
+%>
 
 <br>
+<h3 class="t-sage-heading-6">Tertiary (disabled)</h3>
 
 <!-- Tertiary button disabled -->
-<button class="sage-btn sage-btn--tertiary" disabled>Tertiary</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Button",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Tertiary button link (disabled) -->
-<a href="#" class="sage-btn sage-btn--tertiary disabled" aria-disabled="true">Tertiary Link</a>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: ""
+%>
+
 <!-- Tertiary button (icon-left, disabled) -->
-<button class="sage-btn sage-btn--tertiary sage-btn--icon-left-comment" disabled>Tertiary (icon-left)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link (icon-left)",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-left-comment"
+%>
+
 <!-- Tertiary button (icon-right, disabled) -->
-<button class="sage-btn sage-btn--tertiary sage-btn--icon-right-preview-off" disabled>Tertiary (icon-right)</button>
+<%= render "sage/examples/elements/button/markup",
+  text: "Link (icon-right)",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: true,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: false,
+  sage_icon_name: "sage-btn--icon-right-preview-off"
+%>
+
+<br><br>
+<h3 class="t-sage-heading-6">Small</h3>
+
+<!-- Primary small -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Primary small",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: true,
+  sage_icon_name: ""
+%>
+
+
+<!-- Primary button small (disabled) -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Primary small",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: true,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_small: true,
+  sage_icon_name: ""
+%>
+
+<!-- Secondary small -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Secondary small link",
+  is_link_btn: true,
+  link_url: "#",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_small: true,
+  sage_icon_name: ""
+%>
+
+<!-- Tertiary small -->
+<%= render "sage/examples/elements/button/markup",
+  text: "Tertiary small",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_small: true,
+  sage_icon_name: ""
+%>

--- a/app/views/sage/examples/elements/button/_props.html.erb
+++ b/app/views/sage/examples/elements/button/_props.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td>Icon usage</td>
+  <td>Classnames dictate the icon positioning to the left or right of text. For example, `sage-btn--icon-left-gear` indicates that the "gear" icon will be displayed to the left. Reference the <a href="/sage/pages/icon" rel="nofollow">full list of icons</a> for naming.</td>
+  <td>String</td>
+  <td>null</td>
+</tr>

--- a/app/views/sage/examples/objects/banner/_markup.html.erb
+++ b/app/views/sage/examples/objects/banner/_markup.html.erb
@@ -8,10 +8,10 @@
     </p>
   <% end %>
   <% if link and link_url %>
-    <a href="<%= link_url %>" class="<% if link_is_button %>sage-btn sage-btn--secondary sage-banner__btn <% end %>sage-banner__link">
+    <a href="<%= link_url %>" class="<% if link_is_button %>sage-btn sage-btn--small sage-btn--secondary sage-banner__btn <% end %>sage-banner__link">
       <%= link_text != "" ? " #{link_text}" : "link" -%>
     </a>
   <% elsif dismissable %>
-    <button class="sage-btn sage-banner__btn sage-banner__close"><%= dismiss_text != "" ? " #{dismiss_text}" : "" %></button>
+    <button class="sage-btn sage-btn--small sage-banner__btn sage-banner__close"><%= dismiss_text != "" ? " #{dismiss_text}" : "" %></button>
   <% end %>
 </div>

--- a/app/views/sage/examples/objects/banner/_markup.html.erb
+++ b/app/views/sage/examples/objects/banner/_markup.html.erb
@@ -12,6 +12,6 @@
       <%= link_text != "" ? " #{link_text}" : "link" -%>
     </a>
   <% elsif dismissable %>
-    <button class="sage-btn sage-btn--small sage-banner__btn sage-banner__close"><%= dismiss_text != "" ? " #{dismiss_text}" : "" %></button>
+    <button class="sage-btn sage-btn--small sage-btn--link sage-banner__close"><%= dismiss_text != "" ? " #{dismiss_text}" : "" %></button>
   <% end %>
 </div>

--- a/app/views/sage/examples/objects/banner/_markup.html.erb
+++ b/app/views/sage/examples/objects/banner/_markup.html.erb
@@ -8,7 +8,7 @@
     </p>
   <% end %>
   <% if link and link_url %>
-    <a href="<%= link_url %>" class="<% if link_is_button %>sage-btn sage-btn--small sage-btn--secondary sage-banner__btn <% end %>sage-banner__link">
+    <a href="<%= link_url %>" class="sage-banner__link<% if link_is_button %> sage-btn sage-btn--small sage-btn--secondary sage-banner__link--btn<% end %>">
       <%= link_text != "" ? " #{link_text}" : "link" -%>
     </a>
   <% elsif dismissable %>


### PR DESCRIPTION
## Description
Base `.sage-btn` styles include bottom and right margin settings that should be scoped to specific use cases. For example, in Sage documentation and within specific modules.

When applied in the super admin, these margins push the buttons out of alignment with other inline elements.

- Addresses button sizing from #190
- Updates preview markup using includes

## Related issues
- Resolves #190 