### PR TITLE
Sage Tooltips: Namespace as [data-js-tooltip]

### DIFF
--- a/app/views/examples/elements/tooltip/_markup.html.erb
+++ b/app/views/examples/elements/tooltip/_markup.html.erb
@@ -1,1 +1,1 @@
-<button class="sage-btn sage-btn--secondary" data-tooltip="<%= text %>" data-position="<%= position %>" <% if theme != "" %>data-tooltip-theme="<%= theme %>"<% end %><% if size != ""%> data-tooltip-size="<%= size %>"<% end %>><%= position.capitalize %></button>
+<button class="sage-btn sage-btn--secondary" data-js-tooltip="<%= text %>" data-js-tooltip-position="<%= position %>" <% if theme != "" %>data-js-tooltip-theme="<%= theme %>"<% end %><% if size != ""%> data-js-tooltip-size="<%= size %>"<% end %>><%= position.capitalize %></button>

--- a/app/views/examples/elements/tooltip/_props.html.erb
+++ b/app/views/examples/elements/tooltip/_props.html.erb
@@ -1,23 +1,23 @@
 <tr>
-  <td><code>data-tooltip</code></td>
+  <td><code>data-js-tooltip</code></td>
   <td>data attribute for text that will be displayed within the tooltip</td>
   <td>String</td>
   <td>Default</td>
 </tr>
 <tr>
-  <td><code>data-position</code></td>
+  <td><code>data-js-tooltip-position</code></td>
   <td>data attribute to position the tooltip - top | bottom | left | right</td>
   <td>String</td>
   <td>top</td>
 </tr>
 <tr>
-  <td><code>data-tooltip-theme</code></td>
+  <td><code>data-js-tooltip--theme</code></td>
   <td>data attribute to set a light theme on tooltip. If empty, defaults to "dark".</td>
   <td>String</td>
   <td>null</td>
 </tr>
 <tr>
-  <td><code>data-tooltip-size</code></td>
+  <td><code>data-js-tooltip--size</code></td>
   <td>data attribute to assign tooltip size. Choose between <code>small</code> (decreased horizontal padding) and <code>large</code> (increased maximum width). When empty, defaults to a maximum width of 200px.</td>
   <td>String</td>
   <td>null</td>

--- a/lib/sage-frontend/javascript/system/init.js
+++ b/lib/sage-frontend/javascript/system/init.js
@@ -9,7 +9,7 @@ Sage.init = function(elementNamesToInit) {
   }
 
   // Initialize Tooltip
-  if ( shouldInit('tooltip', '[data-tooltip]') ) {
+  if ( shouldInit('tooltip', '[data-js-tooltip]') ) {
     Sage.tooltip();
   }
 

--- a/lib/sage-frontend/javascript/system/tooltip.js
+++ b/lib/sage-frontend/javascript/system/tooltip.js
@@ -3,8 +3,10 @@ Sage.tooltip = function() {
   // ==================================================
   // Variables
   // ==================================================
-  var toolTips = Sage.util.nodelistToArray(document.querySelectorAll("[data-tooltip]"));
-  var toolTipClassname = ".sage-tooltip";
+  const DATA_ATTR = "data-js-tooltip";
+  const SELECTOR = `[${DATA_ATTR}]`;
+  const TOOLTIP_CLASS = "sage-tooltip";
+  var toolTips = Sage.util.nodelistToArray(document.querySelectorAll(SELECTOR));
 
 
   // ==================================================
@@ -17,7 +19,7 @@ Sage.tooltip = function() {
     });
 
     item.addEventListener("mouseout", function(e) {
-      if (e.target.hasAttribute("data-tooltip")) {
+      if (e.target.hasAttribute(DATA_ATTR)) {
         window.requestAnimationFrame(removeTooltip);
       }
     });
@@ -26,14 +28,14 @@ Sage.tooltip = function() {
 
   // tooltip template
   function buildToolTip(e) {
-    if (!e.target.hasAttribute("data-tooltip")) return;
+    if (!e.target.hasAttribute(DATA_ATTR)) return;
 
-    var pos = e.target.getAttribute("data-position") || "top";
+    var pos = e.target.getAttribute(`${DATA_ATTR}-position`) || "top";
     var tooltip = document.createElement("div");
-    tooltip.className = "sage-tooltip";
-    tooltip.innerHTML = e.target.getAttribute("data-tooltip");
-    tooltip.position = e.target.getAttribute("data-position");
-    tooltip.dataItems = ["data-tooltip-theme", "data-tooltip-size"];
+    tooltip.className = TOOLTIP_CLASS;
+    tooltip.innerHTML = e.target.getAttribute(DATA_ATTR);
+    tooltip.position = e.target.getAttribute(`${DATA_ATTR}-position`);
+    tooltip.dataItems = [`${DATA_ATTR}-theme`, `${DATA_ATTR}-size`];
 
     if (!tooltip.innerHTML.length > 0) return;
     generateClasses(tooltip, e);
@@ -45,8 +47,8 @@ Sage.tooltip = function() {
 
   // Removes tooltip from DOM
   function removeTooltip() {
-    if (document.querySelector(toolTipClassname) !== null) {
-      document.body.removeChild(document.querySelector(toolTipClassname));
+    if (document.querySelector(SELECTOR) !== null) {
+      document.body.removeChild(document.querySelector(`.${TOOLTIP_CLASS}`));
     }
   }
 
@@ -56,7 +58,7 @@ Sage.tooltip = function() {
     ele.dataItems.forEach(function(item) {
       var tgt = evt.target;
       if (tgt.hasAttribute(item)) {
-        ele.classList.add("sage-tooltip--" + tgt.getAttribute(item));
+        ele.classList.add(`${TOOLTIP_CLASS}--${tgt.getAttribute(item)}`);
       }
     });
   }
@@ -95,6 +97,6 @@ Sage.tooltip = function() {
 
     tooltip.style.left = left + "px";
     tooltip.style.top = top + pageYOffset + "px";
-    tooltip.classList.add("sage-tooltip-" + position);
+    tooltip.classList.add(`${TOOLTIP_CLASS}--${position}`);
   }
 };

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_tooltip.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_tooltip.scss
@@ -26,7 +26,7 @@
   }
 }
 
-.sage-tooltip-top {
+.sage-tooltip--top {
   &::after {
     left: 50%;
     top: 100%;
@@ -36,7 +36,7 @@
   }
 }
 
-.sage-tooltip-bottom {
+.sage-tooltip--bottom {
   &::after {
     left: 50%;
     bottom: 100%;
@@ -47,7 +47,7 @@
   }
 }
 
-.sage-tooltip-left {
+.sage-tooltip--left {
   &::after {
     left: 100%;
     bottom: 50%;
@@ -58,7 +58,7 @@
   }
 }
 
-.sage-tooltip-right {
+.sage-tooltip--right {
   &::after {
     left: 0;
     bottom: 50%;
@@ -73,16 +73,16 @@
   color: $sage-tooltip-light-font-color;
   background: $sage-tooltip-light-bg-color;
 
-  &.sage-tooltip-top::after {
+  &.sage-tooltip--top::after {
     border-top-color: sage-color(white);
   }
-  &.sage-tooltip-bottom::after {
+  &.sage-tooltip--bottom::after {
     border-bottom-color: sage-color(white);
   }
-  &.sage-tooltip-left::after {
+  &.sage-tooltip--left::after {
     border-left-color: sage-color(white);
   }
-  &.sage-tooltip-right::after {
+  &.sage-tooltip--right::after {
     border-right-color: sage-color(white);
   }
 }


### PR DESCRIPTION
## Description
Updates sage tooltip namespace to follow our js binding pattern (`[data-js-tooltip]`).
Update some js file namespacing

### Steps for testing
1. ensure tooltips work with `[data-js-tooltip]`
2. ensure tooltips _don't_ work with bootstrap powered tooltips in super or admin


## Related
https://kajabi.slack.com/archives/CU5JG6N2E/p1592839312000700