### PR TITLE
Adjust z-index scale

### DIFF
--- a/lib/sage-frontend/stylesheets/docs/_example.scss
+++ b/lib/sage-frontend/stylesheets/docs/_example.scss
@@ -138,7 +138,7 @@ $-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
   &::before {
     content: "";
     display: block;
-    z-index: sage-z-index(default, 1);
+    z-index: sage-z-index(default, 100);
     position: absolute;
     left: 0;
     right: 0;

--- a/lib/sage-frontend/stylesheets/system/tokens/_z_index.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_z_index.scss
@@ -12,12 +12,12 @@
 $sage-z-indexes: (
   negative: -1,
   default: 0,
-  raised: 10,
-  alert: 20,
-  underlay: 40,
-  nav: 50,
-  overlay: 60,
-  modal: 70,
-  priority: 80,
-  nuclear: 100
+  raised: 1000,
+  alert: 2000,
+  underlay: 3000,
+  nav: 4000,
+  overlay: 5000,
+  modal: 6000,
+  priority: 8000,
+  nuclear: 9000
 );


### PR DESCRIPTION
## Description
Investigate and/or adjust our `z-index` scale to accommodate for high-level `z-index` values in `kajabi-products`.

We're using various levels of `z-index` in `kajabi-products` far above our Sage values (currently ranging from `-1` to `100`). Most of the values are in the `800` to `1000` range, but some are as high as `10000000000` 😱 

- Ideally we should set our base and scale to allow for stacking flexibility, while keeping our existing levels to maintain priority and organization
- We'll also want to reign in the outliers as much as possible. Anything above `2000` in `kajabi-products` should probably be investigated and potentially refactored
- Initial increment levels should be by `100` unless negative. For example, `sage-z-index('raised', 100)` for `1100`. If more granular adjustment is needed, the lowest increment should be a factor of `10` (`1110` and `1120`) **and not by `1`** (`1101` and `1102`)

|  | current   |  proposed  | notes |
|--------|--------|--------|--------|
|default| 0 | 0 | used for reset and negative positioning|
|negative| -1 | -1 | |
|raised| 10 | 1000 | page widgets, like tooltips, dropdowns |
| alert | 20 | 2000 | raised priority on-page items: banners |
| underlay | 40 | 3000 | lower priority overlay, moved one level down from current position |
| nav | 50 | 4000 | uses underlay, not overlay |
| overlay | 60 | 5000 | |
| modal | 70 | 6000 | |
| | | | reserving 7000 for future use |
| priority | 80 | 8000 | |
| nuclear | 100 | 9000 | |

## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- https://github.com/Kajabi/kajabi-products/pull/14619