### PR TITLE
Revise alert styling and documentation

### DIFF
--- a/app/assets/javascripts/sage/sage_system.js
+++ b/app/assets/javascripts/sage/sage_system.js
@@ -5,5 +5,6 @@
 //= require sage/system/sidebar
 //= require sage/system/overlay
 //= require sage/system/banner
+//= require sage/system/alert
 
 //= require sage/system/init

--- a/app/assets/javascripts/sage/system/alert.js
+++ b/app/assets/javascripts/sage/system/alert.js
@@ -11,7 +11,7 @@ Sage.alert = (function () {
 
   alertCloseBtns.forEach(function (btn) {
     var alert = btn.closest(".sage-alert");
-    btn.addEventListener("click", function (e) {
+    btn.addEventListener("click", function () {
       alert.style.display = "none";
     });
   });

--- a/app/assets/javascripts/sage/system/alert.js
+++ b/app/assets/javascripts/sage/system/alert.js
@@ -1,0 +1,24 @@
+Sage.alert = (function () {
+  // ==================================================
+  // Variables
+  // ==================================================
+
+  var alertCloseBtns = document.querySelectorAll(".sage-alert__close");
+
+  // ==================================================
+  // Functions
+  // ==================================================
+
+  alertCloseBtns.forEach(function (btn) {
+    var alert = btn.closest(".sage-alert");
+    btn.addEventListener("click", function (e) {
+      alert.style.display = "none";
+    });
+  });
+
+  function init() {}
+
+  return {
+    init: init,
+  };
+})();

--- a/app/assets/javascripts/sage/system/init.js
+++ b/app/assets/javascripts/sage/system/init.js
@@ -18,4 +18,9 @@ Sage.init = function(elementNamesToInit) {
     Sage.overlay.init();
   }
 
+   // Initialize Alert
+   if ( shouldInit('alert', '.sage-alert') ) {
+    Sage.alert.init();
+  }
+
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
@@ -12,6 +12,8 @@ $-alert-colors: (
 );
 
 .sage-alert {
+  display: flex;
+  position: relative;
   margin-bottom: sage-spacing();
   padding: sage-spacing();
   background: sage-color(gray, 200);
@@ -25,6 +27,16 @@ $-alert-colors: (
   .sage-alert--#{$name} {
     border-color: sage-color($color);
     background: sage-color($color, 100);
+  }
+}
+
+.sage-alert__icon {
+  transform: translateY(rem(2px));
+  margin-right: rem(16px);
+  @each $name, $color in $-alert-colors {
+    .sage-alert--#{$name} & {
+      color: sage-color($color, 300);
+    }
   }
 }
 

--- a/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
@@ -31,7 +31,7 @@ $-alert-colors: (
 }
 
 .sage-alert-copy {
-  padding-right: rem(16px);
+  padding-right: rem(26px);
 }
 
 .sage-alert__title {
@@ -70,9 +70,10 @@ $-alert-colors: (
   position: absolute;
   top: sage-spacing();
   right: sage-spacing();
-  height: 30px;
+  height: rem(27.65px);
+  width: rem(27.65px);
   padding: 0;
-  font-size: rem(28px);
+  font-size: sage-font-size(2xl);
   line-height: 1;
   background-color: transparent;
   border: 0;

--- a/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
@@ -23,10 +23,34 @@ $-alert-colors: (
   box-shadow: sage-shadow();
 }
 
+.sage-alert-copy {
+  padding-right: rem(16px);
+}
+
 @each $name, $color in $-alert-colors {
   .sage-alert--#{$name} {
     border-color: sage-color($color);
     background: sage-color($color, 100);
+  }
+}
+
+.sage-alert__title {
+  color: sage-color(charcoal, 500);
+  @extend %t-sage-body-semi;
+  @each $name, $color in $-alert-colors {
+    .sage-alert--#{$name} & {
+      color: sage-color($color, 500);
+    }
+  }
+}
+
+.sage-alert__desc {
+  color: sage-color(charcoal, 300);
+  @extend %t-sage-body-small;
+  @each $name, $color in $-alert-colors {
+    .sage-alert--#{$name} & {
+      color: sage-color($color, 400);
+    }
   }
 }
 
@@ -40,26 +64,23 @@ $-alert-colors: (
   }
 }
 
-.sage-alert__title {
-  color: sage-color(charcoal, 500);
-
-  @extend %t-sage-body-semi;
-
-  @each $name, $color in $-alert-colors {
-    .sage-alert--#{$name} & {
-      color: sage-color($color, 500);
-    }
-  }
-}
-
-.sage-alert__copy {
-  color: sage-color(charcoal, 300);
-
-  @extend %t-sage-body-small;
-
+.sage-alert__close {
+  transform: translateY(rem(-2px));
+  position: absolute;
+  top: sage-spacing();
+  right: sage-spacing();
+  padding: 0;
+  font-size: rem(28px);
+  line-height: 1;
+  background-color: transparent;
+  border: 0;
+  appearance: none;
   @each $name, $color in $-alert-colors {
     .sage-alert--#{$name} & {
       color: sage-color($color, 400);
     }
+  }
+  &:hover {
+    opacity: 0.7;
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
@@ -19,7 +19,6 @@ $-alert-colors: (
   background: sage-color(gray, 200);
   border-top: 4px solid;
   border-bottom-left-radius: sage-border(radius);
-  border-bottom-left-radius: sage-border(radius);
   box-shadow: sage-shadow();
 }
 

--- a/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
@@ -5,10 +5,10 @@
 ================================================== */
 
 $-alert-colors: (
-  primary: primary,
+  info: primary,
   success: sage,
   warning: yellow,
-  danger: red
+  danger: red,
 );
 
 .sage-alert {
@@ -23,15 +23,15 @@ $-alert-colors: (
   box-shadow: sage-shadow();
 }
 
-.sage-alert-copy {
-  padding-right: rem(16px);
-}
-
 @each $name, $color in $-alert-colors {
   .sage-alert--#{$name} {
     border-color: sage-color($color);
     background: sage-color($color, 100);
   }
+}
+
+.sage-alert-copy {
+  padding-right: rem(16px);
 }
 
 .sage-alert__title {
@@ -45,7 +45,7 @@ $-alert-colors: (
 }
 
 .sage-alert__desc {
-  color: sage-color(charcoal, 300);
+  color: sage-color(charcoal, 400);
   @extend %t-sage-body-small;
   @each $name, $color in $-alert-colors {
     .sage-alert--#{$name} & {
@@ -56,7 +56,8 @@ $-alert-colors: (
 
 .sage-alert__icon {
   transform: translateY(rem(2px));
-  margin-right: rem(16px);
+  margin: 0 rem(16px) 0 0;
+  color: sage-color(charcoal, 200);
   @each $name, $color in $-alert-colors {
     .sage-alert--#{$name} & {
       color: sage-color($color, 300);
@@ -65,11 +66,12 @@ $-alert-colors: (
 }
 
 .sage-alert__close {
-  transform: translateY(rem(-2px));
+  overflow: hidden;
   position: absolute;
-  top: 0;
-  right: 0;
-  padding: sage-spacing();
+  top: sage-spacing();
+  right: sage-spacing();
+  height: 30px;
+  padding: 0;
   font-size: rem(28px);
   line-height: 1;
   background-color: transparent;

--- a/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_alert.scss
@@ -67,9 +67,9 @@ $-alert-colors: (
 .sage-alert__close {
   transform: translateY(rem(-2px));
   position: absolute;
-  top: sage-spacing();
-  right: sage-spacing();
-  padding: 0;
+  top: 0;
+  right: 0;
+  padding: sage-spacing();
   font-size: rem(28px);
   line-height: 1;
   background-color: transparent;

--- a/app/views/sage/application/_scripts.html.erb
+++ b/app/views/sage/application/_scripts.html.erb
@@ -7,7 +7,8 @@
     Sage.init([
       'tooltip',
       'sidebar',
-      'overlay'
+      'overlay',
+      'alert'
     ]);
   });
 </script>

--- a/app/views/sage/examples/objects/alert/_markup.html.erb
+++ b/app/views/sage/examples/objects/alert/_markup.html.erb
@@ -1,0 +1,8 @@
+<div class="sage-alert<%= color != "" ? " sage-alert--#{color}" : "" %>">
+  <% if sage_icon_name != "" %><i class="sage-alert__icon <%= sage_icon_name %>" aria-hidden="true"></i><% end %>
+  <div class="sage-alert-copy">
+    <p class="sage-alert__title"><%= sage_alert_title %></p>
+    <p class="sage-alert__desc"><%= sage_alert_desc %></p>
+    <% if dismissable %><button type="button" class="sage-alert__close" aria-label="Close"><span aria-hidden="true">&times;</span></button><% end %>
+  </div>
+</div>

--- a/app/views/sage/examples/objects/alert/_markup.html.erb
+++ b/app/views/sage/examples/objects/alert/_markup.html.erb
@@ -1,8 +1,8 @@
 <div class="sage-alert<%= color != "" ? " sage-alert--#{color}" : "" %>">
-  <% if sage_icon_name != "" %><i class="sage-alert__icon <%= sage_icon_name %>" aria-hidden="true"></i><% end %>
+  <i class="sage-alert__icon <%= sage_icon_name %>" aria-hidden="true"></i>
   <div class="sage-alert-copy">
     <p class="sage-alert__title"><%= sage_alert_title %></p>
     <p class="sage-alert__desc"><%= sage_alert_desc %></p>
-    <% if dismissable %><button type="button" class="sage-alert__close" aria-label="Close"><span aria-hidden="true">&times;</span></button><% end %>
+    <button type="button" class="sage-alert__close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   </div>
 </div>

--- a/app/views/sage/examples/objects/alert/_markup.html.erb
+++ b/app/views/sage/examples/objects/alert/_markup.html.erb
@@ -1,7 +1,7 @@
 <div class="sage-alert<%= color != "" ? " sage-alert--#{color}" : "" %>">
   <i class="sage-alert__icon <%= sage_icon_name %>" aria-hidden="true"></i>
   <div class="sage-alert-copy">
-    <p class="sage-alert__title"><%= sage_alert_title %></p>
+    <h3 class="sage-alert__title"><%= sage_alert_title %></h3>
     <p class="sage-alert__desc"><%= sage_alert_desc %></p>
     <button type="button" class="sage-alert__close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   </div>

--- a/app/views/sage/examples/objects/alert/_preview.html.erb
+++ b/app/views/sage/examples/objects/alert/_preview.html.erb
@@ -3,38 +3,33 @@
   color: "",
   sage_icon_name: "sage-icon-info-circle",
   sage_alert_title: "Our privacy policy has changed",
-  sage_alert_desc: "Make sure you know how these changes affect you.",
-  dismissable: true
+  sage_alert_desc: "Make sure you know how these changes affect you."
 %>
 <!-- Info -->
 <%= render "sage/examples/objects/alert/markup",
   color: "info",
   sage_icon_name: "sage-icon-info-circle",
   sage_alert_title: "Our privacy policy has changed",
-  sage_alert_desc: "Make sure you know how these changes affect you.",
-  dismissable: true
+  sage_alert_desc: "Make sure you know how these changes affect you."
 %>
 <!-- Success -->
 <%= render "sage/examples/objects/alert/markup",
   color: "success",
-  sage_icon_name: "sage-icon-info-circle",
+  sage_icon_name: "sage-icon-check-circle",
   sage_alert_title: "Account settings updated",
-  sage_alert_desc: "Make sure you know how these changes affect you.",
-  dismissable: true
+  sage_alert_desc: "Make sure you know how these changes affect you."
 %>
 <!-- Warning -->
 <%= render "sage/examples/objects/alert/markup",
   color: "warning",
-  sage_icon_name: "sage-icon-info-circle",
+  sage_icon_name: "sage-icon-warning",
   sage_alert_title: "Exceeded product amount limit",
-  sage_alert_desc: "Make sure you know how these changes affect you.",
-  dismissable: true
+  sage_alert_desc: "Make sure you know how these changes affect you."
 %>
 <!-- Danger -->
 <%= render "sage/examples/objects/alert/markup",
   color: "danger",
-  sage_icon_name: "sage-icon-info-circle",
+  sage_icon_name: "sage-icon-warning",
   sage_alert_title: "App outage tonight at 12am",
-  sage_alert_desc: "Make sure you know how these changes affect you.",
-  dismissable: true
+  sage_alert_desc: "Make sure you know how these changes affect you."
 %>

--- a/app/views/sage/examples/objects/alert/_preview.html.erb
+++ b/app/views/sage/examples/objects/alert/_preview.html.erb
@@ -6,3 +6,39 @@
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
+
+<%= render "sage/examples/objects/alert/markup",
+  color: "primary",
+  content: "Another happy landing.",
+  sage_icon_name: "sage-icon-info-circle",
+  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_desc: "Make sure you know how these changes affect you.",
+  dismissable: true
+%>
+
+<%= render "sage/examples/objects/alert/markup",
+  color: "success",
+  content: "Another happy landing.",
+  sage_icon_name: "sage-icon-info-circle",
+  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_desc: "Make sure you know how these changes affect you.",
+  dismissable: true
+%>
+
+<%= render "sage/examples/objects/alert/markup",
+  color: "warning",
+  content: "Another happy landing.",
+  sage_icon_name: "sage-icon-info-circle",
+  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_desc: "Make sure you know how these changes affect you.",
+  dismissable: true
+%>
+
+<%= render "sage/examples/objects/alert/markup",
+  color: "danger",
+  content: "Another happy landing.",
+  sage_icon_name: "sage-icon-info-circle",
+  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_desc: "Make sure you know how these changes affect you.",
+  dismissable: true
+%>

--- a/app/views/sage/examples/objects/alert/_preview.html.erb
+++ b/app/views/sage/examples/objects/alert/_preview.html.erb
@@ -1,3 +1,4 @@
+<!-- Default -->
 <%= render "sage/examples/objects/alert/markup",
   color: "",
   content: "Another happy landing.",
@@ -6,7 +7,7 @@
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
-
+<!-- Primary -->
 <%= render "sage/examples/objects/alert/markup",
   color: "primary",
   content: "Another happy landing.",
@@ -15,7 +16,7 @@
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
-
+<!-- Success -->
 <%= render "sage/examples/objects/alert/markup",
   color: "success",
   content: "Another happy landing.",
@@ -24,7 +25,7 @@
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
-
+<!-- Warning -->
 <%= render "sage/examples/objects/alert/markup",
   color: "warning",
   content: "Another happy landing.",
@@ -33,7 +34,7 @@
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
-
+<!-- Danger -->
 <%= render "sage/examples/objects/alert/markup",
   color: "danger",
   content: "Another happy landing.",

--- a/app/views/sage/examples/objects/alert/_preview.html.erb
+++ b/app/views/sage/examples/objects/alert/_preview.html.erb
@@ -6,7 +6,7 @@
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
-<!-- Primary -->
+<!-- Info -->
 <%= render "sage/examples/objects/alert/markup",
   color: "info",
   sage_icon_name: "sage-icon-info-circle",

--- a/app/views/sage/examples/objects/alert/_preview.html.erb
+++ b/app/views/sage/examples/objects/alert/_preview.html.erb
@@ -1,25 +1,8 @@
-<!-- Default -->
-<div class="sage-alert">
-  <p class="sage-alert__title">Our privacy policy has changed</p>
-  <p class="sage-alert__copy">Make sure you know how these changes affect you.</p>
-</div>
-<!-- Primary -->
-<div class="sage-alert sage-alert--primary">
-  <p class="sage-alert__title">Our privacy policy has changed</p>
-  <p class="sage-alert__copy">Make sure you know how these changes affect you.</p>
-</div>
-<!-- Success -->
-<div class="sage-alert sage-alert--success">
-  <p class="sage-alert__title">Account settings updated</p>
-  <p class="sage-alert__copy">Make sure you know how these changes affect you.</p>
-</div>
-<!-- Warning -->
-<div class="sage-alert sage-alert--warning">
-  <p class="sage-alert__title">Exceeded product amount limit</p>
-  <p class="sage-alert__copy">Make sure you know how these changes affect you.</p>
-</div>
-<!-- Danger -->
-<div class="sage-alert sage-alert--danger">
-  <p class="sage-alert__title">App outage tonight at 12am</p>
-  <p class="sage-alert__copy">Make sure you know how these changes affect you.</p>
-</div>
+<%= render "sage/examples/objects/alert/markup",
+  color: "",
+  content: "Another happy landing.",
+  sage_icon_name: "sage-icon-info-circle",
+  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_desc: "Make sure you know how these changes affect you.",
+  dismissable: true
+%>

--- a/app/views/sage/examples/objects/alert/_preview.html.erb
+++ b/app/views/sage/examples/objects/alert/_preview.html.erb
@@ -1,7 +1,6 @@
 <!-- Default -->
 <%= render "sage/examples/objects/alert/markup",
   color: "",
-  content: "Another happy landing.",
   sage_icon_name: "sage-icon-info-circle",
   sage_alert_title: "Our privacy policy has changed",
   sage_alert_desc: "Make sure you know how these changes affect you.",
@@ -9,8 +8,7 @@
 %>
 <!-- Primary -->
 <%= render "sage/examples/objects/alert/markup",
-  color: "primary",
-  content: "Another happy landing.",
+  color: "info",
   sage_icon_name: "sage-icon-info-circle",
   sage_alert_title: "Our privacy policy has changed",
   sage_alert_desc: "Make sure you know how these changes affect you.",
@@ -19,27 +17,24 @@
 <!-- Success -->
 <%= render "sage/examples/objects/alert/markup",
   color: "success",
-  content: "Another happy landing.",
   sage_icon_name: "sage-icon-info-circle",
-  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_title: "Account settings updated",
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
 <!-- Warning -->
 <%= render "sage/examples/objects/alert/markup",
   color: "warning",
-  content: "Another happy landing.",
   sage_icon_name: "sage-icon-info-circle",
-  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_title: "Exceeded product amount limit",
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>
 <!-- Danger -->
 <%= render "sage/examples/objects/alert/markup",
   color: "danger",
-  content: "Another happy landing.",
   sage_icon_name: "sage-icon-info-circle",
-  sage_alert_title: "Our privacy policy has changed",
+  sage_alert_title: "App outage tonight at 12am",
   sage_alert_desc: "Make sure you know how these changes affect you.",
   dismissable: true
 %>


### PR DESCRIPTION
## Description
Update alert styling, functionality, and documentation to account for icons and dismissable actions. 

- Previously named as "banners", which have been superseded by the new banner object
- **NOTE:** This update does not include updated icons and uses the existing icons.

THIS UPDATE REQUIRES AN UPDATE IN KAJABI-PRODUCTS DUE TO RENAMING.

![alerts](https://user-images.githubusercontent.com/816579/79609412-8fe2f480-80ab-11ea-975d-614401af8bb6.png)

## Related issues
- #176 