### PR TITLE
[BUG] Input group button margin

### DIFF
--- a/lib/sage-frontend/stylesheets/docs/_button.scss
+++ b/lib/sage-frontend/stylesheets/docs/_button.scss
@@ -11,4 +11,8 @@
     margin-left: 0;
     margin-right: sage-spacing(xs);
   }
+
+  .example__preview:not(.example__preview--page) .sage-input-group & {
+    margin-right: 0;
+  }
 }


### PR DESCRIPTION
## Description
Fixes input group button right margin, inherited from a docs-specific style intended for `.sage-btn`. 


### Screenshots
|  before   |  after  |
|--------|--------|
|![input-group](https://user-images.githubusercontent.com/816579/85907474-773b3d00-b7c6-11ea-95f0-f429418e82dd.png)|![input-group-after](https://user-images.githubusercontent.com/816579/85907661-1102ea00-b7c7-11ea-8bd0-98784171f71f.png)|


