### PR TITLE
Sage panel overflow hides content on mobile devices

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/objects/_panel.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_panel.scss
@@ -21,6 +21,7 @@
 }
 
 .sage-panel__body {
+  position: relative;
   overflow: auto;
 }
 


### PR DESCRIPTION
In Sage panels, the default setting `overflow: auto` on `.sage-panel__body` is causing a rendering issue in iOS 13.2.2. The content is hidden until some user action (tapping or scrolling) is applied. 

Might be caused by `overflow` establishing a new block formatting context, since setting `position: relative` on the element corrects the issue as seen below:

|  before   |  after (with `position: relative`)  |
|--------|--------|
|![panel-before](https://user-images.githubusercontent.com/816579/80744679-e3096e00-8ad3-11ea-842f-2e0451d83036.gif)|![panel-after](https://user-images.githubusercontent.com/816579/80744800-14823980-8ad4-11ea-97a2-e67dc73ae1dc.gif)|

