### PR TITLE
Form select documentation updates

### DIFF
--- a/app/helpers/elements_helper.rb
+++ b/app/helpers/elements_helper.rb
@@ -27,7 +27,7 @@ module ElementsHelper
       },
       {
         title: "form_select",
-        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+        description: "The form select presents a selectable menu of options. The options within the menu are represented by <option> elements.",
         scss_design:  "done",
         scss_dev:     "done",
         scss_doc:     "todo",

--- a/app/views/examples/elements/form_select/_props.html.erb
+++ b/app/views/examples/elements/form_select/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td>ID</td>
-  <td>Unique identifier for this input field. Should match the "for" property on the corresponding label</td>
+  <td>Unique identifier for the select element. Should match the "for" property on the corresponding label</td>
   <td>String</td>
   <td>null</td>
 </tr>

--- a/app/views/examples/elements/form_select/_props.html.erb
+++ b/app/views/examples/elements/form_select/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td>Prop Name</td>
-  <td>The description of the property goes here.</td>
+  <td>ID</td>
+  <td>Unique identifier for this input field. Should match the "for" property on the corresponding label</td>
   <td>String</td>
-  <td>Default</td>
+  <td>null</td>
 </tr>

--- a/app/views/examples/elements/form_select/_rules_do.html.erb
+++ b/app/views/examples/elements/form_select/_rules_do.html.erb
@@ -1,3 +1,1 @@
-<ul>
-  <li>Rules for what you should do with this element go here.</li>
-</ul>
+

--- a/app/views/examples/elements/form_select/_rules_dont.html.erb
+++ b/app/views/examples/elements/form_select/_rules_dont.html.erb
@@ -1,3 +1,1 @@
-<ul>
-  <li>Rules for what you should not do with this element go here.</li>
-</ul>
+


### PR DESCRIPTION
## Description
Adds missing documentation for the form select element.

### Related issues
- https://github.com/Kajabi/sage/issues/273