### PR TITLE
Restructure nav markup to use nested list for sub links.

### DIFF
--- a/app/views/examples/objects/nav/_markup.html.erb
+++ b/app/views/examples/objects/nav/_markup.html.erb
@@ -2,7 +2,7 @@
   <ul class="sage-nav__list">
     <% nav_links.each do |link| %>
     <li>
-      <a href="<%= link[:url] %>" class="sage-nav__link<%= link[:is_sublink] ? " sage-nav__link--sub" : "" %><%= link[:is_active] ? " sage-nav__link--active" : "" %>"><%= link[:text] %></a>
+      <a href="<%= link[:url] %>" class="sage-nav__link<%= link[:is_active] ? " sage-nav__link--active" : "" %>"><%= link[:text] %></a>
       <% if link[:sub_links] %>
       <ul class="sage-nav__list sage-nav__list--sub">
         <% link[:sub_links].each do |link| %>
@@ -11,6 +11,6 @@
       </ul>
       <% end %>
     </li>
-     <% end %>
+    <% end %>
   </ul>
 </nav>

--- a/app/views/examples/objects/nav/_markup.html.erb
+++ b/app/views/examples/objects/nav/_markup.html.erb
@@ -3,7 +3,14 @@
     <% nav_links.each do |link| %>
     <li>
       <a href="<%= link[:url] %>" class="sage-nav__link<%= link[:is_sublink] ? " sage-nav__link--sub" : "" %><%= link[:is_active] ? " sage-nav__link--active" : "" %>"><%= link[:text] %></a>
-    <% end %>
+      <% if link[:sub_links] %>
+      <ul class="sage-nav__list sage-nav__list--sub">
+        <% link[:sub_links].each do |link| %>
+        <li><a href="<%= link[:url] %>" class="sage-nav__link sage-nav__link--sub<%= link[:is_active] ? " sage-nav__link--active" : "" %>"><%= link[:text] %></a></li>
+        <% end %>
+      </ul>
+      <% end %>
     </li>
+     <% end %>
   </ul>
 </nav>

--- a/app/views/examples/objects/nav/_preview.html.erb
+++ b/app/views/examples/objects/nav/_preview.html.erb
@@ -2,49 +2,43 @@
   nav_links: [
     {
       text: "Nav Link 1",
-      is_sublink: false,
       is_active: false,
       url: "#"
     },
     {
       text: "Nav Link 2",
-      is_sublink: false,
       is_active: false,
-      url: "#"
-    },
-    {
-      text: "Nav Sub Link 1",
-      is_sublink: true,
-      is_active: false,
-      url: "#"
-    },
-    {
-      text: "Nav Sub Link 2",
-      is_sublink: true,
-      is_active: false,
-      url: "#"
-    },
-    {
-      text: "Nav Sub Link 3",
-      is_sublink: true,
-      is_active: true,
-      url: "#"
+      url: "#",
+      sub_links: [
+        {
+          text: "Nav Sub Link 1",
+          is_active: false,
+          url: "#"
+        },
+        {
+          text: "Nav Sub Link 2",
+          is_active: false,
+          url: "#"
+        },
+        {
+          text: "Nav Sub Link 3",
+          is_active: true,
+          url: "#"
+        },
+      ]
     },
     {
       text: "Nav Link 3",
-      is_sublink: false,
       is_active: false,
       url: "#"
     },
     {
       text: "Nav Link 4",
-      is_sublink: false,
       is_active: false,
       url: "#"
     },
     {
       text: "Nav Link 5",
-      is_sublink: false,
       is_active: false,
       url: "#"
     }


### PR DESCRIPTION
## Description
Updates nav element markup to present sub-links in a nested unordered list (instead of a single flat list) to match recent sidebar updates.

- [x] Update nav `_markup.html.erb`
- [x] Update nav `_preview.html.erb`

### Screenshots
|  Before   |  After  |
|--------|--------|
| ![Screen Shot 2020-07-06 at 11 32 09 AM](https://user-images.githubusercontent.com/1175111/86626998-659f2580-bf7c-11ea-8669-1606539f513a.png)|![Screen Shot 2020-07-06 at 11 43 29 AM](https://user-images.githubusercontent.com/1175111/86627947-f9bdbc80-bf7d-11ea-92e3-cfe659159247.png)| 

## Related issues
- n/a