### PR TITLE
Reduce `line-height` in Alert title

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_alert.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_alert.scss
@@ -34,8 +34,10 @@ $-alert-colors: (
 }
 
 .sage-alert__title {
-  color: sage-color(charcoal, 500);
   @extend %t-sage-body-semi;
+  color: sage-color(charcoal, 500);
+  line-height: sage-line-height(md);
+
   @each $name, $color in $-alert-colors {
     .sage-alert--#{$name} & {
       color: sage-color($color, 500);


### PR DESCRIPTION
## Description
Per feedback from design, the `line-height` of the title in the Alert object should be decreased from its current `1.875` value to `1.5`. When the title text wraps, the vertical spacing appears too tall.

This also corrects a misalignment with the title and icon as seen in the attached screens.

|  before   |  after  |
|--------|--------|
|![alert-before](https://user-images.githubusercontent.com/816579/85910016-7d82e680-b7d1-11ea-9369-990380564ce4.png)|![alert-after](https://user-images.githubusercontent.com/816579/85910020-82479a80-b7d1-11ea-92d3-76979cfaf01a.png)|


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- n/a
