### PR TITLE
Typography updates

### DIFF
--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -49,72 +49,72 @@
       <tr>
         <td><span class="t-sage-heading-1">Heading 1</span></td>
         <td><code>t-sage-heading-1</code>
-        <td>800</td>
-        <td>39.81pt</td>
+        <td>700</td>
+        <td>28.83pt</td>
         <td>1.25</td>
-        <td>0.8px</td>
+        <td>1px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-2">Heading 2</span></td>
         <td><code>t-sage-heading-2</code>
-        <td>800</td>
-        <td>33.18pt</td>
+        <td>700</td>
+        <td>25.63pt</td>
         <td>1.25</td>
-        <td>0.8px</td>
+        <td>1px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-3">Heading 3</span></td>
         <td><code>t-sage-heading-3</code>
         <td>700</td>
-        <td>27.65pt</td>
+        <td>22.78pt</td>
         <td>1.25</td>
-        <td>0.5px</td>
+        <td>1px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-4">Heading 4</span></td>
         <td><code>t-sage-heading-4</code>
         <td>600</td>
-        <td>23.04pt</td>
+        <td>20.25pt</td>
         <td>1.25</td>
-        <td>0.5px</td>
+        <td>0.8px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-5">Heading 5</span></td>
         <td><code>t-sage-heading-5</code>
         <td>600</td>
-        <td>19.2pt</td>
+        <td>18pt</td>
         <td>1.25</td>
-        <td>0.3px</td>
+        <td>0.8px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-6">Heading 6</span></td>
         <td><code>t-sage-heading-6</code>
         <td>600</td>
         <td>16pt</td>
-        <td>1.875</td>
-        <td>0.3px</td>
+        <td>1.75</td>
+        <td>0.8px</td>
       </tr>
       <tr>
         <td><span class="t-sage-body">Body*</span></td>
         <td><code>t-sage-body</code>
         <td>400*</td>
         <td>16pt</td>
-        <td>1.875</td>
+        <td>1.75</td>
         <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-body-small">Small Body*</span></td>
         <td><code>t-sage-body-small</code>
         <td>400*</td>
-        <td>13.33pt</td>
-        <td>1.875</td>
+        <td>14.22pt</td>
+        <td>1.75</td>
         <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-body-xsmall">Extra Small Body*</span></td>
         <td><code>t-sage-body-xsmall</code>
         <td>400*</td>
-        <td>11.11pt</td>
+        <td>12.64pt</td>
         <td>1.875</td>
         <td>0.3px</td>
       </tr>

--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -20,7 +20,7 @@
 
 <div class="sage-type">
   <p>
-    The Sage type system uses a minor third modular scale (factor of 1.2) with a base font size of 16pt.
+    The Sage type system uses a minor third modular scale (factor of 1.125) with a base font size of 16px.
   </p>
   <p>
     Typography in our system uses <code>t-sage-</code> classes in order to apply a given typographical specification to an element
@@ -41,7 +41,7 @@
         <th>Class</th>
         <th>Weight</th>
         <th>Size</th>
-        <th>Leading</th>
+        <th>Line-height</th>
         <th>Kerning</th>
       </tr>
     </thead>
@@ -50,73 +50,73 @@
         <td><span class="t-sage-heading-1">Heading 1</span></td>
         <td><code>t-sage-heading-1</code>
         <td>700</td>
-        <td>28.83pt</td>
+        <td>28.83px</td>
         <td>1.25</td>
-        <td>1px</td>
+        <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-2">Heading 2</span></td>
         <td><code>t-sage-heading-2</code>
         <td>700</td>
-        <td>25.63pt</td>
+        <td>25.63px</td>
         <td>1.25</td>
-        <td>1px</td>
+        <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-3">Heading 3</span></td>
         <td><code>t-sage-heading-3</code>
         <td>700</td>
-        <td>22.78pt</td>
+        <td>22.78px</td>
         <td>1.25</td>
-        <td>1px</td>
+        <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-4">Heading 4</span></td>
         <td><code>t-sage-heading-4</code>
         <td>600</td>
-        <td>20.25pt</td>
+        <td>20.25px</td>
         <td>1.25</td>
-        <td>0.8px</td>
+        <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-5">Heading 5</span></td>
         <td><code>t-sage-heading-5</code>
         <td>600</td>
-        <td>18pt</td>
+        <td>18px</td>
         <td>1.25</td>
-        <td>0.8px</td>
+        <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-heading-6">Heading 6</span></td>
         <td><code>t-sage-heading-6</code>
         <td>600</td>
-        <td>16pt</td>
-        <td>1.75</td>
-        <td>0.8px</td>
+        <td>16px</td>
+        <td>1.25</td>
+        <td>0.3px</td>
       </tr>
       <tr>
         <td><span class="t-sage-body">Body*</span></td>
         <td><code>t-sage-body</code>
         <td>400*</td>
-        <td>16pt</td>
+        <td>16px</td>
         <td>1.75</td>
-        <td>0.3px</td>
+        <td>0.2px</td>
       </tr>
       <tr>
         <td><span class="t-sage-body-small">Small Body*</span></td>
         <td><code>t-sage-body-small</code>
         <td>400*</td>
-        <td>14.22pt</td>
+        <td>14.22px</td>
         <td>1.75</td>
-        <td>0.3px</td>
+        <td>0.2px</td>
       </tr>
       <tr>
         <td><span class="t-sage-body-xsmall">Extra Small Body*</span></td>
         <td><code>t-sage-body-xsmall</code>
         <td>400*</td>
-        <td>12.64pt</td>
-        <td>1.875</td>
-        <td>0.3px</td>
+        <td>12.64px</td>
+        <td>1.75</td>
+        <td>0.2px</td>
       </tr>
     </tbody>
     <tfoot>

--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -20,7 +20,7 @@
 
 <div class="sage-type">
   <p>
-    The Sage type system uses a minor third modular scale (factor of 1.125) with a base font size of 16px.
+    The Sage type system uses a major second modular scale (factor of 1.125) with a base font size of 16px.
   </p>
   <p>
     Typography in our system uses <code>t-sage-</code> classes in order to apply a given typographical specification to an element

--- a/lib/sage-frontend/stylesheets/docs/_specs.scss
+++ b/lib/sage-frontend/stylesheets/docs/_specs.scss
@@ -14,7 +14,7 @@
   td {
     padding: 4px;
     font-size: sage-font-size(xs);
-    vertical-align: baseline;
+    vertical-align: middle;
     border-bottom: 1px solid sage-color(grey, 200);
   }
 

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -28,40 +28,40 @@ $t-body-xsmall-spec: map-merge($t-base-spec, (
 $type-specs: (
   // Headings
   "heading-1": (
-    weight: sage-font-weight(xbold),
+    weight: sage-font-weight(bold),
     size: sage-font-size(4xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(lg),
+    kerning: sage-letter-spacing(xl),
   ),
   "heading-2": (
-    weight: sage-font-weight(xbold),
+    weight: sage-font-weight(bold),
     size: sage-font-size(3xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(lg),
+    kerning: sage-letter-spacing(xl),
   ),
   "heading-3": (
     weight: sage-font-weight(bold),
     size: sage-font-size(2xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(md),
+    kerning: sage-letter-spacing(xl),
   ),
   "heading-4": (
     weight: sage-font-weight(semibold),
     size: sage-font-size(xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(md),
+    kerning: sage-letter-spacing(lg)
   ),
   "heading-5": (
     weight: sage-font-weight(semibold),
     size: sage-font-size(lg),
     leading: sage-line-height(sm),
-    kerning: 0,
+    kerning: sage-letter-spacing(lg)
   ),
   "heading-6": (
     weight: sage-font-weight(semibold),
     size: $sage-body-font-size,
     leading: $sage-body-font-line-height,
-    kerning: $sage-body-letter-spacing
+    kerning: sage-letter-spacing(lg)
   ),
 
   // Body

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -31,37 +31,37 @@ $type-specs: (
     weight: sage-font-weight(bold),
     size: sage-font-size(4xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(xl),
+    kerning: sage-letter-spacing(sm),
   ),
   "heading-2": (
     weight: sage-font-weight(bold),
     size: sage-font-size(3xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(xl),
+    kerning: sage-letter-spacing(sm),
   ),
   "heading-3": (
     weight: sage-font-weight(bold),
     size: sage-font-size(2xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(xl),
+    kerning: sage-letter-spacing(sm),
   ),
   "heading-4": (
     weight: sage-font-weight(semibold),
     size: sage-font-size(xl),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(lg)
+    kerning: sage-letter-spacing(sm)
   ),
   "heading-5": (
     weight: sage-font-weight(semibold),
     size: sage-font-size(lg),
     leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(lg)
+    kerning: sage-letter-spacing(sm)
   ),
   "heading-6": (
     weight: sage-font-weight(semibold),
     size: $sage-body-font-size,
-    leading: $sage-body-font-line-height,
-    kerning: sage-letter-spacing(lg)
+    leading: sage-line-height(sm),
+    kerning: sage-letter-spacing(sm)
   ),
 
   // Body

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -33,7 +33,7 @@ $sage-body-font-size: 1rem !default; // 16px
 $sage-body-font-weight: sage-font-weight() !default;
 $sage-body-font-line-height: sage-line-height(lg) !default;
 $sage-body-font-color: sage-color(charcoal, 400) !default;
-$sage-body-letter-spacing: sage-letter-spacing(sm) !default;
+$sage-body-letter-spacing: sage-letter-spacing(xs) !default;
 $sage-body-margin-bottom: sage-spacing() !default;
 
 // Headings

--- a/lib/sage-frontend/stylesheets/system/tokens/_font_size.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_font_size.scss
@@ -4,12 +4,12 @@
 }
 
 $sage-font-sizes: (
-  xs: rem(11.11px),
-  sm: rem(13.33px),
+  xs: rem(12.64px),
+  sm: rem(14.22px),
   md: rem(16px),
-  lg: rem(19.2px),
-  xl: rem(23.04px),
-  2xl: rem(27.65px),
-  3xl: rem(33.18px),
-  4xl: rem(39.81px)
+  lg: rem(18px),
+  xl: rem(20.25px),
+  2xl: rem(22.78px),
+  3xl: rem(25.63px),
+  4xl: rem(28.83px)
 );

--- a/lib/sage-frontend/stylesheets/system/tokens/_font_weight.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_font_weight.scss
@@ -7,6 +7,5 @@ $sage-font-weights: (
   regular: 400,
   medium: 500,
   semibold: 600,
-  bold: 700,
-  xbold: 800,
+  bold: 700
 );

--- a/lib/sage-frontend/stylesheets/system/tokens/_letter_spacing.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_letter_spacing.scss
@@ -7,4 +7,5 @@ $sage-letter-spacings: (
   sm: rem(0.3px),
   md: rem(0.5px),
   lg: rem(0.8px),
+  xl: rem(1px)
 );

--- a/lib/sage-frontend/stylesheets/system/tokens/_letter_spacing.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_letter_spacing.scss
@@ -4,8 +4,8 @@
 }
 
 $sage-letter-spacings: (
+  xs: rem(0.2px),
   sm: rem(0.3px),
   md: rem(0.5px),
-  lg: rem(0.8px),
-  xl: rem(1px)
+  lg: rem(0.8px)
 );

--- a/lib/sage-frontend/stylesheets/system/tokens/_line_height.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_line_height.scss
@@ -6,5 +6,5 @@
 $sage-line-heights: (
   sm: 1.25,
   md: 1.5,
-  lg: 1.875,
+  lg: 1.75
 );


### PR DESCRIPTION
## Description
Various modifications affecting global typography settings. For the most part, naming will remain the same as before, and only the values should have changed.

tldr;
- We're now using a major second scale (a 9:8 ratio, or 1.125 multiplier), vs the previous minor third scale (6:5 ratio, or 1.2 multiplier)
- Headings `H1` - `H6` are smaller, less bold, and more tightly kerned overall
- `line-height` updates:
  - decreased from `1.875` to `1.75` on base text
  - heading `line-height` stays at `1.25`
- `letter-spacing` on base text decreased to `0.2px`
- `xbold` font weight option removed (this had only been used on headings, which are now `bold`/`700`)
- revised documentation:
  - standardized font sizing units to match Figma, with `px` instead of `pt`
  - replace `leading` with `line-height` to align with CSS notation
  - adjust vertical alignment in font spec tables

---

#### `sage-font-size`

| Spec  | New value          | Old value |
| ----- | ------------------ | --------- |
| `xs`  | `12.64px`          | `11.11px` |
| `sm`  | `14.22px`          | `13.33px` |
| `md`  | `16px` (NO CHANGE) | `16px`    |
| `lg`  | `18px`             | `19.2px`  |
| `xl`  | `20.25px`          | `23.04px` |
| `2xl` | `22.78px`          | `27.65px` |
| `3xl` | `25.63px`          | `33.18px` |
| `4xl` | `39.81px`          | `28.83px` |

---

#### `sage-font-weight`
| Spec    | New value | Old value |
| ------- | --------- | --------- |
| `xbold` | (REMOVED) | `800`     |

All other values remain the same

---

#### `sage-line-height`
| Spec | New value | Old value |
| ---- | --------- | --------- |
| `lg` | `1.75`    | `1.875`   |

All other values remain the same

---

#### `sage-letter-spacing`
| Spec | New value     | Old value |
| ---- | ------------- | --------- |
| `xs` | `0.2px` (NEW) | N/A       |

All other values remain the same


### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  NEW   |  OLD  |
|--------|--------|
|<img src="https://user-images.githubusercontent.com/816579/85903120-6e446e80-b7ba-11ea-938e-743523f1bd16.png" width="320">|<img src="https://user-images.githubusercontent.com/816579/85903170-8fa55a80-b7ba-11ea-8551-221ed950dd57.png" width="320">|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the documentation site
2. Navigate through and verify that the typography adjustments have not unexpectedly affected alignment and spacing 


