### PR TITLE
Remove default line height [0.17.2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ $ yarn install
 $ bundle
 ```
 
+Also ensure to setup the database with:
+
+```bash
+$ rake db:setup
+```
+
 ### Run Locally
 
 Run the rails & webpack development servers in tandem.

--- a/lib/sage-frontend/stylesheets/system/vendor/_reboot.scss
+++ b/lib/sage-frontend/stylesheets/system/vendor/_reboot.scss
@@ -7,7 +7,6 @@
 html {
   font-family: sans-serif;
   font-size: initial;
-  line-height: 1.15;
   -webkit-text-size-adjust: 100%; /* stylelint-disable property-no-vendor-prefix */
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
## Description
Removes the root-level line-height setting that is no longer needed due to the setup for type specs added in prior releases.

Also makes small update to README to install database.