### PR TITLE
Live stream updates

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
@@ -18,6 +18,7 @@ $-live-stream-control-start-color: sage-color(white);
 $-live-stream-control-stop-background-color: sage-color(red, 300);
 $-live-stream-control-stop-color: sage-color(white);
 $-live-stream-control-ring-offset: rem(5px);
+$-live-stream-control-active-mic-size: rem(20px);
 
 .sage-live-stream-control {
   display: inline-flex;
@@ -138,8 +139,8 @@ $-live-stream-control-ring-offset: rem(5px);
 }
 
 .sage-live-stream-control__icon--active-mic {
-  width: 20px;
-  height: 20px;
+  width: $-live-stream-control-active-mic-size;
+  height: $-live-stream-control-active-mic-size;
 }
 
 .sage-live-stream-control__label {

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
@@ -137,6 +137,11 @@ $-live-stream-control-ring-offset: rem(5px);
   width: $-live-stream-control-icon-size;
 }
 
+.sage-live-stream-control__icon--active-mic {
+  width: 20px;
+  height: 20px;
+}
+
 .sage-live-stream-control__label {
   display: block;
   width: max-content;

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
@@ -18,7 +18,6 @@ $-live-stream-control-start-color: sage-color(white);
 $-live-stream-control-stop-background-color: sage-color(red, 300);
 $-live-stream-control-stop-color: sage-color(white);
 $-live-stream-control-ring-offset: rem(5px);
-$-live-stream-control-active-mic-size: rem(20px);
 
 .sage-live-stream-control {
   display: inline-flex;
@@ -134,13 +133,13 @@ $-live-stream-control-active-mic-size: rem(20px);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: $-live-stream-control-icon-size;
   width: $-live-stream-control-icon-size;
+  height: $-live-stream-control-icon-size;
 }
 
 .sage-live-stream-control__icon--active-mic {
-  width: $-live-stream-control-active-mic-size;
-  height: $-live-stream-control-active-mic-size;
+  width: $-live-stream-control-icon-sizee;
+  height: $-live-stream-control-icon-size;
 }
 
 .sage-live-stream-control__label {

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_control.scss
@@ -138,7 +138,7 @@ $-live-stream-control-ring-offset: rem(5px);
 }
 
 .sage-live-stream-control__icon--active-mic {
-  width: $-live-stream-control-icon-sizee;
+  width: $-live-stream-control-icon-size;
   height: $-live-stream-control-icon-size;
 }
 

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_video_grid.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_video_grid.scss
@@ -8,12 +8,25 @@ $-live-stream-video-tile-ratio: 1.618;
 $-live-stream-tile-gapper: calc(100% / 6);
 $-live-stream-grid-gap: sage-spacing(lg);
 
-@function tile-height($num-rows: 1, $num-cols: 2) {
+
+/* ==================================================
+  ** Calculate Grid Size by Ratio
+  Usage: `grid-size-by-ratio(2, 3)`
+
+  Creates a calc() that calculates the space needed for tiles to appear at a consistent maximum ratio:
+    - 100vh minus the height of the header and footer plus any row gutters gives us total space occupied by actual tiles
+    - This divided by the number of rows gives us one tile's height
+    - This times desired ration times however many columns plus however many column gutters gives maximum width for the overall grid
+    arguments: {Number} $num-rows, {Number} $num-cols, {Number} $raio, 
+    @return {string} - Calc function
+================================================== */
+
+@function grid-size-by-ratio($num-rows, $num-cols, $ratio: $-live-stream-video-tile-ratio) {
   $total-trimmed-space: ($-live-stream-grid-gap * $num-rows) + ($sage-live-stream-header-footer-height * 2);
-  @return calc((100vh - #{$total-trimmed-space}) / #{$num-rows} * #{$-live-stream-video-tile-ratio} * #{$num-cols} + #{$num-cols * $-live-stream-grid-gap});
+  $column-gutter-space: ($num-cols - 1) * $-live-stream-grid-gap;
+  @return calc(((100vh - #{$total-trimmed-space}) / #{$num-rows }) * #{$ratio * $num-cols} + #{$column-gutter-space});
 }
 
-// Default is for 3 or more participants
 .sage-live-stream-video-grid {
   display: grid;
   position: relative;
@@ -29,7 +42,7 @@ $-live-stream-grid-gap: sage-spacing(lg);
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(1, 1fr);
   grid-template-areas: "t1 t2";
-  max-width: tile-height(1, 2);
+  max-width: grid-size-by-ratio(1, 2);
 }
 
 .sage-live-stream-video-grid--3-up {
@@ -37,7 +50,7 @@ $-live-stream-grid-gap: sage-spacing(lg);
   grid-template-areas:
     ".  t1 t1 . "
     "t2 t2 t3 t3";
-  max-width: tile-height(2, 2);
+  max-width: grid-size-by-ratio(2, 2);
 }
 
 .sage-live-stream-video-grid--4-up {
@@ -45,7 +58,7 @@ $-live-stream-grid-gap: sage-spacing(lg);
   grid-template-areas:
     "t1 t1 t2 t2"
     "t3 t3 t4 t4";
-  max-width: tile-height(2, 2);
+  max-width: grid-size-by-ratio(2, 2);
 }
 
 .sage-live-stream-video-grid--5-up {
@@ -53,7 +66,7 @@ $-live-stream-grid-gap: sage-spacing(lg);
   grid-template-areas:
     ".  t1 t1 t2 t2 . "
     "t3 t3 t4 t4 t5 t5";
-  max-width: tile-height(2, 3);
+  max-width: grid-size-by-ratio(2, 3);
 }
 
 .sage-live-stream-video-grid--6-up {
@@ -61,7 +74,7 @@ $-live-stream-grid-gap: sage-spacing(lg);
   grid-template-areas:
     "t1 t1 t2 t2 t3 t3"
     "t4 t4 t5 t5 t6 t6";
-  max-width: tile-height(2, 3);
+  max-width: grid-size-by-ratio(2, 3);
 }
 
 .sage-live-stream-video-grid--solo {

--- a/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_video_grid.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_live_stream_video_grid.scss
@@ -4,8 +4,14 @@
 
 ================================================== */
 
-$-live-stream-video-tile-ratio: 0.69;
+$-live-stream-video-tile-ratio: 1.618;
 $-live-stream-tile-gapper: calc(100% / 6);
+$-live-stream-grid-gap: sage-spacing(lg);
+
+@function tile-height($num-rows: 1, $num-cols: 2) {
+  $total-trimmed-space: ($-live-stream-grid-gap * $num-rows) + ($sage-live-stream-header-footer-height * 2);
+  @return calc((100vh - #{$total-trimmed-space}) / #{$num-rows} * #{$-live-stream-video-tile-ratio} * #{$num-cols} + #{$num-cols * $-live-stream-grid-gap});
+}
 
 // Default is for 3 or more participants
 .sage-live-stream-video-grid {
@@ -16,12 +22,14 @@ $-live-stream-tile-gapper: calc(100% / 6);
   width: 100%;
   height: 100%;
   padding: 0 sage-spacing(md);
+  margin: 0 auto;
 }
 
 .sage-live-stream-video-grid--2-up {
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(1, 1fr);
   grid-template-areas: "t1 t2";
+  max-width: tile-height(1, 2);
 }
 
 .sage-live-stream-video-grid--3-up {
@@ -29,6 +37,7 @@ $-live-stream-tile-gapper: calc(100% / 6);
   grid-template-areas:
     ".  t1 t1 . "
     "t2 t2 t3 t3";
+  max-width: tile-height(2, 2);
 }
 
 .sage-live-stream-video-grid--4-up {
@@ -36,6 +45,7 @@ $-live-stream-tile-gapper: calc(100% / 6);
   grid-template-areas:
     "t1 t1 t2 t2"
     "t3 t3 t4 t4";
+  max-width: tile-height(2, 2);
 }
 
 .sage-live-stream-video-grid--5-up {
@@ -43,6 +53,7 @@ $-live-stream-tile-gapper: calc(100% / 6);
   grid-template-areas:
     ".  t1 t1 t2 t2 . "
     "t3 t3 t4 t4 t5 t5";
+  max-width: tile-height(2, 3);
 }
 
 .sage-live-stream-video-grid--6-up {
@@ -50,6 +61,7 @@ $-live-stream-tile-gapper: calc(100% / 6);
   grid-template-areas:
     "t1 t1 t2 t2 t3 t3"
     "t4 t4 t5 t5 t6 t6";
+  max-width: tile-height(2, 3);
 }
 
 .sage-live-stream-video-grid--solo {

--- a/app/views/sage/examples/objects/live_stream_video_grid/_preview.html.erb
+++ b/app/views/sage/examples/objects/live_stream_video_grid/_preview.html.erb
@@ -27,6 +27,11 @@
         avatarURL: '',
         color: 'sage',
       },
+      {
+        initials: 'LP',
+        avatarURL: '',
+        color: 'red',
+      },
     ]
   %>
   <%= render "sage/examples/objects/live_stream_footer/markup", 

--- a/app/views/sage/examples/objects/live_stream_video_grid/_preview.html.erb
+++ b/app/views/sage/examples/objects/live_stream_video_grid/_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-live-stream-wrapper sage-live-stream-wrapper--awake">
+<div class="sage-live-stream-wrapper sage-live-stream-wrapper--awake sage-live-stream-wrapper--fullscreen-demo">
   <%= render "sage/examples/objects/live_stream_header/markup", 
     isAwake: true, 
     isRecording: true,
@@ -26,7 +26,7 @@
         initials: 'JJ',
         avatarURL: '',
         color: 'sage',
-      }
+      },
     ]
   %>
   <%= render "sage/examples/objects/live_stream_footer/markup", 

--- a/app/views/sage/examples/objects/live_stream_video_grid/_preview.html.erb
+++ b/app/views/sage/examples/objects/live_stream_video_grid/_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-live-stream-wrapper sage-live-stream-wrapper--awake sage-live-stream-wrapper--fullscreen-demo">
+<div class="sage-live-stream-wrapper sage-live-stream-wrapper--awake">
   <%= render "sage/examples/objects/live_stream_header/markup", 
     isAwake: true, 
     isRecording: true,
@@ -26,11 +26,6 @@
         initials: 'JJ',
         avatarURL: '',
         color: 'sage',
-      },
-      {
-        initials: 'LP',
-        avatarURL: '',
-        color: 'red',
       },
     ]
   %>


### PR DESCRIPTION
## Description
This PR makes a few small patches to previously release Live features:

- Adds modifier to control size of the active mic icon
- Adds constraints to the video tile grid to help control widths of video tiles from becoming too wide.

### Screenshots

|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2020-05-04 at 3 54 40 PM](https://user-images.githubusercontent.com/17955295/81007676-ad3fee80-8e1f-11ea-801b-b796bc7f7565.png) | ![Screen Shot 2020-05-04 at 3 55 06 PM](https://user-images.githubusercontent.com/17955295/81007695-b761ed00-8e1f-11ea-8f11-8982570a2200.png) |

## Test notes
View Objects > Live Stream Video Grid and optionally add the `sage-live-stream-wrapper--fullscreen-demo` modifier on the `wrapper` to see at full screen. Add and remove video tiles from `objects/live_stream_video_grid/_preview.html.erb`.