### PR TITLE
Sage docs sidebar nav modifications 

### DIFF
--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -3,12 +3,21 @@
     <nav class="sage-nav" aria-label="Main">
       <ul class="sage-nav__list">
         <li><%= link_to "Introduction", pages_index_url, class: "#{current? "sage-nav__link--active", pages_index_url} sage-nav__link" %></li>
-        <li><%= link_to "Styles", pages_token_url, class: "sage-nav__link" %></li>
-        <%= yield :sidebar_styles %>
-        <li><%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %></li>
-        <%= yield :sidebar_elements %>
-        <li><%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %></li>
-        <%= yield :sidebar_objects %>
+        <li><%= link_to "Styles", pages_token_url, class: "sage-nav__link" %>
+          <ul class="sage-nav__list">
+            <%= yield :sidebar_styles %>
+          </ul>
+        </li>
+        <li><%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %>
+          <ul class="sage-nav__list">
+            <%= yield :sidebar_elements %>
+          </ul>
+        </li>
+        <li><%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %>
+          <ul class="sage-nav__list">
+            <%= yield :sidebar_objects %>
+          </ul>
+        </li>
         <li><%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_utilities_url}" %></li>
         <li><%= link_to "Code Status", pages_status_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_status_url}" %></li>
       </ul>

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -4,20 +4,23 @@
       <ul class="sage-nav__list">
         <li><%= link_to "Introduction", pages_index_url, class: "#{current? "sage-nav__link--active", pages_index_url} sage-nav__link" %></li>
         <li><%= link_to "Styles", pages_token_url, class: "sage-nav__link" %>
-          <ul class="sage-nav__list">
+          <% if current_page?(pages_token_url) %>
+          <ul class="sage-nav__list sage-nav__list--sub">
             <%= yield :sidebar_styles %>
           </ul>
-        </li>
+          <% end %></li>
         <li><%= link_to "Elements", pages_elements_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_elements_url}" %>
-          <ul class="sage-nav__list">
+          <% if current_page?(pages_elements_url) %>
+          <ul class="sage-nav__list sage-nav__list--sub">
             <%= yield :sidebar_elements %>
           </ul>
-        </li>
+          <% end %></li>
         <li><%= link_to "Objects", pages_objects_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_objects_url}" %>
+          <% if current_page?(pages_objects_url) %>
           <ul class="sage-nav__list">
             <%= yield :sidebar_objects %>
           </ul>
-        </li>
+          <% end %></li>
         <li><%= link_to "Utilities", pages_utilities_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_utilities_url}" %></li>
         <li><%= link_to "Code Status", pages_status_url, class: "sage-nav__link #{current? "sage-nav__link--active", pages_status_url}" %></li>
       </ul>

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
@@ -13,6 +13,7 @@
 .sage-nav__link {
   display: flex;
   align-items: center;
+  margin-bottom: rem(2px);
   padding: sage-spacing(2xs) sage-spacing(xs);
   color: sage-color(charcoal, 400);
   border-radius: sage-border(radius);

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
@@ -21,17 +21,22 @@
     @extend %t-sage-body-med;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: sage-color(grey, 300);
+  }
+
+  &:active {
+    background: sage-color(grey, 400);
   }
 }
 
 .sage-nav__link--sub {
-  margin-left: sage-spacing(xs);
+  padding-left: sage-spacing(sm);
 
   @extend %t-sage-body-small-med;
 }
 
 .sage-nav__link--active {
-  background: sage-color(grey, 300);
+  background: sage-color(sage, 200);
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
@@ -13,7 +13,7 @@
   left: 0;
   transform: translateX(-100%);
   height: calc(100% - #{$sage-assistant-height});
-  width: sage-sidebar();
+  width: sage-sidebar(xl);
   background: sage-color(grey, 200);
   border-right: sage-border();
   box-shadow: sage-shadow();

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
@@ -50,8 +50,21 @@
   @include overflow-scroll();
   flex: 1;
   padding: sage-spacing();
+
+}
+
+.sage-sidebar__footer::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: sage-spacing(sm) / -1;
+  left: 0;
+  right: 0;
+  height: sage-spacing(sm);
+  background: linear-gradient(to top, sage-color(grey, 200) 0%, rgba(255, 255, 255, 0) 60%);
 }
 
 .sage-sidebar__footer {
+  position: relative;
   padding: sage-spacing();
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
@@ -26,6 +26,7 @@
     position: static;
     transform: none;
     height: auto;
+    width: sage-sidebar();
     box-shadow: none;
     transition: none;
     opacity: 1;

--- a/lib/sage-frontend/stylesheets/system/tokens/_sidebar.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_sidebar.scss
@@ -6,5 +6,6 @@
 $sage-sidebars: (
   sm: rem(240px),
   md: rem(320px),
-  lg: rem(400px)
+  lg: rem(400px),
+  xl: 80vw
 );


### PR DESCRIPTION
## Description
Slight modification of sidebar navigation output to improve link hierarchy. Also added a couple of stand-in styles for missing `:focus` and `:active` states and widened the sidebar on mobile devices.


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- n/a
