### PR TITLE
Update card image path

### DIFF
--- a/app/views/sage/examples/objects/card/_markup.html.erb
+++ b/app/views/sage/examples/objects/card/_markup.html.erb
@@ -1,6 +1,6 @@
 <div class="sage-card<%= is_compact ? " sage-card--compact" : "" %><%= is_spaced ? " sage-card--spaced" : "" %>">
   <% if has_img %>
-  <img class="sage-card__img" src="<%= img_path %>" alt="<%= img_alt %>">
+  <%= image_tag("#{img_path}", class: "sage-card__img", alt: "#{img_alt}") %>
   <% end %>
   <div class="sage-card__body">
     <h2 class="sage-card__title t-sage-heading-5"><%= title %></h2>

--- a/app/views/sage/examples/objects/card/_markup.html.erb
+++ b/app/views/sage/examples/objects/card/_markup.html.erb
@@ -5,6 +5,6 @@
   <div class="sage-card__body">
     <h2 class="sage-card__title t-sage-heading-5"><%= title %></h2>
     <p class="sage-card__text"><%= text %></p>
-    <a href="#" class="sage-btn <% if action_style_primary %> sage-btn--primary <% elsif action_style_tertiary %> sage-btn--tertiary sage-btn--icon-right-caret-right<% end %>"><%= action_text %></a>
+    <a href="#" class="sage-btn <% if action_style_primary %>sage-btn--primary<% elsif action_style_tertiary %>sage-btn--tertiary sage-btn--icon-right-caret-right<% end %>"><%= action_text %></a>
   </div>
 </div>

--- a/app/views/sage/examples/objects/card/_preview.html.erb
+++ b/app/views/sage/examples/objects/card/_preview.html.erb
@@ -9,7 +9,7 @@
       action_style_primary: true,
       action_style_tertiary: false,
       has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-lg.png",
+      img_path: "sage/card/card-placeholder-lg.png",
       img_alt: "Alternative text for image"
     %>
   </div>
@@ -23,7 +23,7 @@
       action_style_primary: false,
       action_style_tertiary: true,
       has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-lg.png",
+      img_path: "sage/card/card-placeholder-lg.png",
       img_alt: "Alternative text for image"
     %>
   </div>
@@ -37,7 +37,7 @@
       action_style_primary: true,
       action_style_tertiary: false,
       has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-sm.png",
+      img_path: "sage/card/card-placeholder-sm.png",
       img_alt: "Alternative text for image"
     %>
     <%= render "sage/examples/objects/card/markup",
@@ -49,7 +49,7 @@
       action_style_primary: false,
       action_style_tertiary: true,
        has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-sm.png",
+      img_path: "sage/card/card-placeholder-sm.png",
       img_alt: "Alternative text for image"
     %>
   </div>
@@ -63,7 +63,7 @@
       action_style_primary: true,
       action_style_tertiary: false,
       has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-lg.png",
+      img_path: "sage/card/card-placeholder-lg.png",
       img_alt: "Alternative text for image"
     %>
   </div>
@@ -77,7 +77,7 @@
       action_style_primary: false,
       action_style_tertiary: true,
        has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-lg.png",
+      img_path: "sage/card/card-placeholder-lg.png",
       img_alt: "Alternative text for image"
     %>
   </div>
@@ -91,7 +91,7 @@
       action_style_primary: true,
       action_style_tertiary: false,
       has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-sm.png",
+      img_path: "sage/card/card-placeholder-sm.png",
       img_alt: "Alternative text for image"
     %>
     <%= render "sage/examples/objects/card/markup",
@@ -103,7 +103,7 @@
       action_style_primary: false,
       action_style_tertiary: true,
       has_img: true,
-      img_path: "/assets/sage/card/card-placeholder-sm.png",
+      img_path: "sage/card/card-placeholder-sm.png",
       img_alt: "Alternative text for image"
     %>
   </div>


### PR DESCRIPTION
## Description
The card images are returning 404 on the Sage public site. The image path needs to be adjusted to correct this issue.

- [x] Convert image inclusion to `img_tag` instead of standard HTML `img` element.
- [x] Update file paths passed to each card.

### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screen Shot 2020-05-11 at 8 53 22 AM](https://user-images.githubusercontent.com/1175111/81582547-07333d80-9365-11ea-8455-5d4a2ab25346.png)|![Screen Shot 2020-05-11 at 8 53 32 AM](https://user-images.githubusercontent.com/1175111/81582586-131eff80-9365-11ea-8b47-65dcae82464b.png)| 

## Test notes
There should be no visual changes and this fix applies to the public site. Images were already appearing ok on local builds. The fix will need to be verified once the public site version is updated.