### PR TITLE
Shortened code previews

### DIFF
--- a/app/assets/javascripts/sage/docs/example.js
+++ b/app/assets/javascripts/sage/docs/example.js
@@ -1,17 +1,37 @@
 Sage.docs.example = (function() {
 
+  var expandedText = "Collapse this code snippet";
+  var collapsedText = "Expand this code snippet";
+
+
   // ==================================================
   // Functions
   // ==================================================
 
+
+  // Note: assumes we won't have multiple code snippets per page
   function showHideCodeSample() {
-    var codeBtn = document.querySelector('.example__expand-btn');
+    var codeBtn = document.querySelector('.example__expand-btn'),
+      codeSnippet = codeBtn.closest('.sage-code-snippet');
 
     codeBtn.addEventListener('click', function(e) {
+      updateButtonState(e.target, this);
       e.target.parentElement.classList.toggle('example__code--expanded');
+      e.target.nextElementSibling.focus();
     });
   }
 
+
+  // toggle code example button state
+  function updateButtonState(evt) {
+    if (evt.getAttribute('aria-expanded') === 'false') {
+      evt.setAttribute('aria-expanded', 'true');
+      evt.innerText = expandedText;
+    } else {
+      evt.setAttribute('aria-expanded', 'false');
+      evt.innerText = collapsedText;
+    }
+  }
 
 
   function init() {

--- a/app/assets/javascripts/sage/docs/example.js
+++ b/app/assets/javascripts/sage/docs/example.js
@@ -1,0 +1,26 @@
+Sage.docs.example = (function() {
+
+  // ==================================================
+  // Functions
+  // ==================================================
+
+  function showHideCodeSample() {
+    var codeBtn = document.querySelector('.example__expand-btn');
+
+    codeBtn.addEventListener('click', function(e) {
+      e.target.parentElement.classList.toggle('example__code--expanded');
+    });
+  }
+
+
+
+  function init() {
+    showHideCodeSample();
+  }
+
+
+  return {
+    init: init
+  };
+
+})();

--- a/app/assets/javascripts/sage/sage_docs.js
+++ b/app/assets/javascripts/sage/sage_docs.js
@@ -2,6 +2,7 @@
 
 //= require sage/docs/live-option-menu
 //= require sage/docs/banner
+//= require sage/docs/example
 
 
 // SAGE DOCUMENTATION USE ONLY
@@ -16,6 +17,10 @@ if (document.querySelector('.sage-docs') !== null) {
 
   if (document.querySelector('.sage-banner--active') !== null && document.querySelector('.example__preview--page') !== null) {
     Sage.docs.banner.init();
+  }
+
+  if (document.querySelector('.example__code') !== null && document.querySelector('.example__expand-btn') !== null) {
+    Sage.docs.example.init();
   }
 
 }

--- a/app/assets/stylesheets/sage/docs/_example.scss
+++ b/app/assets/stylesheets/sage/docs/_example.scss
@@ -4,9 +4,14 @@
   For Sage documentation use
 ================================================== */
 
+$-example-link-color: inherit;
+$-example-link-color-hover: sage-color(charcoal, 100);
+
 $-example-code-preview-height: 8rem;
-$-example-code-preview-button-color: sage-color(primary, 200);
+$-example-code-preview-button-color: sage-color(white);
+$-example-code-preview-button-color-hover: sage-color(sage, 200);
 $-example-code-preview-button-blur: blur(2px);
+$-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
 
 .example__title {
   color: sage-color(charcoal, 500);
@@ -14,11 +19,12 @@ $-example-code-preview-button-blur: blur(2px);
 }
 
 .example__link {
-  color: inherit;
-  transition: color 0.1s ease-in-out;
+  color: $-example-link-color;
+  transition: $sage-transition;
+  transition-property: color;
 
   &:hover {
-    color: sage-color(charcoal, 100);
+    color: $-example-link-color-hover;
   }
 
   &:focus,
@@ -74,18 +80,16 @@ $-example-code-preview-button-blur: blur(2px);
   @include button-style-reset();
   position: absolute;
   z-index: sage-z_index(raised);
-  bottom: sage-spacing(lg);
-  left: 50%;
-  transform: translateX(-50%);
-  padding: rem(12px) sage-spacing(sm);
-  color: sage-color(white);
-  background-color: rgba(sage-color(primary, 500), 0.75);
-  border: 1px solid rgba(sage-color(white), 0.8);
-  border-radius: $sage-btn-border-radius;
+  bottom: sage-spacing(xs);
+  left: 0;
+  width: 100%;
+  padding: sage-spacing(xs);
+  color: $-example-code-preview-button-color;
+  background-color: $-example-code-preview-button-bg;
   transition: $sage-transition;
   transition-property: color;
 
-  @extend %t-sage-body-med;
+  @extend %t-sage-body-small-med;
 
   .example__code--expanded & {
     visibility: hidden;
@@ -94,13 +98,14 @@ $-example-code-preview-button-blur: blur(2px);
   &:hover,
   &:focus,
   &:active {
-    color: $-example-code-preview-button-color;
+    color: $-example-code-preview-button-color-hover;
     background-color: transparent;
+    cursor: ns-resize;
   }
 
   &:focus,
   &:active {
-    outline: 1px dotted sage-color(primary, 300);
+    outline: 1px dotted sage-color(sage);
   }
 
   @supports (backdrop-filter: blur(2px)) {

--- a/app/assets/stylesheets/sage/docs/_example.scss
+++ b/app/assets/stylesheets/sage/docs/_example.scss
@@ -4,6 +4,10 @@
   For Sage documentation use
 ================================================== */
 
+$-example-code-preview-height: 8rem;
+$-example-code-preview-button-color: sage-color(primary, 200);
+$-example-code-preview-button-blur: blur(2px);
+
 .example__title {
   color: sage-color(charcoal, 500);
   text-transform: capitalize;
@@ -90,7 +94,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: sage-color(primary, 200);
+    color: $-example-code-preview-button-color;
     background-color: transparent;
   }
 
@@ -100,7 +104,7 @@
   }
 
   @supports (backdrop-filter: blur(2px)) {
-    backdrop-filter: blur(2px);
+    backdrop-filter: $-example-code-preview-button-blur;
     background-color: rgba(sage-color(primary, 500), 0.15);
   }
 }
@@ -108,7 +112,7 @@
 .example__code {
   overflow: hidden;
   position: relative;
-  max-height: 8rem;
+  max-height: $-example-code-preview-height;
   margin: sage-spacing() 0;
 
   .prettyprint {

--- a/app/assets/stylesheets/sage/docs/_example.scss
+++ b/app/assets/stylesheets/sage/docs/_example.scss
@@ -87,12 +87,19 @@ $-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
   color: $-example-code-preview-button-color;
   background-color: $-example-code-preview-button-bg;
   transition: $sage-transition;
-  transition-property: color;
+  transition-property: color, opacity;
 
   @extend %t-sage-body-small-med;
 
   .example__code--expanded & {
-    visibility: hidden;
+    opacity: 0.4;
+
+    &:hover,
+    &:focus,
+    &:active {
+      opacity: 1;
+      cursor: n-resize;
+    }
   }
 
   &:hover,
@@ -100,7 +107,7 @@ $-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
   &:active {
     color: $-example-code-preview-button-color-hover;
     background-color: transparent;
-    cursor: ns-resize;
+    cursor: s-resize;
   }
 
   &:focus,
@@ -111,6 +118,10 @@ $-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
   @supports (backdrop-filter: blur(2px)) {
     backdrop-filter: $-example-code-preview-button-blur;
     background-color: rgba(sage-color(primary, 500), 0.15);
+
+    .example__code--expanded & {
+      backdrop-filter: none;
+    }
   }
 }
 

--- a/app/assets/stylesheets/sage/docs/_example.scss
+++ b/app/assets/stylesheets/sage/docs/_example.scss
@@ -66,10 +66,75 @@
   margin-bottom: sage-spacing(lg);
 }
 
+.example__expand-btn {
+  @include button-style-reset();
+  position: absolute;
+  z-index: sage-z_index(raised);
+  bottom: sage-spacing(lg);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: rem(12px) sage-spacing(sm);
+  color: sage-color(white);
+  background-color: rgba(sage-color(primary, 500), 0.75);
+  border: 1px solid rgba(sage-color(white), 0.8);
+  border-radius: $sage-btn-border-radius;
+  transition: $sage-transition;
+  transition-property: color;
+
+  @extend %t-sage-body-med;
+
+  .example__code--expanded & {
+    visibility: hidden;
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: sage-color(primary, 200);
+    background-color: transparent;
+  }
+
+  &:focus,
+  &:active {
+    outline: 1px dotted sage-color(primary, 300);
+  }
+
+  @supports (backdrop-filter: blur(2px)) {
+    backdrop-filter: blur(2px);
+    background-color: rgba(sage-color(primary, 500), 0.15);
+  }
+}
+
 .example__code {
+  overflow: hidden;
+  position: relative;
+  max-height: 8rem;
   margin: sage-spacing() 0;
 
   .prettyprint {
     margin-bottom: 0;
+  }
+
+  &::before {
+    content: "";
+    display: block;
+    z-index: sage-z-index(default, 1);
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 100%;
+    background-image: linear-gradient(to bottom, rgba(sage-color(primary, 500), 0.3) 0%, rgba(sage-color(primary, 500), 0.9) 100%);
+    transition: $sage-transition;
+    transition-property: opacity;
+    pointer-events: none;
+  }
+
+  &.example__code--expanded {
+    max-height: none;
+
+    &::before {
+      opacity: 0;
+    }
   }
 }

--- a/app/assets/stylesheets/sage/system/core/_mixins.scss
+++ b/app/assets/stylesheets/sage/system/core/_mixins.scss
@@ -38,7 +38,6 @@
   padding: 0;
   appearance: none;
   font-family: inherit;
-  font-size: inherit;
   line-height: 1;
   color: inherit;
   box-shadow: none;

--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -19,6 +19,7 @@
 <div class="sage-panel">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
+    <button class="example__expand-btn">Expand this code snippet</button>
     <div class="sage-code-snippet">
       <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{@title}/preview") %></code></pre>
     </div>

--- a/app/views/sage/examples/elements/_element.html.erb
+++ b/app/views/sage/examples/elements/_element.html.erb
@@ -19,8 +19,8 @@
 <div class="sage-panel">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
-    <button class="example__expand-btn">Expand this code snippet</button>
-    <div class="sage-code-snippet">
+    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= @title %>">Expand this code snippet</button>
+    <div id="example-code-<%= @title %>" class="sage-code-snippet" tabindex="-1">
       <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/elements/#{@title}/preview") %></code></pre>
     </div>
   </div>

--- a/app/views/sage/examples/objects/_object.html.erb
+++ b/app/views/sage/examples/objects/_object.html.erb
@@ -4,9 +4,9 @@
 
 <%= render "sage/examples/shared/heading" %>
 
-<%= render "sage/examples/shared/quick_links", 
-  props_content: props_content, 
-  do_content: do_content, 
+<%= render "sage/examples/shared/quick_links",
+  props_content: props_content,
+  do_content: do_content,
   dont_content: dont_content %>
 
 <div class="sage-panel">
@@ -19,18 +19,19 @@
 <div class="sage-panel">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
+    <button class="example__expand-btn">Expand this code snippet</button>
     <div class="sage-code-snippet">
       <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/objects/#{@title}/preview") %></code></pre>
     </div>
   </div>
 </div>
 
-<%= render "sage/examples/shared/props", 
-  props_content: props_content, 
-  do_content: do_content, 
+<%= render "sage/examples/shared/props",
+  props_content: props_content,
+  do_content: do_content,
   dont_content: dont_content %>
 
-<%= render "sage/examples/shared/rules", 
-  props_content: props_content, 
-  do_content: do_content, 
+<%= render "sage/examples/shared/rules",
+  props_content: props_content,
+  do_content: do_content,
   dont_content: dont_content %>

--- a/app/views/sage/examples/objects/_object.html.erb
+++ b/app/views/sage/examples/objects/_object.html.erb
@@ -19,8 +19,8 @@
 <div class="sage-panel">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
-    <button class="example__expand-btn">Expand this code snippet</button>
-    <div class="sage-code-snippet">
+    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= @title %>">Expand this code snippet</button>
+    <div id="example-code-<%= @title %>" class="sage-code-snippet" tabindex="-1">
       <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "sage/examples/objects/#{@title}/preview") %></code></pre>
     </div>
   </div>


### PR DESCRIPTION
## Description
I got a little tired of scrolling through the code previews to reach the properties while building out the `table` element, so I thought I'd try to clean them up. Code previews are shortened by default, with a button to expand when needed.

Applies only to the expanded element/object views and not on the list view.

### Screenshots
|  before  |  after  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/81598541-55a00680-937c-11ea-9993-f1317851cb61.png)|![after](https://user-images.githubusercontent.com/816579/81598426-1ffb1d80-937c-11ea-9810-83255c1c938e.png)|


## Related
- n/a
