### PR TITLE
Fix broken spacing for sage-select

### DIFF
--- a/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
+++ b/app/assets/stylesheets/sage/system/patterns/elements/_form_select.scss
@@ -37,13 +37,14 @@ $-sage-selectfield-color-error: $sage-inputfield-color-error;
   white-space: nowrap;
   line-height: initial;
   pointer-events: none;
+  transform: translateY(-50%);
 
-  @include position((($-sage-selectfield-height / 2) - $sage-body-font-size), unset, unset, $-sage-selectfield-padding-x);
+  @include position(($-sage-selectfield-height / 2), unset, unset, $-sage-selectfield-padding-x);
 
   .sage-select--value-selected & {
     @extend %t-sage-body-xsmall-semi;
 
-    transform: translateY(calc(-50% - (#{$sage-body-font-size} / 4)));
+    transform: translateY(calc(#{-$-sage-selectfield-height} + 50%));
     padding: 0 $-sage-selectfield-padding-label;
     color: $-sage-selectfield-color-success;
     background-color: $-sage-selectfield-bg-label;


### PR DESCRIPTION
## Description
Fixes `sage-select` label vertical spacing. The calculation being reliant on `$sage-body-font-size` was fragile.