### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report an issue
+title: "[BUG] "
+labels: 'bug :space_invader:'
+assignees: ''
+
+---
+
+## Description
+<!-- A clear and concise description of what the bug is -->
+
+### Environment
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+## Steps to reproduce
+Describe the steps to reproduce the behavior: 
+1. 
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,15 @@
+---
+name: Issue
+about: Generic issue template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+<!-- REQUIRED: Add a short description of the work to be done -->
+
+## Related
+<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
+- n/a


### PR DESCRIPTION
## Description
Enforces content descriptions using templates when creating new issues in GitHub. Two templates available:
1. General issues (barebones, similar to what you see here)
2. Bug reports (for more detail, steps to reproduce, etc)

Also writing up corresponding documentation for the wiki re: issues, pull requests, and general workflow.

More detail available in the docs: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

## Related
- #237 