### PR TITLE
[BUG] Form section styles not applied

### DIFF
--- a/app/views/sage/examples/objects/form_section/_markup.html.erb
+++ b/app/views/sage/examples/objects/form_section/_markup.html.erb
@@ -1,10 +1,10 @@
-<div class="sage-form_section">
-  <div class="sage-form_section__info">
-    <h3 class="sage-form_section__title"><%= title %></h3>
-    <p class="sage-form_section__subtitle"><%= sub_title %></p>
+<div class="sage-form-section">
+  <div class="sage-form-section__info">
+    <h3 class="sage-form-section__title"><%= title %></h3>
+    <p class="sage-form-section__subtitle"><%= sub_title %></p>
   </div>
-  <div class="sage-form_section__content">
-    <div class="sage-form_section__panel">
+  <div class="sage-form-section__content">
+    <div class="sage-form-section__panel">
       <!-- Start Of Content -->
       <%= render "sage/examples/objects/alert/markup",
         color: "",


### PR DESCRIPTION
## Description
Form section classname mismatch is causing the styles to not be applied: `.sage-form_section` in the markup vs `.sage-form-section` in the CSS. 

## Screenshots
|  expected   |  actual  |
|--------|--------|
|![expected](https://user-images.githubusercontent.com/816579/81973474-0a366400-95d9-11ea-955a-36596d217351.png)|![actual](https://user-images.githubusercontent.com/816579/81973500-11f60880-95d9-11ea-96f0-3373a1035ac1.png)|

## Related
- #245 