### PR TITLE
Sortable, Button Icon-Only, Panel – for BUILD Site Navigation Project

### DIFF
--- a/app/helpers/objects_helper.rb
+++ b/app/helpers/objects_helper.rb
@@ -233,6 +233,19 @@ module ObjectsHelper
         react_dev:    "todo",
         react_doc:    "todo"
       },
+      {
+        title: "sortable",
+        description: "Sage sortable list",
+        scss_design:  "done",
+        scss_dev:     "done",
+        scss_doc:     "done",
+        rails_design: "doing",
+        rails_dev:    "doing",
+        rails_doc:    "doing",
+        react_design: "todo",
+        react_dev:    "todo",
+        react_doc:    "todo"
+      },
     ]
   end
 

--- a/app/views/application/_assistant.html.erb
+++ b/app/views/application/_assistant.html.erb
@@ -11,7 +11,7 @@
   <div class="sage-assistant__actions">
     <%= link_to "v#{$SAGE_VERSION}",
       "https://github.com/Kajabi/sage/releases/tag/v#{$SAGE_VERSION}",
-      class: "sage-btn sage-btn--small sage-btn--secondary",
+      class: "sage-btn sage-btn--small sage-btn--primary",
       target: "_blank",
       rel: "noopener noreferrer"
     %>

--- a/app/views/application/_scripts.html.erb
+++ b/app/views/application/_scripts.html.erb
@@ -17,7 +17,8 @@
       'inputgroup',
       'inputhelper',
       'modal',
-      'dropdown'
+      'dropdown',
+      'sortable'
     ]);
   });
 </script>

--- a/app/views/examples/elements/_element.html.erb
+++ b/app/views/examples/elements/_element.html.erb
@@ -9,14 +9,14 @@
   do_content: do_content,
   dont_content: dont_content %>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-preview" class="t-sage-heading-2 example__title">Preview</h2>
   <div class="example__preview">
     <%= render "examples/elements/#{@title}/preview" %>
   </div>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
     <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= @title %>">Expand this code snippet</button>

--- a/app/views/examples/elements/_element_preview.html.erb
+++ b/app/views/examples/elements/_element_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-media">
     <h2 id="element-<%= title %>" class="sage-media-body t-sage-heading-2 example__title"><%= link_to pages_element_url(title: title, description: description), class: "example__link" do %><%= title.titleize %><% end %></h2>
     <%= link_to pages_breakout_url(type: "element", title: title, description: description), target: "_blank", class: "example__link example__link--breakout" do %>

--- a/app/views/examples/elements/button/_preview.html.erb
+++ b/app/views/examples/elements/button/_preview.html.erb
@@ -592,7 +592,7 @@
 
 <!-- Primary button (icon-right) -->
 <%= render "examples/elements/button/markup",
-  text: "",
+  text: "Name Of Action",
   is_link_btn: false,
   link_url: "",
   is_disabled: false,
@@ -602,27 +602,12 @@
   style_danger: false,
   style_small: false,
   style_align_end: false,
-  sage_icon_name: "sage-btn--icon-gear"
+  sage_icon_name: "sage-btn--icon-only-add"
 %>
 
 <!-- Primary button (icon-right) -->
 <%= render "examples/elements/button/markup",
-  text: "",
-  is_link_btn: false,
-  link_url: "",
-  is_disabled: false,
-  style_primary: false,
-  style_secondary: false,
-  style_tertiary: true,
-  style_danger: false,
-  style_small: false,
-  style_align_end: false,
-  sage_icon_name: "sage-btn--icon-pen"
-%>
-
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  text: "",
+  text: "Name Of Action",
   is_link_btn: false,
   link_url: "",
   is_disabled: false,
@@ -632,13 +617,28 @@
   style_danger: false,
   style_small: false,
   style_align_end: false,
-  sage_icon_name: "sage-btn--icon-send-message"
+  sage_icon_name: "sage-btn--icon-only-send-message"
 %>
 
 <!-- Primary button (icon-right) -->
 <%= render "examples/elements/button/markup",
-  text: "",
+  text: "Name Of Action",
   is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_danger: false,
+  style_small: false,
+  style_align_end: false,
+  sage_icon_name: "sage-btn--icon-only-pen"
+%>
+
+<!-- Primary button (icon-right) -->
+<%= render "examples/elements/button/markup",
+  text: "Name Of Action",
+  is_link_btn: true,
   link_url: "",
   is_disabled: false,
   style_primary: false,
@@ -647,5 +647,5 @@
   style_danger: true,
   style_small: false,
   style_align_end: false,
-  sage_icon_name: "sage-btn--icon-remove"
+  sage_icon_name: "sage-btn--icon-only-remove"
 %>

--- a/app/views/examples/elements/button/_preview.html.erb
+++ b/app/views/examples/elements/button/_preview.html.erb
@@ -585,3 +585,67 @@
   style_align_end: false,
   sage_icon_name: ""
 %>
+
+
+<br><br><br>
+<h3 class="t-sage-heading-6">Icon Button</h3>
+
+<!-- Primary button (icon-right) -->
+<%= render "examples/elements/button/markup",
+  text: "",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: true,
+  style_secondary: false,
+  style_tertiary: false,
+  style_danger: false,
+  style_small: false,
+  style_align_end: false,
+  sage_icon_name: "sage-btn--icon-gear"
+%>
+
+<!-- Primary button (icon-right) -->
+<%= render "examples/elements/button/markup",
+  text: "",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: true,
+  style_danger: false,
+  style_small: false,
+  style_align_end: false,
+  sage_icon_name: "sage-btn--icon-pen"
+%>
+
+<!-- Primary button (icon-right) -->
+<%= render "examples/elements/button/markup",
+  text: "",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: true,
+  style_tertiary: false,
+  style_danger: false,
+  style_small: false,
+  style_align_end: false,
+  sage_icon_name: "sage-btn--icon-send-message"
+%>
+
+<!-- Primary button (icon-right) -->
+<%= render "examples/elements/button/markup",
+  text: "",
+  is_link_btn: false,
+  link_url: "",
+  is_disabled: false,
+  style_primary: false,
+  style_secondary: false,
+  style_tertiary: false,
+  style_danger: true,
+  style_small: false,
+  style_align_end: false,
+  sage_icon_name: "sage-btn--icon-remove"
+%>

--- a/app/views/examples/objects/_object.html.erb
+++ b/app/views/examples/objects/_object.html.erb
@@ -9,14 +9,14 @@
   do_content: do_content,
   dont_content: dont_content %>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-preview" class="t-sage-heading-2 example__title">Preview</h2>
   <div class="example__preview example__preview--page">
     <%= render "examples/objects/#{@title}/preview" %>
   </div>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
     <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= @title %>">Expand this code snippet</button>

--- a/app/views/examples/objects/_object_preview.html.erb
+++ b/app/views/examples/objects/_object_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-media">
     <div class="sage-media-body">
       <h2 id="object-<%= title %>" class="t-sage-heading-2 example__title"><%= link_to pages_object_url(title: title, description: description), class: "example__link" do %><%= title.titleize %><% end %></h2>

--- a/app/views/examples/objects/sortable/_markup.html.erb
+++ b/app/views/examples/objects/sortable/_markup.html.erb
@@ -1,0 +1,44 @@
+<div class="sage-sortable" data-js-sortable>
+
+  <div class="sage-sortable__item">
+    <div class="sage-sortable__item-content">
+      <h5 class="t-sage-body">Train Conducting</h5>
+      <p class="t-sage-body-xsmall">Assignment</p>
+    </div>
+    <div class="sage-sortable__item-actions">
+      <a class="sage-btn sage-btn--tertiary">Edit<a>
+    </div>
+  </div>
+
+  <div class="sage-sortable__item">
+    <div class="sage-sortable__item-content">
+      <h5 class="t-sage-body">Train Conducting</h5>
+      <p class="t-sage-body-xsmall">Assignment</p>
+    </div>
+    <div class="sage-sortable__item-actions">
+      <a class="sage-btn sage-btn--tertiary">Edit<a>
+    </div>
+  </div>
+
+  <div class="sage-sortable__item">
+    <div class="sage-sortable__item-content">
+      <h5 class="t-sage-body">Train Conducting</h5>
+      <p class="t-sage-body-xsmall">Assignment</p>
+    </div>
+    <div class="sage-sortable__item-actions">
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-preview-on"><a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-pen"><a>
+    </div>
+  </div>
+
+  <div class="sage-sortable__item">
+    <div class="sage-sortable__item-content">
+      <h5 class="t-sage-body">Train Conducting</h5>
+      <p class="t-sage-body-xsmall">Assignment</p>
+    </div>
+    <div class="sage-sortable__item-actions">
+      <a class="sage-btn sage-btn--tertiary">Edit<a>
+    </div>
+  </div>
+
+</div>

--- a/app/views/examples/objects/sortable/_markup.html.erb
+++ b/app/views/examples/objects/sortable/_markup.html.erb
@@ -6,7 +6,8 @@
       <p class="t-sage-body-xsmall">Assignment</p>
     </div>
     <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary">Edit<a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
     </div>
   </div>
 
@@ -16,7 +17,8 @@
       <p class="t-sage-body-xsmall">Assignment</p>
     </div>
     <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary">Edit<a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
     </div>
   </div>
 
@@ -26,8 +28,8 @@
       <p class="t-sage-body-xsmall">Assignment</p>
     </div>
     <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-preview-on"><a>
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-pen"><a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
     </div>
   </div>
 
@@ -37,7 +39,8 @@
       <p class="t-sage-body-xsmall">Assignment</p>
     </div>
     <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary">Edit<a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
+      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
     </div>
   </div>
 

--- a/app/views/examples/objects/sortable/_markup.html.erb
+++ b/app/views/examples/objects/sortable/_markup.html.erb
@@ -1,47 +1,25 @@
-<div class="sage-sortable" data-js-sortable>
+<div class="sage-sortable" data-js-sortable="resourceNameHere">
 
-  <div class="sage-sortable__item">
+  <section class="sage-sortable__item" data-js-sortable-update-url="/update/url/here">
     <div class="sage-sortable__item-content">
-      <h5 class="t-sage-body">Train Conducting</h5>
-      <p class="t-sage-body-xsmall">Assignment</p>
+      <h1 class="t-sage-body">Batman</h1>
+      <p class="t-sage-body-xsmall">Batmobile</p>
     </div>
     <div class="sage-sortable__item-actions">
       <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
       <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
     </div>
-  </div>
+  </section>
 
-  <div class="sage-sortable__item">
+  <section class="sage-sortable__item" data-js-sortable-update-url="/update/url/here">
     <div class="sage-sortable__item-content">
-      <h5 class="t-sage-body">Train Conducting</h5>
-      <p class="t-sage-body-xsmall">Assignment</p>
+      <h1 class="t-sage-body">Spiderman</h1>
+      <p class="t-sage-body-xsmall">Mary Jane's Oldsmobile</p>
     </div>
     <div class="sage-sortable__item-actions">
       <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
       <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
     </div>
-  </div>
-
-  <div class="sage-sortable__item">
-    <div class="sage-sortable__item-content">
-      <h5 class="t-sage-body">Train Conducting</h5>
-      <p class="t-sage-body-xsmall">Assignment</p>
-    </div>
-    <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
-    </div>
-  </div>
-
-  <div class="sage-sortable__item">
-    <div class="sage-sortable__item-content">
-      <h5 class="t-sage-body">Train Conducting</h5>
-      <p class="t-sage-body-xsmall">Assignment</p>
-    </div>
-    <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
-    </div>
-  </div>
+  </section>
 
 </div>

--- a/app/views/examples/objects/sortable/_preview.html.erb
+++ b/app/views/examples/objects/sortable/_preview.html.erb
@@ -1,0 +1,1 @@
+<%= render "examples/objects/sortable/markup" %>

--- a/app/views/examples/shared/_props.html.erb
+++ b/app/views/examples/shared/_props.html.erb
@@ -1,5 +1,5 @@
 <% if props_content.present? %>
-  <div id="<%= @title %>-example-props" class="sage-panel sage-type">
+  <div id="<%= @title %>-example-props" class="docs-container sage-type">
     <h2 class="t-sage-heading-2 example__title">Properties</h2>
     <div class="sage-table-wrapper">
       <div class="sage-table-wrapper__overflow">

--- a/app/views/examples/shared/_rules.html.erb
+++ b/app/views/examples/shared/_rules.html.erb
@@ -1,5 +1,5 @@
 <% if do_content.present? || dont_content.present? %>
-  <div id="<%= @title %>-example-best-practices" class="sage-panel sage-type">
+  <div id="<%= @title %>-example-best-practices" class="docs-container sage-type">
     <h2 class="t-sage-heading-2 example__title">Best Practices</h2>
     <div class="sage-row">
       <div class="sage-col--md-6">

--- a/app/views/examples/utilities/_utility.html.erb
+++ b/app/views/examples/utilities/_utility.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-media">
     <div class="sage-media-body">
       <h2 id="<%= title %>" class="t-sage-heading-2 example__title"><%= title.titleize %></h2>

--- a/app/views/pages/color.html.erb
+++ b/app/views/pages/color.html.erb
@@ -49,13 +49,13 @@
   <p>You will notice <strong>pure black is not used at all as a text color</strong>. Instead, we rely on 400 for our darkest text color value. Our default text color is sage-color(charcoal, 400). To achive more depth use 300 to 400 shades for text on top of lighter background colors using 100 to 200 for their fill. You can also use 100 to 200 as the text color on darker backgrounds using from 300 to 400 for their fill. Pure white is used as a text color when the lightest shade (100) of a color will not pass color contrast tests. At the moment, this only occurs on the 300 shades of purple, primary, and red.</p>
   <h2 id="primary">Primary</h2>
   <p>These are the splashes of color that appear the most in Kajabi’s UI, and are the ones that determine the overall "look" of the app. Use these for things like primary actions, links, navigation items, icons, accent borders, or text we want to emphasize.</p>
-  <div class="sage-panel">
+  <div class="docs-container">
     <%= render "color_values", color: "primary"%>
   </div>
   <h2 id="neutral">Neutrals</h2>
   <p>These are the colors we will use the most and will make up the majority of Kajabi’s UI.<br>
   Use them for most of our text, backgrounds, and borders, as well as for things like alternative buttons and links.</p>
-  <div class="sage-panel">
+  <div class="docs-container">
     <div class="sage-row">
       <div class="sage-col--md-6">
         <h3 id="grey">Grey</h3>
@@ -69,7 +69,7 @@
   </div>
   <h2>Supporting</h2>
   <p>These colors should be used fairly conservatively throughout Kajabi’s UI to avoid overpowering our primary colors. We’ll use them when we need an element to stand out.</p>
-  <div class="sage-panel">
+  <div class="docs-container">
     <div class="sage-row">
       <div class="sage-col--md-6">
         <h3 id="purple">Purple</h3>

--- a/app/views/pages/container.html.erb
+++ b/app/views/pages/container.html.erb
@@ -21,7 +21,7 @@
     </ul>
   </div>
 <% end %>
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="standard">Standard Container</h2>
   <pre class="prettyprint"><code>&lt;div class=&quot;sage-container&quot;&gt;
   &lt;!-- 1200px width container --&gt;

--- a/app/views/pages/grid.html.erb
+++ b/app/views/pages/grid.html.erb
@@ -42,7 +42,7 @@
     </ul>
   </div>
 <% end %>
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="grid-how-to">How to use the Sage grid</h2>
   <p>You may be familiar with grid systems from popular front-end frameworks, such as <a href="https://getbootstrap.com/docs/4.0/layout/grid/" rel="nofollow">Bootstrap</a> or <a href="https://get.foundation/sites/docs/grid.html" rel="nofollow">Foundation</a>. Similar to these, the Sage layout grid is constructed of individual columns (<code>.sage-col</code>) grouped within rows (<code>.sage-row</code>).</p>
 
@@ -89,7 +89,7 @@
 
 </div>
 
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="grid-responsive">Responsive grid layouts</h2>
   <p>Viewing the <a href="#grid-columns">column combinations example above</a>, you may have noticed that the columns display as full-width blocks when viewed at smaller screen sizes. To account for the increased or decreased space available, we can target specific screen sizes (called <em>breakpoints</em>) by modifying the classnames used in each column. This is referred to as <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design" rel="nofollow">responsive design</a>, giving us greater flexibility in our layouts.</p>
 
@@ -271,7 +271,7 @@
 
 </div>
 
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="grid-alignment">Alignment</h2>
   <h3 class="t-heading-5" id="grid-alignment-vertical">Vertical alignment</h3>
   <p>The default vertical alignment for each <code>.sage-row</code> aligns its columns to the top of the <code>.sage-row</code> container. This can be changed by adding one of the following <code>sage-row--valign</code> classes:</p>

--- a/app/views/pages/icon.html.erb
+++ b/app/views/pages/icon.html.erb
@@ -13,7 +13,7 @@
   then <code>aria-hidden="true"</code> can be used instead.
 </p>
 <% end %>
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-row">
     <div class="sage-col--md-4 sage-col--sm-6">
       <div class="sage-icon-block">

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="t-sage-heading-1">Welcome to Sage</h1>
   <p>The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.</p>
 <% end %>
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="how_works">How it works</h2>
   <p>The UI of the Kajabi Core application is a combination of Rails Components, React Components and a custom CSS Framework called Sage that applies a uniform style to both.</p>
   <p>We think of our approach to UI at Kajabi in this way: We default to using Rails Components and a classic Rails approach to most problems and move to React where it counts.</p>

--- a/app/views/pages/status.html.erb
+++ b/app/views/pages/status.html.erb
@@ -24,7 +24,7 @@
     </ul>
   </div>
 <% end %>
-<div class="sage-panel">
+<div class="docs-container">
   <h2 class="t-sage-heading-2">Elements</h2>
   <div class="sage-table-wrapper">
     <div class="sage-table-wrapper__overflow">
@@ -45,7 +45,7 @@
     </div>
   </div>
 </div>
-<div class="sage-panel">
+<div class="docs-container">
   <h2 class="t-sage-heading-2">Objects</h2>
   <div class="sage-table-wrapper">
     <div class="sage-table-wrapper__overflow">

--- a/app/views/pages/token.html.erb
+++ b/app/views/pages/token.html.erb
@@ -16,7 +16,7 @@
   </div>
 <% end %>
 <% sage_tokens.each do |token| %>
-  <div class="sage-panel sage-type">
+  <div class="docs-container sage-type">
     <h2 id="<%= token[:category] %>"><%= token[:category].titleize %></h2>
     <h3 class="t-sage-heading-6">Default</h3>
     <div class="tokens">

--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -154,7 +154,7 @@
   </p>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h3 class="t-sage-heading-3">Lorem ipsum dolor sit</h3>
   <div class="sage-code-snippet">
     <pre class="prettyprint"><code>&lt;h3 class="t-sage-heading-3"&gt;Lorem ipsum dolor sit&lt;/h3&gt;</code></pre>
@@ -170,7 +170,7 @@
   </p>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <span class="t-sage-heading-3">Lorem ipsum dolor sit</span>
   <div class="sage-code-snippet">
     <pre class="prettyprint"><code>&lt;span class="t-sage-heading-3"&gt;Lorem ipsum dolor sit&lt;/span&gt;</code></pre>
@@ -187,7 +187,7 @@
   </p>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-type">
     <h3>User-generated content</h3>
     <p>See how content inside this <code>sage-type</code> container automatically recieves corresponding type specs?</p>

--- a/lib/sage-frontend/javascript/system/index.js
+++ b/lib/sage-frontend/javascript/system/index.js
@@ -13,5 +13,6 @@ require('./dropdown')
 require('./inputgroup')
 require('./inputhelper')
 require('./modal')
+require('./sortable')
 
 require('./init')

--- a/lib/sage-frontend/javascript/system/init.js
+++ b/lib/sage-frontend/javascript/system/init.js
@@ -1,7 +1,11 @@
 Sage.init = function(elementNamesToInit) {
-  var shouldInit = function(elementName, selector) {
+  let shouldInit = function(elementName, selector) {
     return elementNamesToInit.includes(elementName) && document.querySelector(selector) !== null;
   };
+
+  let inDocumentationContext = function() {
+    return !!document.querySelector('.sage-docs');
+  }
 
   // Initialize Table
   if ( shouldInit('table', '.sage-table') ) {
@@ -53,13 +57,18 @@ Sage.init = function(elementNamesToInit) {
     Sage.modal.init();
   }
 
-  // Initialize Menu
+  // Initialize Dropdown
   if ( shouldInit('dropdown', '[data-js-dropdown]') ) {
     Sage.dropdown.init();
   }
 
+  // Initialize Sortable
+  if ( shouldInit('dropdown', '[data-js-sortable]') ) {
+    Sage.sortable.init();
+  }
+
   // Initialize Banner
-  if ( shouldInit('banner', '.sage-banner--active') && !document.querySelector('.sage-docs') ) {
+  if ( shouldInit('banner', '.sage-banner--active') && !inDocumentationContext() ) {
     Sage.banner.init();
   }
 

--- a/lib/sage-frontend/javascript/system/init.js
+++ b/lib/sage-frontend/javascript/system/init.js
@@ -63,7 +63,7 @@ Sage.init = function(elementNamesToInit) {
   }
 
   // Initialize Sortable
-  if ( shouldInit('dropdown', '[data-js-sortable]') ) {
+  if ( shouldInit('sortable', '[data-js-sortable]') ) {
     Sage.sortable.init();
   }
 

--- a/lib/sage-frontend/javascript/system/sortable.js
+++ b/lib/sage-frontend/javascript/system/sortable.js
@@ -4,6 +4,7 @@ Sage.sortable = (function() {
   // ==================================================
   // Variables
   // ==================================================
+
   const SELECTOR_CONTAINER = 'data-js-sortable';
   const SELECTOR_ITEM_UPDATE_URL = 'data-js-sortable-update-url';
   const SETTINGS = {
@@ -21,7 +22,7 @@ Sage.sortable = (function() {
   function init() {
     sortableContainerArray.forEach(function(el) {
       let resourceName = el.getAttribute(SELECTOR_CONTAINER);
-      if (!resourceName) return console.error(`Sage Sortable requires a resource name \n\n EXAMPLE: \n [${SELECTOR_CONTAINER}="resource_name}"]`);
+      if (!resourceName) return console.error(`Sage Sortable requires a resource name \n\n EXAMPLE: \n [${SELECTOR_CONTAINER}="resourceName}"]`);
 
       Sortable.create(el, {
         ...SETTINGS,

--- a/lib/sage-frontend/javascript/system/sortable.js
+++ b/lib/sage-frontend/javascript/system/sortable.js
@@ -33,12 +33,7 @@ Sage.sortable = (function() {
           data.append('_method', 'PUT');
           data.append(`${resourceName}[sort_position]`, evt.newIndex);
 
-          let xhr = new XMLHttpRequest();
-          xhr.open('POST', updateUrl);
-          xhr.setRequestHeader('Accept', 'text/javascript, application/javascript, */*');
-          xhr.setRequestHeader('X-CSRF-Token', document.querySelector('meta[name="csrf-token"]').content);
-          xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
-          xhr.send(data);
+          Sage.util.ajaxRequestWithJsResponse(updateUrl, data)
         }
       });
     });

--- a/lib/sage-frontend/javascript/system/sortable.js
+++ b/lib/sage-frontend/javascript/system/sortable.js
@@ -27,7 +27,11 @@ Sage.sortable = (function() {
         ...SETTINGS,
         onEnd: function (evt) {
           let updateUrl = evt.item.getAttribute(SELECTOR_ITEM_UPDATE_URL)
-          if (!updateUrl) return;  // If item doesn't have a [data-js-sortable-update-url="url-here"] attr, do nothing
+
+          // Check if the sorted Item:
+          // - Has a [data-js-sortable-update-url="url-here"] attr
+          // - Didn't have the same index as its new index
+          if (!updateUrl || evt.oldIndex == evt.newIndex) return;
 
           var data = new URLSearchParams();
           data.append('_method', 'PUT');

--- a/lib/sage-frontend/javascript/system/sortable.js
+++ b/lib/sage-frontend/javascript/system/sortable.js
@@ -19,8 +19,6 @@ Sage.sortable = (function() {
   // ==================================================
 
   function init() {
-    console.log('sortable', sortableContainerArray);
-
     sortableContainerArray.forEach(function(el) {
       let resourceName = el.getAttribute(SELECTOR_CONTAINER);
       if (!resourceName) return console.error(`Sage Sortable requires a resource name \n\n EXAMPLE: \n [${SELECTOR_CONTAINER}="resource_name}"]`);
@@ -32,13 +30,15 @@ Sage.sortable = (function() {
           if (!updateUrl) return;  // If item doesn't have a [data-js-sortable-update-url="url-here"] attr, do nothing
 
           var data = new URLSearchParams();
-              data.append('_method', 'PUT');
-              data.append(`${resourceName}[sort_position]`, evt.newIndex);
+          data.append('_method', 'PUT');
+          data.append(`${resourceName}[sort_position]`, evt.newIndex);
 
-          let request = new XMLHttpRequest();
-          request.open('POST', updateUrl, true);
-          request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
-          request.send(data);
+          let xhr = new XMLHttpRequest();
+          xhr.open('POST', updateUrl);
+          xhr.setRequestHeader('Accept', 'text/javascript, application/javascript, */*');
+          xhr.setRequestHeader('X-CSRF-Token', document.querySelector('meta[name="csrf-token"]').content);
+          xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+          xhr.send(data);
         }
       });
     });

--- a/lib/sage-frontend/javascript/system/sortable.js
+++ b/lib/sage-frontend/javascript/system/sortable.js
@@ -4,14 +4,14 @@ Sage.sortable = (function() {
   // ==================================================
   // Variables
   // ==================================================
-  const SELECTOR_PARENT = "data-js-sortable";
-  const SELECTOR_CHILD = "data-js-sortable-item-url";
+  const SELECTOR_CONTAINER = 'data-js-sortable';
+  const SELECTOR_ITEM_UPDATE_URL = 'data-js-sortable-update-url';
   const SETTINGS = {
-    ghostClass: "sage-sortable__item--ghost",
-    chosenClass: "sage-sortable__item--active"
+    ghostClass: 'sage-sortable__item--ghost',
+    chosenClass: 'sage-sortable__item--active'
   };
 
-  let sortableContainerArray = document.querySelectorAll(`[${SELECTOR_PARENT}]`);
+  let sortableContainerArray = document.querySelectorAll(`[${SELECTOR_CONTAINER}]`);
 
 
   // ==================================================
@@ -22,36 +22,23 @@ Sage.sortable = (function() {
     console.log('sortable', sortableContainerArray);
 
     sortableContainerArray.forEach(function(el) {
-      let resourceName = el.getAttribute(SELECTOR_PARENT);
-      if (!resourceName) return console.error(`Sage Sortable requires a resource name \n\n EXAMPLE: \n [${SELECTOR_PARENT}="resource_name}"]`);
+      let resourceName = el.getAttribute(SELECTOR_CONTAINER);
+      if (!resourceName) return console.error(`Sage Sortable requires a resource name \n\n EXAMPLE: \n [${SELECTOR_CONTAINER}="resource_name}"]`);
 
       Sortable.create(el, {
         ...SETTINGS,
         onEnd: function (evt) {
-          console.log('resourceName', resourceName)
-          let url = evt.item.getAttribute(SELECTOR_CHILD)
-          console.log('url', url);
-          if (!url) return;
+          let updateUrl = evt.item.getAttribute(SELECTOR_ITEM_UPDATE_URL)
+          if (!updateUrl) return;  // If item doesn't have a [data-js-sortable-update-url="url-here"] attr, do nothing
 
-          let data = { _method: "PUT" };
-          data[resourceName] = { sort_position: evt.newIndex };
+          var data = new URLSearchParams();
+              data.append('_method', 'PUT');
+              data.append(`${resourceName}[sort_position]`, evt.newIndex);
 
           let request = new XMLHttpRequest();
           request.open('POST', updateUrl, true);
           request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
           request.send(data);
-
-
-          // $.ajax({ type: 'POST', url: url, dataType: 'script', data: data });
-
-
-          // var itemEl = evt.item;  // dragged HTMLElement
-          // evt.to;    // target list
-          // evt.from;  // previous list
-          // evt.oldIndex;  // element's old index within old parent
-          // evt.newIndex;  // element's new index within new parent
-          // evt.oldDraggableIndex; // element's old index within old parent, only counting draggable elements
-          // evt.newDraggableIndex; // element's new index within new parent, only counting draggable elements
         }
       });
     });

--- a/lib/sage-frontend/javascript/system/sortable.js
+++ b/lib/sage-frontend/javascript/system/sortable.js
@@ -1,0 +1,64 @@
+import Sortable from 'sortablejs/modular/sortable.core.esm.js';
+
+Sage.sortable = (function() {
+  // ==================================================
+  // Variables
+  // ==================================================
+  const SELECTOR_PARENT = "data-js-sortable";
+  const SELECTOR_CHILD = "data-js-sortable-item-url";
+  const SETTINGS = {
+    ghostClass: "sage-sortable__item--ghost",
+    chosenClass: "sage-sortable__item--active"
+  };
+
+  let sortableContainerArray = document.querySelectorAll(`[${SELECTOR_PARENT}]`);
+
+
+  // ==================================================
+  // Functions
+  // ==================================================
+
+  function init() {
+    console.log('sortable', sortableContainerArray);
+
+    sortableContainerArray.forEach(function(el) {
+      let resourceName = el.getAttribute(SELECTOR_PARENT);
+      if (!resourceName) return console.error(`Sage Sortable requires a resource name \n\n EXAMPLE: \n [${SELECTOR_PARENT}="resource_name}"]`);
+
+      Sortable.create(el, {
+        ...SETTINGS,
+        onEnd: function (evt) {
+          console.log('resourceName', resourceName)
+          let url = evt.item.getAttribute(SELECTOR_CHILD)
+          console.log('url', url);
+          if (!url) return;
+
+          let data = { _method: "PUT" };
+          data[resourceName] = { sort_position: evt.newIndex };
+
+          let request = new XMLHttpRequest();
+          request.open('POST', updateUrl, true);
+          request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+          request.send(data);
+
+
+          // $.ajax({ type: 'POST', url: url, dataType: 'script', data: data });
+
+
+          // var itemEl = evt.item;  // dragged HTMLElement
+          // evt.to;    // target list
+          // evt.from;  // previous list
+          // evt.oldIndex;  // element's old index within old parent
+          // evt.newIndex;  // element's new index within new parent
+          // evt.oldDraggableIndex; // element's old index within old parent, only counting draggable elements
+          // evt.newDraggableIndex; // element's new index within new parent, only counting draggable elements
+        }
+      });
+    });
+  }
+
+  return {
+    init: init
+  }
+
+})();

--- a/lib/sage-frontend/javascript/system/sortable.js
+++ b/lib/sage-frontend/javascript/system/sortable.js
@@ -33,11 +33,11 @@ Sage.sortable = (function() {
           // - Didn't have the same index as its new index
           if (!updateUrl || evt.oldIndex == evt.newIndex) return;
 
-          var data = new URLSearchParams();
-          data.append('_method', 'PUT');
-          data.append(`${resourceName}[sort_position]`, evt.newIndex);
+          var params = new URLSearchParams();
+          params.append('_method', 'PUT');
+          params.append(`${resourceName}[sort_position]`, evt.newIndex);
 
-          Sage.util.ajaxRequestWithJsResponse(updateUrl, data)
+          Sage.util.ajaxRequestWithJsResponse(updateUrl, params)
         }
       });
     });

--- a/lib/sage-frontend/javascript/system/util.js
+++ b/lib/sage-frontend/javascript/system/util.js
@@ -5,7 +5,6 @@ Sage.util = (function(Sage) {
     return e.target.getAttribute('aria-controls') ? e.target.getAttribute('aria-controls') : e.target.getAttribute('data-js-menu');
   }
 
-
   // convert nodelist to array for iteration
   function nodelistToArray(selection) {
     return Array.prototype.slice.apply(selection);
@@ -22,13 +21,13 @@ Sage.util = (function(Sage) {
   function ajaxRequestWithJsResponse(urlTarget, urlParams) {
     let xhr = new XMLHttpRequest();
     xhr.open('POST', urlTarget);
-    xhr.setRequestHeader("Accept", "text/javascript");
+    xhr.setRequestHeader('Accept', 'text/javascript');
     xhr.setRequestHeader('X-CSRF-Token', document.querySelector('meta[name="csrf-token"]').content);
     xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
 
     xhr.onload = function (evt) {
       let elScript = document.createElement('script');
-      elScript.setAttribute('type', 'text/javascript')
+      elScript.setAttribute('type', 'text/javascript');
       elScript.innerHTML = evt.currentTarget.response;
       document.body.appendChild(elScript);
     };

--- a/lib/sage-frontend/javascript/system/util.js
+++ b/lib/sage-frontend/javascript/system/util.js
@@ -19,11 +19,29 @@ Sage.util = (function(Sage) {
     return document.documentMode ? true : false;
   }
 
+  function ajaxRequestWithJsResponse(urlTarget, urlParams) {
+    let xhr = new XMLHttpRequest();
+    xhr.open('POST', urlTarget);
+    xhr.setRequestHeader("Accept", "text/javascript");
+    xhr.setRequestHeader('X-CSRF-Token', document.querySelector('meta[name="csrf-token"]').content);
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+
+    xhr.onload = function (evt) {
+      let elScript = document.createElement('script');
+      elScript.setAttribute('type', 'text/javascript')
+      elScript.innerHTML = evt.currentTarget.response;
+      document.body.appendChild(elScript);
+    };
+
+    xhr.send(urlParams);
+  }
+
   return {
     getBtnTarget: getBtnTarget,
     nodelistToArray: nodelistToArray,
     isEmptyString: isEmptyString,
-    isIE: isIE
+    isIE: isIE,
+    ajaxRequestWithJsResponse: ajaxRequestWithJsResponse
   };
 
 })(Sage);

--- a/lib/sage-frontend/stylesheets/docs/_docs_container.scss
+++ b/lib/sage-frontend/stylesheets/docs/_docs_container.scss
@@ -1,0 +1,13 @@
+/* ==================================================
+  ** _docs_container.scss
+
+  For Sage documentation use
+================================================== */
+
+.docs-container {
+  margin-bottom: sage-spacing();
+  background: $sage-panel-bg-color;
+  border-radius: $sage-panel-border-radius;
+  box-shadow: $sage-panel-box-shadow;
+  padding: $sage-panel-padding;
+}

--- a/lib/sage-frontend/stylesheets/docs/index.scss
+++ b/lib/sage-frontend/stylesheets/docs/index.scss
@@ -50,3 +50,4 @@
 @import "status_table";
 @import "table";
 @import "theme";
+@import "docs_container";

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -316,7 +316,7 @@ $sage-overlay-transition-backdrop-filter: backdrop-filter 0.7s ease-in-out !defa
 // ==================================================
 
 $sage-panel-bg-color: sage-color(white) !default;
-$sage-panel-padding: sage-spacing() !default;
+$sage-panel-padding: sage-spacing(sm) !default;
 $sage-panel-border-radius: sage-border(radius) !default;
 $sage-panel-box-shadow: sage-shadow(sm) !default;
 

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -85,7 +85,7 @@ $sage-btn-shadow-base: sage-shadow(sm) !default;
 $sage-btn-shadow-hover: sage-shadow(md) !default;
 
 // Focus outline
-$sage-btn-focus-outline-spacing: ( sage-spacing(2xs) / 2) !default;
+$sage-btn-focus-outline-spacing: sage-spacing(3xs) !default;
 $sage-btn-focus-outline-width: 1 !default;
 $sage-btn-focus-outline-color: currentColor !default;
 

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -85,7 +85,7 @@ $sage-btn-shadow-base: sage-shadow(sm) !default;
 $sage-btn-shadow-hover: sage-shadow(md) !default;
 
 // Focus outline
-$sage-btn-focus-outline-spacing: sage-spacing(2xs) !default;
+$sage-btn-focus-outline-spacing: ( sage-spacing(2xs) / 2) !default;
 $sage-btn-focus-outline-width: 1 !default;
 $sage-btn-focus-outline-color: currentColor !default;
 
@@ -96,10 +96,10 @@ $sage-btn-primary-bg-hover-color: lighten($sage-btn-primary-bg-color, 9%) !defau
 $sage-btn-primary-text-color: sage-color(white) !default;
 
 // Secondary button
-$sage-btn-secondary-text-color: sage-color(charcoal, 400) !default;
+$sage-btn-secondary-text-color: sage-color(primary) !default;
 
 // Tertiary button
-$sage-btn-tertiary-text-color: sage-color(primary) !default;
+$sage-btn-tertiary-text-color: sage-color(charcoal, 300) !default;
 
 // Danger button
 $sage-btn-danger-bg-color: sage-color(red) !default;

--- a/lib/sage-frontend/stylesheets/system/index.scss
+++ b/lib/sage-frontend/stylesheets/system/index.scss
@@ -80,3 +80,5 @@
 @import "patterns/objects/panel";
 @import "patterns/objects/sidebar";
 @import "patterns/objects/tabs";
+@import "patterns/objects/modal";
+@import "patterns/objects/sortable";

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -144,7 +144,8 @@
 
 .sage-btn--secondary {
   color: $sage-btn-secondary-text-color;
-  background: sage-color(white);
+  border: 0;
+  box-shadow: none;
 
   &::after {
     border-color: sage-color(primary);
@@ -152,31 +153,32 @@
 
   &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
     color: $sage-btn-secondary-text-color;
-    box-shadow: $sage-btn-shadow-hover;
+    background-color: sage-color(grey, 200);
+  }
+
+  &:focus {
+    color: $sage-btn-secondary-text-color;
+    background: sage-color(white);
+    box-shadow: none;
   }
 
   &:active {
-    background-color: sage-color(grey, 200);
+    color: $sage-btn-secondary-text-color;
+    background-color: sage-color(grey, 300);
+    box-shadow: none;
   }
 
   &:disabled,
   &.disabled {
     @include button-style-disabled;
 
-    color: sage-color(grey, 400);
-    background-color: sage-color(grey, 200);
-
-    &:hover,
-    &:focus,
-    &:active {
-      box-shadow: none;
-    }
+    color: sage-color(primary, 200);
+    background-color: transparent;
   }
 }
 
 .sage-btn--tertiary {
   color: $sage-btn-tertiary-text-color;
-  background: transparent;
   border: 0;
   box-shadow: none;
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -13,6 +13,8 @@
   @include button-style-reset();
   @extend %t-sage-body-med;
   align-self: flex-start;
+  align-items: baseline;
+  display: inline-flex;
   position: relative;
   padding: rem(12px) sage-spacing(sm);
   margin-left: sage-spacing(2xs);
@@ -35,6 +37,7 @@
     outline: none;
   }
 }
+
 
 .sage-btn {
   @include button-style-base;
@@ -173,7 +176,7 @@
 
 .sage-btn--tertiary {
   color: $sage-btn-tertiary-text-color;
-  background: sage-color(white);
+  background: transparent;
   border: 0;
   box-shadow: none;
 
@@ -263,23 +266,15 @@
 
 @mixin button-icon-generator($direction) {
   @each $icon-name, $icon-code in $sage-icons {
-    %sage-btn--icon-base {
-      display: inline-flex;
-      align-items: baseline;
-
-      &::before {
-        align-self: center;
-      }
-    }
-
     // --- Right Icon Buttons
     @if $direction == right {
       .sage-btn--icon-right-#{$icon-name} {
-        @extend %sage-btn--icon-base;
         flex-direction: row-reverse;
 
         &::before {
           @include icon-base($icon-name);
+
+          align-self: center;
           margin: 0 0 0 sage-spacing(xs);
         }
       }
@@ -288,31 +283,37 @@
     // --- Left Icon Buttons
     @else if $direction == left {
       .sage-btn--icon-left-#{$icon-name} {
-        @extend %sage-btn--icon-base;
         flex-direction: row;
 
         &::before {
           @include icon-base($icon-name);
+
+          align-self: center;
           margin: 0 sage-spacing(xs) 0 0;
         }
       }
     }
 
     // --- Standalone Icon Buttons
-    @else if $direction == none {
-      .sage-btn--icon-#{$icon-name} {
-        @extend %sage-btn--icon-base;
+    @else if $direction == only {
+      .sage-btn--icon-only-#{$icon-name} {
+        font-size: 0;
         padding-left: rem(10);
         padding-right: rem(10);
+        width: rem(36);
 
         &::before {
           @include icon-base($icon-name);
+
+          transform: scale(1.1);
+          font-size: initial;
+          align-self: center;
         }
       }
     }
   }
 }
 
-@include button-icon-generator(none);
+@include button-icon-generator(only);
 @include button-icon-generator(left);
 @include button-icon-generator(right);

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -262,32 +262,57 @@
 }
 
 @mixin button-icon-generator($direction) {
-  $right: null;
-
-  @if $direction == right {
-    $right: true;
-  }
-  @else if $direction == left {
-    $right: false;
-  }
-  @else {
-    @error "button-icon-generator() requires argument value of either `right` or `left`";
-  }
-
   @each $icon-name, $icon-code in $sage-icons {
-    .sage-btn--icon-#{if($right, "right", "left")}-#{$icon-name} {
+    %sage-btn--icon-base {
       display: inline-flex;
       align-items: baseline;
-      flex-direction: if($right, row-reverse, row);
 
       &::before {
-        @include icon-base($icon-name);
         align-self: center;
-        margin: if($right, 0 0 0 sage-spacing(xs), 0 sage-spacing(xs) 0 0);
+      }
+    }
+
+    // --- Right Icon Buttons
+    @if $direction == right {
+      .sage-btn--icon-right-#{$icon-name} {
+        @extend %sage-btn--icon-base;
+        flex-direction: row-reverse;
+
+        &::before {
+          @include icon-base($icon-name);
+          margin: 0 0 0 sage-spacing(xs);
+        }
+      }
+    }
+
+    // --- Left Icon Buttons
+    @else if $direction == left {
+      .sage-btn--icon-left-#{$icon-name} {
+        @extend %sage-btn--icon-base;
+        flex-direction: row;
+
+        &::before {
+          @include icon-base($icon-name);
+          margin: 0 sage-spacing(xs) 0 0;
+        }
+      }
+    }
+
+    // --- Standalone Icon Buttons
+    @else if $direction == none {
+      .sage-btn--icon-#{$icon-name} {
+        @extend %sage-btn--icon-base;
+        padding-left: rem(10);
+        padding-right: rem(10);
+
+        &::before {
+          @include icon-base($icon-name);
+        }
       }
     }
   }
 }
 
+@include button-icon-generator(none);
 @include button-icon-generator(left);
 @include button-icon-generator(right);

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_tooltip.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_tooltip.scss
@@ -30,6 +30,7 @@
   &::after {
     left: 50%;
     top: 100%;
+    transform: translate3d(-50%, 0, 0);
     border-left: $sage-tooltip-arrow-inactive;
     border-right: $sage-tooltip-arrow-inactive;
     border-top: $sage-tooltip-arrow-active;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
@@ -41,7 +41,7 @@ $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
 .sage-dropdown__menu {
   visibility: hidden;
   position: absolute;
-  top: calc(100% - #{( sage-spacing(xs) / 2)});
+  top: calc(100% - #{sage-spacing(3xs)});
   overflow: hidden;
   z-index: sage-z-index(nav, -1);
   transform: rotate3d(1, 0, 0, -90deg);

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
@@ -6,7 +6,7 @@
 ================================================== */
 
 $-dropdown-height: rem(40px);
-$-dropdown-width: rem(300px);
+$-dropdown-width: rem(280px);
 $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
 
 .sage-dropdown {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
@@ -11,6 +11,7 @@ $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
 
 .sage-dropdown {
   position: relative;
+  display: inline-flex;
 }
 
 .sage-dropdown__container {
@@ -20,9 +21,8 @@ $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
     content: "";
     visibility: hidden;
     position: fixed;
-    background-color: sage-color(primary, 300);
+    background-color: transparent;
     pointer-events: none;
-    opacity: 0.04;
     cursor: default;
 
     @include position-full;
@@ -41,7 +41,7 @@ $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
 .sage-dropdown__menu {
   visibility: hidden;
   position: absolute;
-  top: calc(100% + #{sage-spacing(xs)});
+  top: calc(100% - #{( sage-spacing(xs) / 2)});
   overflow: hidden;
   z-index: sage-z-index(nav, -1);
   transform: rotate3d(1, 0, 0, -90deg);

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
@@ -41,7 +41,6 @@ $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
 .sage-dropdown__menu {
   visibility: hidden;
   position: absolute;
-  left: 0;
   top: calc(100% + #{sage-spacing(xs)});
   overflow: hidden;
   z-index: sage-z-index(nav, -1);
@@ -56,17 +55,17 @@ $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
   transition: $sage-transition;
   transition-property: transform, z-index;
 
-  &:not(.sage-dropdown--anchor-right) {
-    left: 0;
-  }
-
-  &.sage-dropdown--anchor-right {
-    right: 0;
-  }
-
   [aria-expanded="true"] > .sage-dropdown__container & {
     visibility: visible;
     transform: rotate3d(0, 0, 0, 0);
+  }
+
+  :not(.sage-dropdown--anchor-right) > .sage-dropdown__container & {
+    left: 0;
+  }
+
+  .sage-dropdown--anchor-right > .sage-dropdown__container & {
+    right: 0;
   }
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -13,14 +13,14 @@
 }
 
 .sage-panel__header {
-  padding: sage-spacing(sm) $sage-panel-padding;
+  padding: sage-spacing(xs) $sage-panel-padding;
   display: flex;
   align-items: center;
   border-bottom: sage-border();
 }
 
 .sage-panel__header-title {
-  @extend %t-sage-heading-4;
+  @extend %t-sage-heading-5;
 
   padding: 0;
   margin: 0 auto 0 0;
@@ -40,5 +40,5 @@
 
 .sage-panel__footer {
   border-top: sage-border();
-  padding: sage-spacing(sm) $sage-panel-padding;
+  padding: sage-spacing(xs);
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -13,25 +13,22 @@
 }
 
 .sage-panel__header {
-  padding: sage-spacing(xs) $sage-panel-padding;
+  padding: sage-spacing(xs) sage-spacing(xs) 0 $sage-panel-padding;
   display: flex;
   align-items: center;
   border-bottom: sage-border();
+  min-height: rem(60px);
 }
 
-.sage-panel__header-title {
-  @extend %t-sage-heading-5;
-
-  padding: 0;
-  margin: 0 auto 0 0;
+.sage-panel__header-right {
+  margin: 0 0 0 auto;
+  display: inline-flex;
+  align-self: baseline;
 }
 
 .sage-panel__body {
   padding: $sage-panel-padding;
-  display: flex;
   position: relative;
-  overflow: auto;
-  flex-direction: column;
 
   > :last-child {
     margin-bottom: 0;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -7,17 +7,27 @@
 %sage-panel,
 .sage-panel {
   margin-bottom: sage-spacing();
-  padding: $sage-panel-padding;
   background: $sage-panel-bg-color;
   border-radius: $sage-panel-border-radius;
   box-shadow: $sage-panel-box-shadow;
 }
 
 .sage-panel__header {
-  margin-bottom: $sage-panel-padding;
+  padding: sage-spacing(sm) $sage-panel-padding;
+  display: flex;
+  align-items: center;
+  border-bottom: sage-border();
+}
+
+.sage-panel__header-title {
+  @extend %t-sage-heading-4;
+
+  padding: 0;
+  margin: 0 auto 0 0;
 }
 
 .sage-panel__body {
+  padding: $sage-panel-padding;
   display: flex;
   position: relative;
   overflow: auto;
@@ -29,5 +39,6 @@
 }
 
 .sage-panel__footer {
-  margin-top: $sage-panel-padding;
+  border-top: sage-border();
+  padding: sage-spacing(sm) $sage-panel-padding;
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -6,7 +6,7 @@
 ================================================== */
 
 .sage-sortable {
-  /* stylelint-disable-line block-no-empty */
+  padding: sage-spacing(xs) 0 0;
 }
 
 .sage-sortable__item {
@@ -14,17 +14,17 @@
   flex-direction: row;
   border: sage-border();
   border-radius: sage-border(radius-large);
-  padding: sage-spacing(xs);
+  padding: sage-spacing(xs) sage-spacing(xs) sage-spacing(xs) sage-spacing(sm);
   align-items: center;
   cursor: grab;
-  margin: sage-spacing(xs) 0;
+  margin: 0 0 sage-spacing(xs);
   transition: $sage-transition;
   transition-property: border-color, box-shadow;
 
   &:before {
-    @include icon-base(enlarge-vertical);
+    @include icon-base(enlarge);
 
-    padding: 0 sage-spacing(xs) 0 0;
+    padding: 0 sage-spacing(sm) 0 0;
     color: sage-color(grey, 500);
   }
 
@@ -45,7 +45,7 @@
 }
 
 .sage-sortable__item-content {
-  z-index: sage-z-index(modal);
+  z-index: sage-z-index();
   width: 100%;
   list-style: none;
   overflow: hidden;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -6,17 +6,12 @@
 ================================================== */
 
 .sage-sortable {
-  position: relative;
   padding: sage-spacing(xs) 0;
 }
 
 .sage-sortable__item {
-  position: relative;
   display: flex;
   flex-direction: row;
-  z-index: sage-z-index(modal);
-  width: 100%;
-  list-style: none;
   border: sage-border();
   border-radius: sage-border(radius-large);
   padding: sage-spacing(xs);
@@ -50,7 +45,6 @@
 }
 
 .sage-sortable__item-content {
-  position: relative;
   z-index: sage-z-index(modal);
   width: 100%;
   list-style: none;
@@ -63,5 +57,6 @@
 
 .sage-sortable__item-actions {
   margin: 0 0 0 auto;
+  display: flex;
   padding: 0 sage-spacing(xs) 0 sage-spacing(sm);
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -11,6 +11,7 @@
 
 .sage-sortable__item {
   display: flex;
+  background: sage-color(white);
   flex-direction: row;
   border: sage-border();
   border-radius: sage-border(radius-large);
@@ -36,11 +37,16 @@
     }
   }
 
+  &.sage-sortable__item--active,
   &:focus,
   &:active {
     cursor: grabbing;
-    border-color: sage-color(grey, 400);
-    box-shadow: sage-shadow(lg);
+    border-color: sage-color(grey, 500);
+    box-shadow: sage-shadow(md);
+  }
+
+  &.sage-sortable__item--ghost {
+    border-color: sage-color(primary);
   }
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -6,7 +6,7 @@
 ================================================== */
 
 .sage-sortable {
-  padding: sage-spacing(xs) 0;
+  /* stylelint-disable-line block-no-empty */
 }
 
 .sage-sortable__item {
@@ -48,10 +48,14 @@
   z-index: sage-z-index(modal);
   width: 100%;
   list-style: none;
+  overflow: hidden;
 
   & > * {
     user-select: none;
     margin-bottom: 0;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -58,7 +58,6 @@
   overflow: hidden;
 
   & > * {
-    user-select: none;
     margin-bottom: 0;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -29,6 +29,7 @@
     color: sage-color(grey, 500);
   }
 
+  &:focus,
   &:hover {
     box-shadow: sage-shadow(sm);
 
@@ -38,15 +39,15 @@
   }
 
   &.sage-sortable__item--active,
-  &:focus,
   &:active {
     cursor: grabbing;
-    border-color: sage-color(grey, 500);
+    border-color: sage-color(primary);
     box-shadow: sage-shadow(md);
   }
 
   &.sage-sortable__item--ghost {
-    border-color: sage-color(primary);
+    opacity: 0.5;
+    border-color: sage-color(grey, 500);
   }
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -1,0 +1,67 @@
+/* ==================================================
+  ** sortable
+  type: object
+
+
+================================================== */
+
+.sage-sortable {
+  position: relative;
+  padding: sage-spacing(xs) 0;
+}
+
+.sage-sortable__item {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  z-index: sage-z-index(modal);
+  width: 100%;
+  list-style: none;
+  border: sage-border();
+  border-radius: sage-border(radius-large);
+  padding: sage-spacing(xs);
+  align-items: center;
+  cursor: grab;
+  margin: sage-spacing(xs) 0;
+  transition: $sage-transition;
+  transition-property: border-color, box-shadow;
+
+  &:before {
+    @include icon-base(enlarge-vertical);
+
+    padding: 0 sage-spacing(xs) 0 0;
+    color: sage-color(grey, 500);
+  }
+
+  &:hover {
+    box-shadow: sage-shadow(sm);
+
+    &:before {
+      color: sage-color(primary);
+    }
+  }
+
+  &:focus,
+  &:active {
+    cursor: grabbing;
+    border-color: sage-color(grey, 400);
+    box-shadow: sage-shadow(lg);
+  }
+}
+
+.sage-sortable__item-content {
+  position: relative;
+  z-index: sage-z-index(modal);
+  width: 100%;
+  list-style: none;
+
+  & > * {
+    user-select: none;
+    margin-bottom: 0;
+  }
+}
+
+.sage-sortable__item-actions {
+  margin: 0 0 0 auto;
+  padding: 0 sage-spacing(xs) 0 sage-spacing(sm);
+}

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
@@ -14,7 +14,7 @@
   color: $sage-tabs-default-color;
   transition: color $sage-tabs-default-transition;
 
-  @extend %t-sage-body-small-semi;
+  @extend %t-sage-body-med;
 
   &:last-of-type {
     margin-right: 0;

--- a/lib/sage-frontend/stylesheets/system/tokens/_spacing.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_spacing.scss
@@ -4,6 +4,7 @@
 }
 
 $sage-spacings: (
+  3xs: rem(2px),
   2xs: rem(4px),
   xs: rem(8px),
   sm: rem(16px),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sage",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@rails/webpacker": "4.2.2",
     "left-pad": "^1.3.0",
+    "sortablejs": "^1.10.2",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7228,6 +7228,11 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.10.2.tgz#6e40364d913f98b85a14f6678f92b5c1221f5290"
+  integrity sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"


### PR DESCRIPTION
#### ⚠️ NOTE! Docs Panel is fixed in this followup: #323

## Description
#### New
- Adds Sage Sortable object
- Sage Sortable scripting using SortableJS
- Add Sage JS util helper for sending an AJAX and receiving a JS response back, this is a common pattern in KJB-Products
- Sage Buttons now support a `sage-btn--icon-only-iconnamehere` modifier
  - This matches our syntax for other icon buttons (`sage-btn--icon-iconstyle-iconnamehere`)

#### Refactor
- Sage JS Init: Cleaner handling of checking whether the context is Sage Docs
- Sage Buttons style treatment update: Tertiary is now the new Secondary
  - Colab with: @philschanely, @croswell @cameronsimony 
- Sage Panel refactor to allow for headers, footers, and "header actions"
  - **Note:** Sage Panel syntax has now diverged from our usage in Docs
  - **#323, follow up PR has the fix for the Docs to keep this PR's diff scoped**

#### Bugs
- Fixes Sage Dropdown alignment issue and removes color overlay (ty @philschanely)
- Fixes Sage Tooltip caret alignment

## Screenshots
![image](https://user-images.githubusercontent.com/565743/86939379-81870080-c10f-11ea-8d66-2876535e8545.png)
![image](https://user-images.githubusercontent.com/565743/86939434-8fd51c80-c10f-11ea-8003-909527d375d1.png)
![image](https://user-images.githubusercontent.com/565743/86939469-9bc0de80-c10f-11ea-9fd4-bd158a1c1331.png)


## Related
#### See KJB accompanying PR: https://github.com/Kajabi/kajabi-products/pull/14898
#### Followup fix for Docs `.sage-panel`: https://github.com/Kajabi/sage/pull/323
