### PR TITLE
Extend grid classes

### DIFF
--- a/lib/sage-frontend/stylesheets/system/layout/_grid.scss
+++ b/lib/sage-frontend/stylesheets/system/layout/_grid.scss
@@ -54,6 +54,10 @@
 }
 
 @for $sage-i from 1 through $sage-grid-columns {
+  %sage-col-#{$sage-i},
+  %sage-col--sm-#{$sage-i},
+  %sage-col--md-#{$sage-i},
+  %sage-col--lg-#{$sage-i},
   .sage-col-#{$sage-i},
   .sage-col--sm-#{$sage-i},
   .sage-col--md-#{$sage-i},
@@ -62,6 +66,7 @@
     flex: 0 0 100%;
   }
 
+  %sage-col-#{$sage-i},
   .sage-col-#{$sage-i} {
     flex: 0 1 auto;
     width: percentage($sage-i / $sage-grid-columns);
@@ -70,6 +75,7 @@
 
 @media (min-width: $sage-grid-breakpoint-sm) {
   @for $sage-i from 1 through $sage-grid-columns {
+    %sage-col--sm-#{$sage-i},
     .sage-col--sm-#{$sage-i} {
       flex: 0 1 auto;
       width: percentage($sage-i / $sage-grid-columns);
@@ -86,6 +92,7 @@
 
 @media (min-width: $sage-grid-breakpoint-md) {
   @for $sage-i from 1 through $sage-grid-columns {
+    %sage-col--md-#{$sage-i},
     .sage-col--md-#{$sage-i} {
       flex: 0 1 auto;
       width: percentage($sage-i / $sage-grid-columns);
@@ -106,6 +113,7 @@
 
 @media (min-width: $sage-grid-breakpoint-lg) {
   @for $sage-i from 1 through $sage-grid-columns {
+    %sage-col--lg-#{$sage-i},
     .sage-col--lg-#{$sage-i} {
       flex: 0 1 auto;
       width: percentage($sage-i / $sage-grid-columns);

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_form_section.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_form_section.scss
@@ -32,7 +32,7 @@
   // Form Section Panels commonly wrap a <form> tag generated within rails.
   // In the event that a form tag is not present, ensure the children behave identically.
   &,
-  & > form {
+  > form {
     display: flex;
     flex-direction: column;
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_form_section.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_form_section.scss
@@ -11,7 +11,7 @@
 
 // TODO: refactor extends following final design of form section
 .sage-form-section__info {
-  @extend .sage-col--md-4;
+  @extend %sage-col--md-4;
 }
 
 .sage-form-section__title {
@@ -23,7 +23,7 @@
 }
 
 .sage-form-section__content {
-  @extend .sage-col--md-8;
+  @extend %sage-col--md-8;
 }
 
 .sage-form-section__panel {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "webpack:server": "./bin/webpack-dev-server",
     "rails:server": "rails server -p 4000",
     "start": "npm-run-all --parallel webpack:server rails:server",
-    "stylelint": "stylelint \"./**/*.scss\"",
+    "lint": "stylelint \"./**/*.scss\"",
     "deploy": "git push heroku $(git rev-parse --abbrev-ref HEAD):master --force",
     "preversion": "git ls-remote --exit-code --heads heroku master && git fetch --tags",
     "postversion": "git push origin v$npm_package_version && yarn run deploy && echo \"Successfully released and deployed version $npm_package_version!\""

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "webpack:server": "./bin/webpack-dev-server",
     "rails:server": "rails server -p 4000",
     "start": "npm-run-all --parallel webpack:server rails:server",
+    "stylelint": "stylelint \"./**/*.scss\"",
     "deploy": "git push heroku $(git rev-parse --abbrev-ref HEAD):master --force",
     "preversion": "git ls-remote --exit-code --heads heroku master && git fetch --tags",
     "postversion": "git push origin v$npm_package_version && yarn run deploy && echo \"Successfully released and deployed version $npm_package_version!\""


### PR DESCRIPTION
## Description
Grew tired of seeing the 'don't extend' warnings from Stylelint. The change here adds placeholders into the grid class generator. I'm still on the fence about this implementation, since generally we shouldn't be extending classes for layout. In either case, these do **not** get output in the compiled CSS.

Also adding a standalone `yarn lint` script in cases when spinning up the server isn't needed.

### Screenshots
No visual changes should be introduced here.


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the documentation site
2. Navigate to "Form section" under "Objects"
3. Verify the object looks and functions as expected with no changes.


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- n/a
