### PR TITLE
Convert nav object to an unordered list

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/objects/_nav.scss
+++ b/app/assets/stylesheets/sage/system/patterns/objects/_nav.scss
@@ -4,6 +4,12 @@
 
 ================================================== */
 
+.sage-nav__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .sage-nav__link {
   display: flex;
   align-items: center;

--- a/app/views/sage/application/_sidebar.html.erb
+++ b/app/views/sage/application/_sidebar.html.erb
@@ -1,22 +1,26 @@
 <div class="sage-sidebar" data-js-sidebar="sage-sidebar-menu" id="sage-sidebar-menu">
   <div class="sage-sidebar__body">
     <nav class="sage-nav" aria-label="Main">
-      <%= link_to "Introduction", pages_index_url, class: "#{current? "sage-nav__link--active", pages_index_url} sage-nav__link" %>
-      <%= link_to "Styles", pages_token_url, class: "sage-nav__link" %>
+      <ul class="sage-nav__list">
+      <li><%= link_to "Introduction", pages_index_url, class: "#{current? "sage-nav__link--active", pages_index_url} sage-nav__link" %></li>
+      <li><%= link_to "Styles", pages_token_url, class: "sage-nav__link" %></li>
       <%= yield :sidebar_styles %>
-      <%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %>
+      <li><%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %></li>
       <%= yield :sidebar_elements %>
-      <%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %>
+      <li><%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %></li>
       <%= yield :sidebar_objects %>
-      <%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_utilities_url}" %>
-      <%= link_to "Code Status", pages_status_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_status_url}" %>
+      <li><%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_utilities_url}" %></li>
+      <li><%= link_to "Code Status", pages_status_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_status_url}" %></li>
+      </ul>
     </nav>
   </div>
   <div class="sage-sidebar__footer">
     <nav class="sage-nav" aria-label="Secondary">
-      <%= link_to "Guidelines", "https://github.com/Kajabi/sage/wiki", class: "sage-nav__link", target: "_blank" %>
-      <%= link_to "Github", "https://github.com/Kajabi/sage", class: "sage-nav__link", target: "_blank" %>
-      <%= link_to "Changelog", "https://github.com/Kajabi/sage/releases", class: "sage-nav__link", target: "_blank" %>
+      <ul class="sage-nav__list">
+      <li><%= link_to "Guidelines", "https://github.com/Kajabi/sage/wiki", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+      <li><%= link_to "Github", "https://github.com/Kajabi/sage", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+      <li><%= link_to "Changelog", "https://github.com/Kajabi/sage/releases", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+      </ul>
     </nav>
   </div>
 </div>

--- a/app/views/sage/application/_sidebar.html.erb
+++ b/app/views/sage/application/_sidebar.html.erb
@@ -2,24 +2,24 @@
   <div class="sage-sidebar__body">
     <nav class="sage-nav" aria-label="Main">
       <ul class="sage-nav__list">
-      <li><%= link_to "Introduction", pages_index_url, class: "#{current? "sage-nav__link--active", pages_index_url} sage-nav__link" %></li>
-      <li><%= link_to "Styles", pages_token_url, class: "sage-nav__link" %></li>
-      <%= yield :sidebar_styles %>
-      <li><%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %></li>
-      <%= yield :sidebar_elements %>
-      <li><%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %></li>
-      <%= yield :sidebar_objects %>
-      <li><%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_utilities_url}" %></li>
-      <li><%= link_to "Code Status", pages_status_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_status_url}" %></li>
+        <li><%= link_to "Introduction", pages_index_url, class: "#{current? "sage-nav__link--active", pages_index_url} sage-nav__link" %></li>
+        <li><%= link_to "Styles", pages_token_url, class: "sage-nav__link" %></li>
+        <%= yield :sidebar_styles %>
+        <li><%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %></li>
+        <%= yield :sidebar_elements %>
+        <li><%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %></li>
+        <%= yield :sidebar_objects %>
+        <li><%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_utilities_url}" %></li>
+        <li><%= link_to "Code Status", pages_status_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_status_url}" %></li>
       </ul>
     </nav>
   </div>
   <div class="sage-sidebar__footer">
     <nav class="sage-nav" aria-label="Secondary">
       <ul class="sage-nav__list">
-      <li><%= link_to "Guidelines", "https://github.com/Kajabi/sage/wiki", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
-      <li><%= link_to "Github", "https://github.com/Kajabi/sage", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
-      <li><%= link_to "Changelog", "https://github.com/Kajabi/sage/releases", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+        <li><%= link_to "Guidelines", "https://github.com/Kajabi/sage/wiki", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+        <li><%= link_to "Github", "https://github.com/Kajabi/sage", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+        <li><%= link_to "Changelog", "https://github.com/Kajabi/sage/releases", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
       </ul>
     </nav>
   </div>

--- a/app/views/sage/application/_sidebar_elements.html.erb
+++ b/app/views/sage/application/_sidebar_elements.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :sidebar_elements do %>
   <% sorted_sage_elements.each do |element| %>
-    <%= link_to pages_element_url(title: element[:title], description: element[:description]), class: "sage-nav__link #{current? "sage-nav__link--active", pages_element_url(title: element[:title], description: element[:description])} sage-nav__link--sub" do %>
-      <%= element[:title].titleize %>
-    <% end %>
+    <li>
+      <%= link_to pages_element_url(title: element[:title], description: element[:description]), class: "sage-nav__link #{current? "sage-nav__link--active", pages_element_url(title: element[:title], description: element[:description])} sage-nav__link--sub" do %><%= element[:title].titleize %><% end %>
+    </li>
   <% end %>
 <% end %>

--- a/app/views/sage/application/_sidebar_objects.html.erb
+++ b/app/views/sage/application/_sidebar_objects.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :sidebar_objects do %>
   <% sorted_sage_objects.each do |object| %>
-    <%= link_to pages_object_url(title: object[:title], description: object[:description]), class: "sage-nav__link #{current? "sage-nav__link--active", pages_object_url(title: object[:title], description: object[:description])} sage-nav__link--sub" do %>
-      <%= object[:title].titleize %>
-    <% end %>
+    <li>
+      <%= link_to pages_object_url(title: object[:title], description: object[:description]), class: "sage-nav__link #{current? "sage-nav__link--active", pages_object_url(title: object[:title], description: object[:description])} sage-nav__link--sub" do %><%= object[:title].titleize %><% end %>
+    </li>
   <% end %>
 <% end %>

--- a/app/views/sage/application/_sidebar_styles.html.erb
+++ b/app/views/sage/application/_sidebar_styles.html.erb
@@ -1,8 +1,8 @@
 <%= content_for :sidebar_styles do %>
-  <%= link_to "Tokens", pages_token_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_token_url} sage-nav__link--sub" %>
-  <%= link_to "Colors", pages_color_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_color_url} sage-nav__link--sub" %>
-  <%= link_to "Typography", pages_typography_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_typography_url} sage-nav__link--sub" %>
-  <%= link_to "Icons", pages_icon_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_icon_url} sage-nav__link--sub" %>
-  <%= link_to "Containers", pages_container_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_container_url} sage-nav__link--sub" %>
-  <%= link_to "Grid", pages_grid_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_grid_url} sage-nav__link--sub" %>
+  <li><%= link_to "Tokens", pages_token_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_token_url} sage-nav__link--sub" %></li>
+  <li><%= link_to "Colors", pages_color_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_color_url} sage-nav__link--sub" %></li>
+  <li><%= link_to "Typography", pages_typography_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_typography_url} sage-nav__link--sub" %></li>
+  <li><%= link_to "Icons", pages_icon_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_icon_url} sage-nav__link--sub" %></li>
+  <li><%= link_to "Containers", pages_container_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_container_url} sage-nav__link--sub" %></li>
+  <li><%= link_to "Grid", pages_grid_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_grid_url} sage-nav__link--sub" %></li>
 <% end %>

--- a/app/views/sage/examples/objects/nav/_markup.html.erb
+++ b/app/views/sage/examples/objects/nav/_markup.html.erb
@@ -1,5 +1,9 @@
 <nav class="sage-nav" aria-label="Main">
-  <% nav_links.each do |link| %>
-  <a href="<%= link[:url] %>" class="sage-nav__link<%= link[:is_sublink] ? " sage-nav__link--sub" : "" %><%= link[:is_active] ? " sage-nav__link--active" : "" %>"><%= link[:text] %></a>
-  <% end %>
+  <ul class="sage-nav__list">
+    <% nav_links.each do |link| %>
+    <li>
+      <a href="<%= link[:url] %>" class="sage-nav__link<%= link[:is_sublink] ? " sage-nav__link--sub" : "" %><%= link[:is_active] ? " sage-nav__link--active" : "" %>"><%= link[:text] %></a>
+    <% end %>
+    </li>
+  </ul>
 </nav>


### PR DESCRIPTION
## Description
The nav object is currently just `a` elements inside of a `nav` element. Ideally, these links would be contained within an unordered list (`ul`) and list items (`li`).

- [x] Update `nav` object to include unordered list (`ul`) and items (`li`)
- [x] Update app sidebar `nav` to include unordered list (`ul`) and items (`li`)

## Test notes

- Check that nav object links and app sidebar are contained in an unordered list.
- There should be no visual changes.