### PR TITLE
JS error on products/superadmin

### DIFF
--- a/app/assets/javascripts/sage/system/banner.js
+++ b/app/assets/javascripts/sage/system/banner.js
@@ -4,11 +4,10 @@ Sage.banner = (function() {
   // Variables
   // ==================================================
 
-  var bannerClass = ".sage-banner--active";
-  var bodyClass = "banner-active";
+  var activeBanner, bannerCloseBtn;
 
-  var activeBanner = document.querySelector(bannerClass);
-  var bannerCloseBtn = activeBanner.querySelector('.sage-banner__close');
+  var bodyClass = "banner-active";
+  var bannerClass = ".sage-banner--active";
 
 
   // ==================================================
@@ -20,22 +19,19 @@ Sage.banner = (function() {
     return document.querySelector(bannerClass) !== null;
   }
 
-  function toggleBodyBanner(bodyClass) {
-    document.querySelector('body').classList.toggle(bodyClass);
-  }
-
   function bindEvents() {
     bannerCloseBtn.addEventListener('click', function(e) {
       e.target.parentElement.classList.toggle('sage-banner--active');
-      toggleBodyBanner(bodyClass);
+      document.querySelector('body').classList.toggle(bodyClass);
     });
   }
 
 
-
   function init() {
     if (bannerIsEnabled()) {
-      document.querySelector('body').classList.add(bodyClass);
+      document.body.classList.add(bodyClass);
+      activeBanner = document.querySelector(bannerClass);
+      bannerCloseBtn = activeBanner.querySelector('.sage-banner__close');
 
       bindEvents();
     }

--- a/app/assets/javascripts/sage/system/init.js
+++ b/app/assets/javascripts/sage/system/init.js
@@ -23,4 +23,9 @@ Sage.init = function(elementNamesToInit) {
     Sage.alert.init();
   }
 
+   // Initialize Banner
+   if ( shouldInit('banner', '.sage-banner--active') && !document.querySelector('.sage-docs') ) {
+    Sage.banner.init();
+  }
+
 }

--- a/app/views/sage/application/_scripts.html.erb
+++ b/app/views/sage/application/_scripts.html.erb
@@ -8,7 +8,8 @@
       'tooltip',
       'sidebar',
       'overlay',
-      'alert'
+      'alert',
+      'banner'
     ]);
   });
 </script>


### PR DESCRIPTION
While working in the superadmin, I noticed that the Sage JS did not appear to be initializing, though the global `Sage` object was accessible from the console. The solution being to add the inline `init` script (`application/_scripts.html.erb`), which seems to be missing from the page templates. During troubleshooting, @cmcfadzean pointed out that there was an error on prod, which this PR should correct.

- Corrects issue with JS variable initializing incorrectly
- Revises loading strategy for banner JS

