### PR TITLE
Revisions to input hint meter and label

### DIFF
--- a/app/views/examples/elements/meter/_markup.html.erb
+++ b/app/views/examples/elements/meter/_markup.html.erb
@@ -1,4 +1,4 @@
 <div class="sage-meter">
-  <% if label != "" %><label for="<%= id -%>" class="sage-meter__label"><%= label -%></label><% end %>
+  <% if label != "" %><label for="<%= id -%>" class="sage-meter__label visually-hidden"><%= label -%></label><% end %>
   <meter class="sage-meter__bar" id="<%= id -%>" max="<%= max_value -%>" <% if optimum_value != "" -%>optimum="<%= optimum_value -%>"<%- end %> value="<%= value -%>" js-meter-type="password" aria-live="off"></meter>
 </div>

--- a/app/views/examples/elements/meter/_markup.html.erb
+++ b/app/views/examples/elements/meter/_markup.html.erb
@@ -1,4 +1,5 @@
 <div class="sage-meter">
   <% if label != "" %><label for="<%= id -%>" class="sage-meter__label visually-hidden"><%= label -%></label><% end %>
-  <meter class="sage-meter__bar" id="<%= id -%>" max="<%= max_value -%>" <% if optimum_value != "" -%>optimum="<%= optimum_value -%>"<%- end %> value="<%= value -%>" js-meter-type="password" aria-live="off"></meter>
+  <p id="<%= id -%>-description" class="sage-meter__description" data-low-text="<%= low_value_text %>" data-med-text="<%= med_value_text %>" data-high-text="<%= high_value_text %>" data-max-text="<%= max_value_text %>"></p>
+  <meter class="sage-meter__bar" id="<%= id -%>" max="<%= max_value -%>" <% if optimum_value != "" -%>optimum="<%= optimum_value -%>"<%- end %> value="<%= value -%>" js-meter-type="password" aria-live="polite" aria-describedby="<%= id -%>-description"></meter>
 </div>

--- a/app/views/examples/elements/meter/_preview.html.erb
+++ b/app/views/examples/elements/meter/_preview.html.erb
@@ -23,5 +23,9 @@
   label: "Password strength",
   value: 1,
   max_value: 8,
-  optimum_value: 6
+  optimum_value: 6,
+  low_value_text: "Weak password",
+  med_value_text: "¯\\_(ツ)_/¯",
+  high_value_text: "Not bad",
+  max_value_text: "Strong password"
 %>

--- a/app/views/examples/objects/input_helper/_markup.html.erb
+++ b/app/views/examples/objects/input_helper/_markup.html.erb
@@ -14,6 +14,10 @@
     label: "Password strength",
     value: 0,
     max_value: 4,
-    optimum_value: 4
+    optimum_value: 4,
+    low_value_text: "Weak password",
+    med_value_text: "¯\\_(ツ)_/¯",
+    high_value_text: "Not bad",
+    max_value_text: "Strong password"
   %>
 </div>

--- a/lib/sage-frontend/javascript/system/inputhelper.js
+++ b/lib/sage-frontend/javascript/system/inputhelper.js
@@ -12,6 +12,14 @@ Sage.inputhelper = (function() {
   var passingClass = "sage-hint__list-item--success";
   var inputErrorClass = "sage-input--error";
   var sageMeterBar = ".sage-meter__bar";
+  var sageMeterBarDesc = document.querySelector(".sage-meter__description");
+
+  var meterLevels = {
+    low: 0.25,
+    med: 0.5,
+    high: 0.75,
+    max: 0.9
+  };
 
 
   // ==================================================
@@ -25,14 +33,48 @@ Sage.inputhelper = (function() {
     if (typeof zxcvbn !== "undefined") {
       trueScore = zxcvbn(inputValue).score;
       // artificially reduce score if requirements are not met
-      revisedScore = (reqsMet === true ? trueScore : trueScore - 1);
+      revisedScore = (reqsMet === true ? trueScore : limitScore(trueScore));
       // update meter value
       meter.value = revisedScore;
-      // append corresponding classes
+      // append corresponding classes and text
       Sage.meter.updateMeter(sageMeterBar);
+      updateStrengthText(sageMeterBarDesc, revisedScore);
     } else {
       // hides meter if zxcvbn library is not loaded
       meter.closest(".sage-meter").style.display = "none";
+    }
+  }
+
+  function limitScore(num) {
+    return num > 1 ? num - 1 : num;
+  }
+
+  // update strength level text description
+  function updateStrengthText(ele, score) {
+    var constraints = Sage.meter.getMeterValues(sageMeterBar);
+    var meterText = getMeterTextLabels(ele);
+    var meterPct = score / constraints.max;
+
+    if (meterPct >= meterLevels.max) {
+      ele.innerText = meterText.max;
+    } else if (meterPct >= meterLevels.high) {
+      ele.innerText = meterText.high;
+    } else if (meterPct >= meterLevels.med) {
+      ele.innerText = meterText.med;
+    } else if (meterPct >= meterLevels.low) {
+      ele.innerText = meterText.low;
+    } else {
+      ele.innerText = "";
+    }
+  }
+
+  // retrieve data attributes to use as text labels
+  function getMeterTextLabels(ele) {
+    return {
+      low: ele.getAttribute("data-low-text"),
+      med: ele.getAttribute("data-med-text"),
+      high: ele.getAttribute("data-high-text"),
+      max: ele.getAttribute("data-max-text")
     }
   }
 

--- a/lib/sage-frontend/javascript/system/meter.js
+++ b/lib/sage-frontend/javascript/system/meter.js
@@ -54,6 +54,7 @@ Sage.meter = (function() {
 
   return {
     init: init,
+    getMeterValues: getMeterValues,
     updateMeter: updateMeter
   };
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
@@ -4,17 +4,17 @@
 
 ================================================== */
 
-$-sage-meter-bar-height: rem(4px);
-$-sage-meter-color-bg: sage-color(grey, 200);
-$-sage-meter-bar-low: rgba(sage-color(red), 0.9);
-$-sage-meter-bar-med: rgba(sage-color(orange), 0.9);
-$-sage-meter-bar-success: rgba(sage-color(sage, 200), 0.9);
-$-sage-meter-bar-max: rgba(sage-color(sage), 0.9);
+$-meter-bar-height: rem(4px);
+$-meter-color-bg: sage-color(grey, 200);
+$-meter-bar-low: rgba(sage-color(red), 0.9);
+$-meter-bar-med: rgba(sage-color(orange), 0.9);
+$-meter-bar-success: rgba(sage-color(sage, 200), 0.9);
+$-meter-bar-max: rgba(sage-color(sage), 0.9);
 
 @mixin meter-bar-reset {
-  height: $-sage-meter-bar-height;
+  height: $-meter-bar-height;
   width: 100%;
-  background: $-sage-meter-color-bg;
+  background: $-meter-color-bg;
   border: 0;
 }
 
@@ -41,8 +41,8 @@ $-sage-meter-bar-max: rgba(sage-color(sage), 0.9);
 .sage-meter__bar {
   overflow: hidden;
   width: 100%;
-  height: $-sage-meter-bar-height;
-  background: $-sage-meter-color-bg;
+  height: $-meter-bar-height;
+  background: $-meter-color-bg;
   border-radius: sage-border(radius);
   border: 0;
 
@@ -62,24 +62,24 @@ $-sage-meter-bar-max: rgba(sage-color(sage), 0.9);
 
 .sage-meter__bar--low {
   @include meter-bar-value() {
-    background-color: $-sage-meter-bar-low;
+    background-color: $-meter-bar-low;
   }
 }
 
 .sage-meter__bar--med {
   @include meter-bar-value() {
-    background-color: $-sage-meter-bar-med;
+    background-color: $-meter-bar-med;
   }
 }
 
 .sage-meter__bar--optimum {
   @include meter-bar-value() {
-    background-color: $-sage-meter-bar-success;
+    background-color: $-meter-bar-success;
   }
 }
 
 .sage-meter__bar--max {
   @include meter-bar-value() {
-    background-color: $-sage-meter-bar-max;
+    background-color: $-meter-bar-max;
   }
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
@@ -10,6 +10,7 @@ $-meter-bar-low: rgba(sage-color(red), 0.9);
 $-meter-bar-med: rgba(sage-color(orange), 0.9);
 $-meter-bar-success: rgba(sage-color(sage, 200), 0.9);
 $-meter-bar-max: rgba(sage-color(sage), 0.9);
+$-meter-bar-divider-color: sage-color(white);
 
 @mixin meter-bar-reset {
   height: $-meter-bar-height;
@@ -29,22 +30,53 @@ $-meter-bar-max: rgba(sage-color(sage), 0.9);
 }
 
 .sage-meter {
-  display: flex;
   position: relative;
 }
 
-.sage-meter__label {
+.sage-meter__label,
+.sage-meter__description {
   @extend %t-sage-body-xsmall;
   line-height: 1;
 }
 
+.sage-meter__description {
+  margin: 0;
+}
+
 .sage-meter__bar {
+  position: relative;
   overflow: hidden;
   width: 100%;
   height: $-meter-bar-height;
   background: $-meter-color-bg;
   border-radius: sage-border(radius);
   border: 0;
+
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: $-meter-bar-height;
+    background: linear-gradient(
+      to left,
+      transparent 25%,
+      $-meter-bar-divider-color 25%,
+      $-meter-bar-divider-color 27.5%,
+      transparent 27.5%,
+      transparent 50%,
+      $-meter-bar-divider-color 50%,
+      $-meter-bar-divider-color 52.5%,
+      transparent 52.5%,
+      transparent 75%,
+      $-meter-bar-divider-color 75%,
+      $-meter-bar-divider-color 77.5%,
+      transparent 77.5%
+    );
+  }
 
   &::-moz-meter-bar {
     @include meter-bar-reset();

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
@@ -4,14 +4,19 @@
 
 ================================================== */
 
-$-sage-meter-height: rem(18px);
-$-sage-meter-color-bg: sage-color(white);
-$-sage-meter-color-label: rgba(sage-color(black), 0.7);
-$-sage-meter-label-shadow: 1px 1px 0 rgba(255, 255, 255, 0.67);
+$-sage-meter-bar-height: rem(4px);
+$-sage-meter-color-bg: sage-color(grey, 200);
 $-sage-meter-bar-low: rgba(sage-color(red), 0.9);
 $-sage-meter-bar-med: rgba(sage-color(orange), 0.9);
 $-sage-meter-bar-success: rgba(sage-color(sage, 200), 0.9);
 $-sage-meter-bar-max: rgba(sage-color(sage), 0.9);
+
+@mixin meter-bar-reset {
+  height: $-sage-meter-bar-height;
+  width: 100%;
+  background: $-sage-meter-color-bg;
+  border: 0;
+}
 
 
 @mixin meter-bar-value {
@@ -23,37 +28,29 @@ $-sage-meter-bar-max: rgba(sage-color(sage), 0.9);
   }
 }
 
-
 .sage-meter {
+  display: flex;
   position: relative;
 }
 
 .sage-meter__label {
   @extend %t-sage-body-xsmall;
-
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate3d(-50%, -50%, 0);
-  z-index: sage-z_index(raised);
   line-height: 1;
-  color: $-sage-meter-color-label;
-  text-shadow: $-sage-meter-label-shadow;
 }
 
 .sage-meter__bar {
-  position: relative;
   overflow: hidden;
   width: 100%;
-  height: $-sage-meter-height;
+  height: $-sage-meter-bar-height;
   background: $-sage-meter-color-bg;
   border-radius: sage-border(radius);
   border: 0;
 
+  &::-moz-meter-bar {
+    @include meter-bar-reset();
+  }
   &::-webkit-meter-bar {
-    height: 100%;
-    width: 100%;
-    background: none;
+    @include meter-bar-reset();
   }
 
   @include meter-bar-value() {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_input_helper.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_input_helper.scss
@@ -45,7 +45,7 @@ $-helper-decoration-list-success: line-through;
     content: "";
     display: block;
     position: absolute;
-    top: calc(-#{$-helper-pointer-size} - #{rem(1px)});
+    top: -$-helper-pointer-size - rem(1px);
     left: 50%;
     transform: translateX(-50%);
     border-left: $-helper-pointer-size solid transparent;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_input_helper.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_input_helper.scss
@@ -4,20 +4,20 @@
 
 ================================================== */
 
-$-sage-helper-min-height: 5em;
-$-sage-helper-max-width: rem(320px);
-$-sage-helper-padding: sage-spacing(sm);
-$-sage-helper-pointer-size: rem(12px);
-$-sage-helper-color-bg: sage-color(white);
-$-sage-helper-color-text: sage-color(white);
-$-sage-helper-color-list-default: sage-color(grey, 200);
-$-sage-helper-color-list-success: sage-color(grey, 500);
-$-sage-helper-decoration-list-success: line-through;
+$-helper-min-height: 5em;
+$-helper-max-width: rem(320px);
+$-helper-padding: sage-spacing(sm);
+$-helper-pointer-size: rem(12px);
+$-helper-color-bg: sage-color(white);
+$-helper-color-text: sage-color(white);
+$-helper-color-list-default: sage-color(grey, 200);
+$-helper-color-list-success: sage-color(grey, 500);
+$-helper-decoration-list-success: line-through;
 
 
 @mixin input-helper-visible() {
   z-index: sage-z_index(raised);
-  top: calc(100% + #{$-sage-helper-pointer-size});
+  top: calc(100% + #{$-helper-pointer-size});
   opacity: 1;
 }
 
@@ -29,10 +29,10 @@ $-sage-helper-decoration-list-success: line-through;
   transform: translateX(-50%);
   left: 50%;
   width: 100%;
-  max-width: $-sage-helper-max-width;
-  min-height: $-sage-helper-min-height;
-  padding: $-sage-helper-padding;
-  background-color: $-sage-helper-color-bg;
+  max-width: $-helper-max-width;
+  min-height: $-helper-min-height;
+  padding: $-helper-padding;
+  background-color: $-helper-color-bg;
   border-radius: sage-border(radius);
   box-shadow: sage-shadow(md);
   transition: $sage-transition;
@@ -45,17 +45,17 @@ $-sage-helper-decoration-list-success: line-through;
     content: "";
     display: block;
     position: absolute;
-    top: calc(-#{$-sage-helper-pointer-size} - #{rem(1px)});
+    top: calc(-#{$-helper-pointer-size} - #{rem(1px)});
     left: 50%;
     transform: translateX(-50%);
-    border-left: $-sage-helper-pointer-size solid transparent;
-    border-right: $-sage-helper-pointer-size solid transparent;
-    border-bottom: $-sage-helper-pointer-size solid rgba(sage-color(black), 0.08);
+    border-left: $-helper-pointer-size solid transparent;
+    border-right: $-helper-pointer-size solid transparent;
+    border-bottom: $-helper-pointer-size solid rgba(sage-color(black), 0.08);
   }
 
   &::after {
-    top: -#{$-sage-helper-pointer-size};
-    border-bottom-color: $-sage-helper-color-bg;
+    top: -#{$-helper-pointer-size};
+    border-bottom-color: $-helper-color-bg;
   }
 
   .sage-input:focus-within ~ & {
@@ -89,7 +89,7 @@ $-sage-helper-decoration-list-success: line-through;
 }
 
 .sage-hint__list-item--success {
-  color: $-sage-helper-color-list-success;
-  text-decoration: $-sage-helper-decoration-list-success;
+  color: $-helper-color-list-success;
+  text-decoration: $-helper-decoration-list-success;
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_input_helper.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_input_helper.scss
@@ -8,7 +8,7 @@ $-sage-helper-min-height: 5em;
 $-sage-helper-max-width: rem(320px);
 $-sage-helper-padding: sage-spacing(sm);
 $-sage-helper-pointer-size: rem(12px);
-$-sage-helper-color-bg: sage-color(charcoal, 400);
+$-sage-helper-color-bg: sage-color(white);
 $-sage-helper-color-text: sage-color(white);
 $-sage-helper-color-list-default: sage-color(grey, 200);
 $-sage-helper-color-list-success: sage-color(grey, 500);
@@ -32,7 +32,6 @@ $-sage-helper-decoration-list-success: line-through;
   max-width: $-sage-helper-max-width;
   min-height: $-sage-helper-min-height;
   padding: $-sage-helper-padding;
-  color: $-sage-helper-color-text;
   background-color: $-sage-helper-color-bg;
   border-radius: sage-border(radius);
   box-shadow: sage-shadow(md);
@@ -41,16 +40,22 @@ $-sage-helper-decoration-list-success: line-through;
   pointer-events: none;
   opacity: 0;
 
-  &::before {
+  &::before,
+  &::after {
     content: "";
     display: block;
     position: absolute;
-    top: -#{$-sage-helper-pointer-size};
+    top: calc(-#{$-sage-helper-pointer-size} - #{rem(1px)});
     left: 50%;
     transform: translateX(-50%);
     border-left: $-sage-helper-pointer-size solid transparent;
     border-right: $-sage-helper-pointer-size solid transparent;
-    border-bottom: $-sage-helper-pointer-size solid $-sage-helper-color-bg;
+    border-bottom: $-sage-helper-pointer-size solid rgba(sage-color(black), 0.08);
+  }
+
+  &::after {
+    top: -#{$-sage-helper-pointer-size};
+    border-bottom-color: $-sage-helper-color-bg;
   }
 
   .sage-input:focus-within ~ & {
@@ -75,7 +80,6 @@ $-sage-helper-decoration-list-success: line-through;
 .sage-hint__list {
   margin-bottom: sage-spacing(sm);
   padding-left: sage-spacing(sm);
-  color: $-sage-helper-color-list-default;
 }
 
 .sage-hint__list-item {


### PR DESCRIPTION
## Description
Drawing on examples from design provided below, we'll make better use of the label as an indicator of strength, and shorten the height of the meter itself to de-emphasize its appearance until a user has interacted with the associated field.

Chrome recently updated their meter styles, which has affected the current implementation (as seen in "Before" screenshot)

- [x] Remove Chrome `meter` border
- [x] Add dynamic descriptive text describing password strength


|  Before   |  After (default)  | After (filled)|
|--------|--------|--------|
|![input-helper-old](https://user-images.githubusercontent.com/816579/86986213-fe35d100-c147-11ea-9d5c-2077af20f040.png)|![input-helper-default](https://user-images.githubusercontent.com/816579/86986223-042bb200-c148-11ea-87c6-1dcf0d6a0dcf.png)|![input-helper-filled](https://user-images.githubusercontent.com/816579/86986231-0b52c000-c148-11ea-8892-652bffdf8c46.png)|



### Inspiration
|  Example 1   |  Example 2  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/816579/83314884-64d2e100-a1d1-11ea-8867-9502ee44854e.png)|![image (1)](https://user-images.githubusercontent.com/816579/83314891-72886680-a1d1-11ea-8fc6-8f1488ba9e4b.png)|

## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- #261 
