### PR TITLE
Sage-Select

### DIFF
--- a/app/assets/stylesheets/sage/sage_system.css.scss
+++ b/app/assets/stylesheets/sage/sage_system.css.scss
@@ -53,6 +53,7 @@
 @import "system/patterns/elements/menu_button";
 @import "system/patterns/elements/form_input";
 @import "system/patterns/elements/form_textarea";
+@import "system/patterns/elements/form_select";
 @import "system/patterns/elements/checkbox";
 @import "system/patterns/elements/radio";
 @import "system/patterns/elements/switch";

--- a/app/assets/stylesheets/sage/system/core/_mixins.scss
+++ b/app/assets/stylesheets/sage/system/core/_mixins.scss
@@ -132,7 +132,7 @@
   } @else if $value != unset {
     @return $value;
   } @else {
-    @return false;
+    @return null;
   }
 }
 
@@ -150,7 +150,7 @@
 ================================================== */
 
 @mixin icon-base($icon: null) {
-  display: inline-block;
+  display: inline-flex;
   text-transform: none;
   font: normal normal normal 1rem/1 "Sage";
   speak: none;

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
@@ -32,8 +32,8 @@ $-sage-selectfield-color-error:               $sage-inputfield-color-error;
 .sage-select__label {
   position: absolute;
   white-space: nowrap;
-  pointer-events: none;
   line-height: initial;
+  pointer-events: none;
 
   @include position((($-sage-selectfield-height / 2) - $sage-body-font-size), unset, unset, $-sage-selectfield-padding-x);
 }
@@ -41,12 +41,11 @@ $-sage-selectfield-color-error:               $sage-inputfield-color-error;
 %sage-select__label--active {
   @extend %t-sage-body-xsmall-semi;
 
-  padding: 0 $-sage-selectfield-padding-label;
-  color: inherit;
-  background-color: $-sage-selectfield-bg-label;
   transform: translateY(calc(-50% - (#{$sage-body-font-size} / 4)));
-  transition: transform 0.15s ease-in-out, color 0.15s ease-out;
+  padding: 0 $-sage-selectfield-padding-label;
   color: $-sage-selectfield-color-success;
+  background-color: $-sage-selectfield-bg-label;
+  transition: transform 0.15s ease-in-out, color 0.15s ease-out;
 }
 
 %sage-select__label--inactive {
@@ -76,10 +75,17 @@ $-sage-selectfield-color-error:               $sage-inputfield-color-error;
   outline: none;
   cursor: pointer;
 
-  // The <Select> is set as [required] & therefore is invalid when the value
+  // Firefox allows setting the color of <options> within a <select>.
+  // This prevents color from being inherited from <select>.
+  option:not(:disabled) {
+    color: $sage-body-font-color;
+  }
+
+  // The <select> is set as [required] & therefore is invalid when the value
   // is empty, we're mapping :invalid to "empty" for more legible code.
   $empty: "invalid";
 
+  &:focus:#{$empty},
   &:hover:#{$empty} {
     border-color: $-sage-selectfield-border-color-hover;
   }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
@@ -29,12 +29,22 @@
   background-color: $sage-inputfield-bg-label;
   transform: translateY(calc(-50% - (#{$sage-body-font-size} / 4)));
   transition: transform 0.15s ease-in-out, color 0.15s ease-out;
+  color: $sage-inputfield-color-success;
 }
 
 %sage-select__label--inactive {
   @extend %t-sage-body;
 
   color: $sage-inputfield-color-default;
+}
+
+.sage-select__arrow::before {
+  @include icon-base(caret-down);
+  @include position(0, sage-spacing(sm), unset, unset);
+  position: absolute;
+  align-items: center;
+  height: $sage-inputfield-height;
+  color: sage-color(grey, 500);
 }
 
 .sage-select__field {
@@ -47,19 +57,58 @@
   border-radius: $sage-inputfield-border-radius;
   background: transparent;
   outline: none;
+  cursor: pointer;
 
-  &:not(:invalid) {
+  // The <Select> is set as [required] & therefore is invalid when the value
+  // is empty, we're mapping :invalid to "empty" for more legible code.
+  $empty: "invalid";
+
+  &:hover:#{$empty} {
+    border-color: sage-color(grey, 500);
+  }
+
+  &:hover {
+    ~ .sage-select__arrow::before {
+      color: $sage-inputfield-color-success;
+    }
+  }
+
+  &:not(:#{$empty}) {
     color: $sage-inputfield-color-default;
     border-color: currentColor;
+    border-color: $sage-inputfield-color-success;
+    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-success;
 
     ~ .sage-select__label {
       @extend %sage-select__label--active;
     }
   }
 
-  &:invalid {
+  &:#{$empty} {
     ~ .sage-select__label {
       @extend %sage-select__label--inactive;
     }
+  }
+
+  .sage-select--error &,
+  .sage-select--error &:#{$empty} {
+    border-color: $sage-inputfield-color-error;
+    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-error;
+
+    ~ .sage-select__arrow::before {
+      color: $sage-inputfield-color-error;
+    }
+
+    ~ .sage-select__label {
+      color: $sage-inputfield-color-error;
+    }
+  }
+}
+
+.sage-select__message {
+  @extend %t-sage-body-small;
+
+  .sage-select--error & {
+    color: $sage-inputfield-color-error;
   }
 }

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
@@ -1,0 +1,65 @@
+/* ==================================================
+  ** _form_select.scss
+  type: element
+
+================================================== */
+
+.sage-select {
+  position: relative;
+
+  &:not(:last-child) {
+    margin-bottom: $sage-inputfield-spacing;
+  }
+}
+
+.sage-select__label {
+  position: absolute;
+  white-space: nowrap;
+  pointer-events: none;
+  line-height: initial;
+
+  @include position((($sage-inputfield-height / 2) - $sage-body-font-size), unset, unset, $sage-inputfield-padding-x);
+}
+
+%sage-select__label--active {
+  @extend %t-sage-body-xsmall-semi;
+
+  padding: 0 $sage-inputfield-padding-label;
+  color: inherit;
+  background-color: $sage-inputfield-bg-label;
+  transform: translateY(calc(-50% - (#{$sage-body-font-size} / 4)));
+  transition: transform 0.15s ease-in-out, color 0.15s ease-out;
+}
+
+%sage-select__label--inactive {
+  @extend %t-sage-body;
+
+  color: $sage-inputfield-color-default;
+}
+
+.sage-select__field {
+  height: $sage-inputfield-height;
+  width: 100%;
+  padding: $sage-inputfield-padding-offset $sage-inputfield-padding-x 0;
+  appearance: none;
+  color: transparent;
+  border: $sage-inputfield-border-width solid $sage-inputfield-border-color;
+  border-radius: $sage-inputfield-border-radius;
+  background: transparent;
+  outline: none;
+
+  &:not(:invalid) {
+    color: $sage-inputfield-color-default;
+    border-color: currentColor;
+
+    ~ .sage-select__label {
+      @extend %sage-select__label--active;
+    }
+  }
+
+  &:invalid {
+    ~ .sage-select__label {
+      @extend %sage-select__label--inactive;
+    }
+  }
+}

--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
@@ -4,11 +4,28 @@
 
 ================================================== */
 
+$-sage-selectfield-height:                    $sage-inputfield-height;
+$-sage-selectfield-bg-label:                  $sage-inputfield-bg-label;
+$-sage-selectfield-padding-x:                 $sage-inputfield-padding-x;
+$-sage-selectfield-filled-top-padding:        rem(6);
+$-sage-selectfield-padding-label:             $sage-inputfield-padding-label;
+$-sage-selectfield-bottom-spacing:            $sage-inputfield-spacing;
+
+$-sage-selectfield-border-radius:             $sage-inputfield-border-radius;
+$-sage-selectfield-border-width:              $sage-inputfield-border-width;
+$-sage-selectfield-border-color:              $sage-inputfield-border-color;
+$-sage-selectfield-border-color-hover:        sage-color(grey, 500);
+$-sage-selectfield-border-box-shadow-size:    $sage-inputfield-box-shadow-size;
+
+$-sage-selectfield-color-default:             $sage-inputfield-color-default;
+$-sage-selectfield-color-success:             $sage-inputfield-color-success;
+$-sage-selectfield-color-error:               $sage-inputfield-color-error;
+
 .sage-select {
   position: relative;
 
   &:not(:last-child) {
-    margin-bottom: $sage-inputfield-spacing;
+    margin-bottom: $-sage-selectfield-bottom-spacing;
   }
 }
 
@@ -18,24 +35,24 @@
   pointer-events: none;
   line-height: initial;
 
-  @include position((($sage-inputfield-height / 2) - $sage-body-font-size), unset, unset, $sage-inputfield-padding-x);
+  @include position((($-sage-selectfield-height / 2) - $sage-body-font-size), unset, unset, $-sage-selectfield-padding-x);
 }
 
 %sage-select__label--active {
   @extend %t-sage-body-xsmall-semi;
 
-  padding: 0 $sage-inputfield-padding-label;
+  padding: 0 $-sage-selectfield-padding-label;
   color: inherit;
-  background-color: $sage-inputfield-bg-label;
+  background-color: $-sage-selectfield-bg-label;
   transform: translateY(calc(-50% - (#{$sage-body-font-size} / 4)));
   transition: transform 0.15s ease-in-out, color 0.15s ease-out;
-  color: $sage-inputfield-color-success;
+  color: $-sage-selectfield-color-success;
 }
 
 %sage-select__label--inactive {
   @extend %t-sage-body;
 
-  color: $sage-inputfield-color-default;
+  color: $-sage-selectfield-color-default;
 }
 
 .sage-select__arrow::before {
@@ -43,18 +60,18 @@
   @include position(0, sage-spacing(sm), unset, unset);
   position: absolute;
   align-items: center;
-  height: $sage-inputfield-height;
+  height: $-sage-selectfield-height;
   color: sage-color(grey, 500);
 }
 
 .sage-select__field {
-  height: $sage-inputfield-height;
+  height: $-sage-selectfield-height;
   width: 100%;
-  padding: $sage-inputfield-padding-offset $sage-inputfield-padding-x 0;
+  padding: $-sage-selectfield-filled-top-padding $-sage-selectfield-padding-x 0;
   appearance: none;
   color: transparent;
-  border: $sage-inputfield-border-width solid $sage-inputfield-border-color;
-  border-radius: $sage-inputfield-border-radius;
+  border: $-sage-selectfield-border-width solid $-sage-selectfield-border-color;
+  border-radius: $-sage-selectfield-border-radius;
   background: transparent;
   outline: none;
   cursor: pointer;
@@ -64,20 +81,19 @@
   $empty: "invalid";
 
   &:hover:#{$empty} {
-    border-color: sage-color(grey, 500);
+    border-color: $-sage-selectfield-border-color-hover;
   }
 
   &:hover {
     ~ .sage-select__arrow::before {
-      color: $sage-inputfield-color-success;
+      color: $-sage-selectfield-color-success;
     }
   }
 
   &:not(:#{$empty}) {
-    color: $sage-inputfield-color-default;
-    border-color: currentColor;
-    border-color: $sage-inputfield-color-success;
-    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-success;
+    color: $-sage-selectfield-color-default;
+    border-color: $-sage-selectfield-color-success;
+    box-shadow: $-sage-selectfield-border-box-shadow-size $-sage-selectfield-color-success;
 
     ~ .sage-select__label {
       @extend %sage-select__label--active;
@@ -92,15 +108,15 @@
 
   .sage-select--error &,
   .sage-select--error &:#{$empty} {
-    border-color: $sage-inputfield-color-error;
-    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-error;
+    border-color: $-sage-selectfield-color-error;
+    box-shadow: $-sage-selectfield-border-box-shadow-size $-sage-selectfield-color-error;
 
     ~ .sage-select__arrow::before {
-      color: $sage-inputfield-color-error;
+      color: $-sage-selectfield-color-error;
     }
 
     ~ .sage-select__label {
-      color: $sage-inputfield-color-error;
+      color: $-sage-selectfield-color-error;
     }
   }
 }
@@ -109,6 +125,6 @@
   @extend %t-sage-body-small;
 
   .sage-select--error & {
-    color: $sage-inputfield-color-error;
+    color: $-sage-selectfield-color-error;
   }
 }

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -14,6 +14,19 @@ module Sage
       [
         # Sage Generated Elements
         {
+          title: "form_select",
+          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", 
+          scss_design:  "todo",
+          scss_dev:     "todo",
+          scss_doc:     "todo",
+          rails_design: "todo",
+          rails_dev:    "todo",
+          rails_doc:    "todo",
+          react_design: "todo",
+          react_dev:    "todo",
+          react_doc:    "todo"
+        },
+        {
           title: "live_stream_wrapper",
           description: "A simple wrapper element for the Live stream application",
           scss_design:  "done",

--- a/app/helpers/sage/elements_helper.rb
+++ b/app/helpers/sage/elements_helper.rb
@@ -15,9 +15,9 @@ module Sage
         # Sage Generated Elements
         {
           title: "form_select",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", 
-          scss_design:  "todo",
-          scss_dev:     "todo",
+          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+          scss_design:  "done",
+          scss_dev:     "done",
           scss_doc:     "todo",
           rails_design: "todo",
           rails_dev:    "todo",

--- a/app/views/sage/examples/elements/form_select/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_select/_preview.html.erb
@@ -1,21 +1,21 @@
 <div class="sage-select">
   <select name="pets" id="pets" class="sage-select__field" required>
-    <option value="" disabled selected>-- Please Select An Option --</option>
+    <option value="" disabled selected>-- Please Select A Character --</option>
     <option value="none">None</option>
-    <option value="dog">Dog</option>
-    <option value="cat">Cat</option>
-    <option value="hamster">Hamster</option>
-    <option value="parrot">Parrot</option>
-    <option value="spider">Spider</option>
-    <option value="goldfish">Goldfish</option>
+    <option value="mario">Mario</option>
+    <option value="Luigi">Luigi</option>
+    <option value="princess-peach">Princess Peach</option>
+    <option value="daisy">Daisy</option>
+    <option value="toad">Toad</option>
   </select>
-  <label for="pets" class="sage-select__label">Pets</label>
+  <label for="pets" class="sage-select__label">Character</label>
+  <i class="sage-select__arrow" aria-hidden="true"></i>
   <div class="sage-select__message">This is a message</div>
 </div>
 
-<div class="sage-select">
-  <select name="pets2" id="pets2" class="sage-select__field" required>
-    <option value="" disabled selected>-- Please Select An Option --</option>
+<div class="sage-select sage-select--error">
+  <select name="pet" id="pet" class="sage-select__field" required>
+    <option value="" disabled selected>-- Please Select A Pet --</option>
     <option value="none">None</option>
     <option value="dog">Dog</option>
     <option value="cat">Cat</option>
@@ -24,6 +24,7 @@
     <option value="spider">Spider</option>
     <option value="goldfish">Goldfish</option>
   </select>
-  <label for="pets2" class="sage-select__label">Pets2</label>
+  <label for="pet" class="sage-select__label">Pet</label>
+  <i class="sage-select__arrow" aria-hidden="true"></i>
   <div class="sage-select__message">This is a message</div>
 </div>

--- a/app/views/sage/examples/elements/form_select/_preview.html.erb
+++ b/app/views/sage/examples/elements/form_select/_preview.html.erb
@@ -1,0 +1,29 @@
+<div class="sage-select">
+  <select name="pets" id="pets" class="sage-select__field" required>
+    <option value="" disabled selected>-- Please Select An Option --</option>
+    <option value="none">None</option>
+    <option value="dog">Dog</option>
+    <option value="cat">Cat</option>
+    <option value="hamster">Hamster</option>
+    <option value="parrot">Parrot</option>
+    <option value="spider">Spider</option>
+    <option value="goldfish">Goldfish</option>
+  </select>
+  <label for="pets" class="sage-select__label">Pets</label>
+  <div class="sage-select__message">This is a message</div>
+</div>
+
+<div class="sage-select">
+  <select name="pets2" id="pets2" class="sage-select__field" required>
+    <option value="" disabled selected>-- Please Select An Option --</option>
+    <option value="none">None</option>
+    <option value="dog">Dog</option>
+    <option value="cat">Cat</option>
+    <option value="hamster">Hamster</option>
+    <option value="parrot">Parrot</option>
+    <option value="spider">Spider</option>
+    <option value="goldfish">Goldfish</option>
+  </select>
+  <label for="pets2" class="sage-select__label">Pets2</label>
+  <div class="sage-select__message">This is a message</div>
+</div>

--- a/app/views/sage/examples/elements/form_select/_props.html.erb
+++ b/app/views/sage/examples/elements/form_select/_props.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td>Prop Name</td>
+  <td>The description of the property goes here.</td>
+  <td>String</td>
+  <td>Default</td>
+</tr>

--- a/app/views/sage/examples/elements/form_select/_rules_do.html.erb
+++ b/app/views/sage/examples/elements/form_select/_rules_do.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should do with this element go here.</li>
+</ul>

--- a/app/views/sage/examples/elements/form_select/_rules_dont.html.erb
+++ b/app/views/sage/examples/elements/form_select/_rules_dont.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should not do with this element go here.</li>
+</ul>


### PR DESCRIPTION
Resolves: #198

# _Sage Select_ 🔮

- Adds sage-select element
- Fixes `position()` mixin (I broke it in my last PR)

### Notes
`<select>` doesn't have an empty/placeholder pseudo selector so I'm using `:invalid` to adjust the positioning of the label.

Feedback on the variable structure requested. The structure in this PR is more in-line with a "private variable" pattern. These variable will become fully "private" once we start using `@use`.

### Preview

![screencast 2020-04-28 09-55-57](https://user-images.githubusercontent.com/565743/80502702-950b3380-8936-11ea-96ee-e1e042ab0f2c.gif)
