### PR TITLE
Introduce review apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.2.11.1'
 
+gem 'pg', '~> 0.21'
 gem 'sass-rails', '~> 5.0'
-gem 'sqlite3', '~> 1.3.6'
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '~> 4.x'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     minitest (5.14.1)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    pg (0.21.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -123,7 +124,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -146,12 +146,12 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  pg (~> 0.21)
   pry
   rails (= 4.2.11.1)
   sage!
   sass-rails (~> 5.0)
   spring
-  sqlite3 (~> 1.3.6)
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   webpacker (~> 4.x)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,19 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: sage_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: sage_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: sage_production


### PR DESCRIPTION
## Description
This makes changes necessary to automatically create review apps on PRs.

Heroku requires a "real" database, so this adds the `pg` gem. I don't think the app even uses the database currently, but I figured it wouldn't hurt. All the devs will already need to have PostgreSQL installed to do app development.