### PR TITLE
v1.1.2 Patch Header Margin

### DIFF
--- a/lib/sage-frontend/stylesheets/system/vendor/_reboot.scss
+++ b/lib/sage-frontend/stylesheets/system/vendor/_reboot.scss
@@ -52,7 +52,7 @@ h4,
 h5,
 h6 {
   margin-top: 0;
-  margin-bottom: 0;
+  margin-bottom: 10px; /* NOTE: margin-bottom must be '10px' to avoid conflicts with Bootstrap reset inside Ladera */
 }
 
 p,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sage",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {


### PR DESCRIPTION
Sets a default of 10px margin-bottom to prevent conflict with bootstrap/ladera, this does not cause issues with our headers because we have our margin-bottoms explicitly set on classnames