### PR TITLE
Docs Container

### DIFF
--- a/app/views/application/_assistant.html.erb
+++ b/app/views/application/_assistant.html.erb
@@ -11,7 +11,7 @@
   <div class="sage-assistant__actions">
     <%= link_to "v#{$SAGE_VERSION}",
       "https://github.com/Kajabi/sage/releases/tag/v#{$SAGE_VERSION}",
-      class: "sage-btn sage-btn--small sage-btn--secondary",
+      class: "sage-btn sage-btn--small sage-btn--primary",
       target: "_blank",
       rel: "noopener noreferrer"
     %>

--- a/app/views/examples/elements/_element.html.erb
+++ b/app/views/examples/elements/_element.html.erb
@@ -9,14 +9,14 @@
   do_content: do_content,
   dont_content: dont_content %>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-preview" class="t-sage-heading-2 example__title">Preview</h2>
   <div class="example__preview">
     <%= render "examples/elements/#{@title}/preview" %>
   </div>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
     <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= @title %>">Expand this code snippet</button>

--- a/app/views/examples/elements/_element_preview.html.erb
+++ b/app/views/examples/elements/_element_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-media">
     <h2 id="element-<%= title %>" class="sage-media-body t-sage-heading-2 example__title"><%= link_to pages_element_url(title: title, description: description), class: "example__link" do %><%= title.titleize %><% end %></h2>
     <%= link_to pages_breakout_url(type: "element", title: title, description: description), target: "_blank", class: "example__link example__link--breakout" do %>

--- a/app/views/examples/objects/_object.html.erb
+++ b/app/views/examples/objects/_object.html.erb
@@ -9,14 +9,14 @@
   do_content: do_content,
   dont_content: dont_content %>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-preview" class="t-sage-heading-2 example__title">Preview</h2>
   <div class="example__preview example__preview--page">
     <%= render "examples/objects/#{@title}/preview" %>
   </div>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h2 id="<%= @title %>-example-code" class="t-sage-heading-2 example__title">Code</h2>
   <div class="example__code">
     <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= @title %>">Expand this code snippet</button>

--- a/app/views/examples/objects/_object_preview.html.erb
+++ b/app/views/examples/objects/_object_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-media">
     <div class="sage-media-body">
       <h2 id="object-<%= title %>" class="t-sage-heading-2 example__title"><%= link_to pages_object_url(title: title, description: description), class: "example__link" do %><%= title.titleize %><% end %></h2>

--- a/app/views/examples/shared/_props.html.erb
+++ b/app/views/examples/shared/_props.html.erb
@@ -1,5 +1,5 @@
 <% if props_content.present? %>
-  <div id="<%= @title %>-example-props" class="sage-panel sage-type">
+  <div id="<%= @title %>-example-props" class="docs-container sage-type">
     <h2 class="t-sage-heading-2 example__title">Properties</h2>
     <div class="sage-table-wrapper">
       <div class="sage-table-wrapper__overflow">

--- a/app/views/examples/shared/_rules.html.erb
+++ b/app/views/examples/shared/_rules.html.erb
@@ -1,5 +1,5 @@
 <% if do_content.present? || dont_content.present? %>
-  <div id="<%= @title %>-example-best-practices" class="sage-panel sage-type">
+  <div id="<%= @title %>-example-best-practices" class="docs-container sage-type">
     <h2 class="t-sage-heading-2 example__title">Best Practices</h2>
     <div class="sage-row">
       <div class="sage-col--md-6">

--- a/app/views/examples/utilities/_utility.html.erb
+++ b/app/views/examples/utilities/_utility.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-media">
     <div class="sage-media-body">
       <h2 id="<%= title %>" class="t-sage-heading-2 example__title"><%= title.titleize %></h2>

--- a/app/views/pages/color.html.erb
+++ b/app/views/pages/color.html.erb
@@ -49,13 +49,13 @@
   <p>You will notice <strong>pure black is not used at all as a text color</strong>. Instead, we rely on 400 for our darkest text color value. Our default text color is sage-color(charcoal, 400). To achive more depth use 300 to 400 shades for text on top of lighter background colors using 100 to 200 for their fill. You can also use 100 to 200 as the text color on darker backgrounds using from 300 to 400 for their fill. Pure white is used as a text color when the lightest shade (100) of a color will not pass color contrast tests. At the moment, this only occurs on the 300 shades of purple, primary, and red.</p>
   <h2 id="primary">Primary</h2>
   <p>These are the splashes of color that appear the most in Kajabi’s UI, and are the ones that determine the overall "look" of the app. Use these for things like primary actions, links, navigation items, icons, accent borders, or text we want to emphasize.</p>
-  <div class="sage-panel">
+  <div class="docs-container">
     <%= render "color_values", color: "primary"%>
   </div>
   <h2 id="neutral">Neutrals</h2>
   <p>These are the colors we will use the most and will make up the majority of Kajabi’s UI.<br>
   Use them for most of our text, backgrounds, and borders, as well as for things like alternative buttons and links.</p>
-  <div class="sage-panel">
+  <div class="docs-container">
     <div class="sage-row">
       <div class="sage-col--md-6">
         <h3 id="grey">Grey</h3>
@@ -69,7 +69,7 @@
   </div>
   <h2>Supporting</h2>
   <p>These colors should be used fairly conservatively throughout Kajabi’s UI to avoid overpowering our primary colors. We’ll use them when we need an element to stand out.</p>
-  <div class="sage-panel">
+  <div class="docs-container">
     <div class="sage-row">
       <div class="sage-col--md-6">
         <h3 id="purple">Purple</h3>

--- a/app/views/pages/container.html.erb
+++ b/app/views/pages/container.html.erb
@@ -21,7 +21,7 @@
     </ul>
   </div>
 <% end %>
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="standard">Standard Container</h2>
   <pre class="prettyprint"><code>&lt;div class=&quot;sage-container&quot;&gt;
   &lt;!-- 1200px width container --&gt;

--- a/app/views/pages/grid.html.erb
+++ b/app/views/pages/grid.html.erb
@@ -42,7 +42,7 @@
     </ul>
   </div>
 <% end %>
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="grid-how-to">How to use the Sage grid</h2>
   <p>You may be familiar with grid systems from popular front-end frameworks, such as <a href="https://getbootstrap.com/docs/4.0/layout/grid/" rel="nofollow">Bootstrap</a> or <a href="https://get.foundation/sites/docs/grid.html" rel="nofollow">Foundation</a>. Similar to these, the Sage layout grid is constructed of individual columns (<code>.sage-col</code>) grouped within rows (<code>.sage-row</code>).</p>
 
@@ -89,7 +89,7 @@
 
 </div>
 
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="grid-responsive">Responsive grid layouts</h2>
   <p>Viewing the <a href="#grid-columns">column combinations example above</a>, you may have noticed that the columns display as full-width blocks when viewed at smaller screen sizes. To account for the increased or decreased space available, we can target specific screen sizes (called <em>breakpoints</em>) by modifying the classnames used in each column. This is referred to as <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design" rel="nofollow">responsive design</a>, giving us greater flexibility in our layouts.</p>
 
@@ -271,7 +271,7 @@
 
 </div>
 
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="grid-alignment">Alignment</h2>
   <h3 class="t-heading-5" id="grid-alignment-vertical">Vertical alignment</h3>
   <p>The default vertical alignment for each <code>.sage-row</code> aligns its columns to the top of the <code>.sage-row</code> container. This can be changed by adding one of the following <code>sage-row--valign</code> classes:</p>

--- a/app/views/pages/icon.html.erb
+++ b/app/views/pages/icon.html.erb
@@ -13,7 +13,7 @@
   then <code>aria-hidden="true"</code> can be used instead.
 </p>
 <% end %>
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-row">
     <div class="sage-col--md-4 sage-col--sm-6">
       <div class="sage-icon-block">

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="t-sage-heading-1">Welcome to Sage</h1>
   <p>The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.</p>
 <% end %>
-<div class="sage-panel sage-type">
+<div class="docs-container sage-type">
   <h2 id="how_works">How it works</h2>
   <p>The UI of the Kajabi Core application is a combination of Rails Components, React Components and a custom CSS Framework called Sage that applies a uniform style to both.</p>
   <p>We think of our approach to UI at Kajabi in this way: We default to using Rails Components and a classic Rails approach to most problems and move to React where it counts.</p>

--- a/app/views/pages/status.html.erb
+++ b/app/views/pages/status.html.erb
@@ -24,7 +24,7 @@
     </ul>
   </div>
 <% end %>
-<div class="sage-panel">
+<div class="docs-container">
   <h2 class="t-sage-heading-2">Elements</h2>
   <div class="sage-table-wrapper">
     <div class="sage-table-wrapper__overflow">
@@ -45,7 +45,7 @@
     </div>
   </div>
 </div>
-<div class="sage-panel">
+<div class="docs-container">
   <h2 class="t-sage-heading-2">Objects</h2>
   <div class="sage-table-wrapper">
     <div class="sage-table-wrapper__overflow">

--- a/app/views/pages/token.html.erb
+++ b/app/views/pages/token.html.erb
@@ -16,7 +16,7 @@
   </div>
 <% end %>
 <% sage_tokens.each do |token| %>
-  <div class="sage-panel sage-type">
+  <div class="docs-container sage-type">
     <h2 id="<%= token[:category] %>"><%= token[:category].titleize %></h2>
     <h3 class="t-sage-heading-6">Default</h3>
     <div class="tokens">

--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -154,7 +154,7 @@
   </p>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <h3 class="t-sage-heading-3">Lorem ipsum dolor sit</h3>
   <div class="sage-code-snippet">
     <pre class="prettyprint"><code>&lt;h3 class="t-sage-heading-3"&gt;Lorem ipsum dolor sit&lt;/h3&gt;</code></pre>
@@ -170,7 +170,7 @@
   </p>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <span class="t-sage-heading-3">Lorem ipsum dolor sit</span>
   <div class="sage-code-snippet">
     <pre class="prettyprint"><code>&lt;span class="t-sage-heading-3"&gt;Lorem ipsum dolor sit&lt;/span&gt;</code></pre>
@@ -187,7 +187,7 @@
   </p>
 </div>
 
-<div class="sage-panel">
+<div class="docs-container">
   <div class="sage-type">
     <h3>User-generated content</h3>
     <p>See how content inside this <code>sage-type</code> container automatically recieves corresponding type specs?</p>

--- a/lib/sage-frontend/stylesheets/docs/_docs_container.scss
+++ b/lib/sage-frontend/stylesheets/docs/_docs_container.scss
@@ -1,0 +1,13 @@
+/* ==================================================
+  ** _docs_container.scss
+
+  For Sage documentation use
+================================================== */
+
+.docs-container {
+  margin-bottom: sage-spacing();
+  background: $sage-panel-bg-color;
+  border-radius: $sage-panel-border-radius;
+  box-shadow: $sage-panel-box-shadow;
+  padding: $sage-panel-padding;
+}

--- a/lib/sage-frontend/stylesheets/docs/index.scss
+++ b/lib/sage-frontend/stylesheets/docs/index.scss
@@ -50,3 +50,4 @@
 @import "status_table";
 @import "table";
 @import "theme";
+@import "docs_container";


### PR DESCRIPTION
## Follow up to #316
`sage-panel` has diverged from our usage in the docs. Since it's only a basic color-boxed wrapper in the context of the docs it has been migrated and renamed to `docs-container`. A general "box" that can be used to wrap things.

