### PR TITLE
Update Type Specs

### DIFF
--- a/app/helpers/tokens_helper.rb
+++ b/app/helpers/tokens_helper.rb
@@ -51,11 +51,14 @@ module TokensHelper
         ]
       },
       {
-        category: "font-height",
+        category: "line-height",
         tokens: [
+          { name: "2xs" },
+          { name: "xs" },
           { name: "sm" },
           { name: "md" },
           { name: "lg" },
+          { name: "xl" },
         ]
       },
       {

--- a/app/views/examples/elements/button/_preview.html.erb
+++ b/app/views/examples/elements/button/_preview.html.erb
@@ -1,626 +1,678 @@
-<h3 class="t-sage-heading-6">Primary</h3>
+<div class="sage-type">
+  <h3 class="t-sage-heading-6">Primary</h3>
 
-<!-- Primary button -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
+  <!-- Primary button -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Primary button (link) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "#element-button",
-  size: "",
-  text: "Link"
-%>
+  <!-- Primary button (link) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "#element-button",
+    size: "",
+    text: "Link"
+  %>
 
-<!-- Primary button (icon-left) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "sage-btn--icon-left-menu",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link (icon-left)"
-%>
+  <!-- Primary button (icon-left) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "sage-btn--icon-left-menu",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link (icon-left)"
+  %>
 
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "sage-btn--icon-right-add",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button (icon-right)"
-%>
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "sage-btn--icon-right-add",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button (icon-right)"
+  %>
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Primary (disabled)</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Primary (disabled)</h3>
 
-<!-- Primary button (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
+  <!-- Primary button (disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Primary button link (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Button Link"
-%>
+  <!-- Primary button link (disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Button Link"
+  %>
 
-<!-- Primary button (icon-left, disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "sage-btn--icon-left-users",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button (icon-left)"
-%>
+  <!-- Primary button (icon-left, disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "sage-btn--icon-left-users",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button (icon-left)"
+  %>
 
-<!-- Primary button (icon-right, disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "sage-btn--icon-right-launch",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link (icon-right)"
-%>
+  <!-- Primary button (icon-right, disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "sage-btn--icon-right-launch",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link (icon-right)"
+  %>
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Secondary</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Secondary</h3>
 
-<!-- Secondary button -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
+  <!-- Secondary button -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Secondary button (link) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link"
-%>
+  <!-- Secondary button (link) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link"
+  %>
 
-<!-- Secondary button (icon-left) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "sage-btn--icon-left-gear",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button (icon-left)"
-%>
+  <!-- Secondary button (icon-left) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-left-gear",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button (icon-left)"
+  %>
 
-<!-- Secondary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "sage-btn--icon-right-search",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link (icon-right)"
-%>
+  <!-- Secondary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-right-search",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link (icon-right)"
+  %>
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Secondary (disabled)</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Secondary (disabled)</h3>
 
-<!-- Secondary button (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
+  <!-- Secondary button (disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Secondary button link (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link"
-%>
+  <!-- Secondary button link (disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link"
+  %>
 
-<!-- Secondary button (icon-left, disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "sage-btn--icon-left-send-message",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link (icon-left)"
-%>
+  <!-- Secondary button (icon-left, disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-left-send-message",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link (icon-left)"
+  %>
 
-<!-- Secondary button (icon-right, disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "sage-btn--icon-right-arrow-right",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Button (icon-right)"
-%>
+  <!-- Secondary button (icon-right, disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-right-arrow-right",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Button (icon-right)"
+  %>
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Tertiary</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Tertiary</h3>
 
-<!-- Tertiary button -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
+  <!-- Tertiary button -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Tertiary button (link) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link"
-%>
+  <!-- Tertiary button (link) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link"
+  %>
 
-<!-- Tertiary button (icon-left) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "sage-btn--icon-left-3-dot-menu",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button (icon-left)"
-%>
+  <!-- Tertiary button (icon-left) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "sage-btn--icon-left-3-dot-menu",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button (icon-left)"
+  %>
 
-<!-- Tertiary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "sage-btn--icon-right-microphone",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button (icon-right)"
-%>
+  <!-- Tertiary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "sage-btn--icon-right-microphone",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button (icon-right)"
+  %>
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Tertiary (disabled)</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Tertiary (disabled)</h3>
 
-<!-- Tertiary button disabled -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
+  <!-- Tertiary button disabled -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Tertiary button link (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link"
-%>
+  <!-- Tertiary button link (disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link"
+  %>
 
-<!-- Tertiary button (icon-left, disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "sage-btn--icon-left-comment",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link (icon-left)"
-%>
+  <!-- Tertiary button (icon-left, disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "sage-btn--icon-left-comment",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link (icon-left)"
+  %>
 
-<!-- Tertiary button (icon-right, disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "sage-btn--icon-right-preview-off",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link (icon-right)"
-%>
+  <!-- Tertiary button (icon-right, disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "sage-btn--icon-right-preview-off",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link (icon-right)"
+  %>
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Danger</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Danger</h3>
 
-<!-- Danger button -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
+  <!-- Danger button -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Danger button (link) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link"
-%>
+  <!-- Danger button (link) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link"
+  %>
 
-<!-- Danger button (icon-left) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "sage-btn--icon-left-microphone",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button (icon-left)"
-%>
+  <!-- Danger button (icon-left) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "sage-btn--icon-left-microphone",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button (icon-left)"
+  %>
 
-<!-- Danger button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "sage-btn--icon-right-enlarge",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button (icon-right)"
-%>
-
-
-<br><br><br>
-<h3 class="t-sage-heading-6">Danger (disabled)</h3>
-
-<!-- Danger button (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Button"
-%>
-
-<!-- Danger button link (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link"
-%>
-
-<!-- Danger button link (icon-left, disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "sage-btn--icon-left-tag",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: true,
-  link_url: "#",
-  size: "",
-  text: "Link (icon-left)"
-%>
+  <!-- Danger button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "sage-btn--icon-right-enlarge",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button (icon-right)"
+  %>
 
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Flex Align End</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Danger (disabled)</h3>
 
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: true,
-  color: "primary",
-  icon_class: "sage-btn--icon-right-add",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Add A Model"
-%>
+  <!-- Danger button (disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Button"
+  %>
 
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: true,
-  color: "tertiary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Cancel"
-%>
+  <!-- Danger button link (disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link"
+  %>
 
-
-<br><br><br>
-<h3 class="t-sage-heading-6">Small</h3>
-
-<!-- Primary small -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "small",
-  text: "Primary small"
-%>
+  <!-- Danger button link (icon-left, disabled) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "sage-btn--icon-left-tag",
+    icon_only: false,
+    is_disabled: true,
+    is_link_btn: true,
+    link_url: "#",
+    size: "",
+    text: "Link (icon-left)"
+  %>
 
 
-<!-- Primary button small (disabled) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "sage-btn--icon-left-folder",
-  icon_only: false,
-  is_disabled: true,
-  is_link_btn: false,
-  link_url: "",
-  size: "small",
-  text: "Primary small"
-%>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Flex Align End</h3>
 
-<!-- Secondary small -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "sage-btn--icon-left-lock",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "#",
-  size: "small",
-  text: "Secondary small link"
-%>
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: true,
+    color: "primary",
+    icon_class: "sage-btn--icon-right-add",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Add A Model"
+  %>
 
-<!-- Tertiary small -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "",
-  icon_only: false,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "small",
-  text: "Tertiary small"
-%>
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: true,
+    color: "tertiary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Cancel"
+  %>
 
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Icon Button</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Small</h3>
 
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "sage-btn--icon-only-add",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Name Of Action"
-%>
+  <!-- Primary small -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "small",
+    text: "Primary small"
+  %>
 
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "sage-btn--icon-only-send-message",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Name Of Action"
-%>
+  <!-- Secondary small -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-left-lock",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "#",
+    size: "small",
+    text: "Secondary small link"
+  %>
 
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "sage-btn--icon-only-pen",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "",
-  text: "Name Of Action"
-%>
-
-<!-- Primary button (icon-right) -->
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "sage-btn--icon-only-remove",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: true,
-  link_url: "",
-  size: "",
-  text: "Name Of Action"
-%>
+  <!-- Tertiary small -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "",
+    icon_only: false,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "small",
+    text: "Tertiary small"
+  %>
 
 
-<br><br><br>
-<h3 class="t-sage-heading-6">Tiny Button</h3>
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Tiny Button (Limited use)</h3>
 
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "primary",
-  icon_class: "sage-btn--icon-only-tag",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "tiny",
-  text: "Name Of Action"
-%>
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "secondary",
-  icon_class: "sage-btn--icon-only-tag",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "tiny",
-  text: "Name Of Action"
-%>
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "tertiary",
-  icon_class: "sage-btn--icon-only-tag",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "tiny",
-  text: "Name Of Action"
-%>
-<%= render "examples/elements/button/markup",
-  align_end: false,
-  color: "danger",
-  icon_class: "sage-btn--icon-only-tag",
-  icon_only: true,
-  is_disabled: false,
-  is_link_btn: false,
-  link_url: "",
-  size: "tiny",
-  text: "Name Of Action"
-%>
+  <button class="sage-btn sage-btn--tertiary sage-btn--icon-left-tag sage-btn--tiny">
+    <span class="sage-label sage-label--draft">#hastag</span>
+  </button>
+  <button class="sage-btn sage-btn--tertiary sage-btn--icon-right-copy sage-btn--tiny">
+    <span class="sage-label sage-label--draft">3.1459</span>
+  </button>
 
-<br><br>
-<button class="sage-btn sage-btn--tertiary sage-btn--icon-left-tag sage-btn--tiny">
-  <span class="sage-label sage-label--draft">#hastag</span>
-</button>
-<button class="sage-btn sage-btn--tertiary sage-btn--icon-right-file sage-btn--tiny">
-  <span class="sage-label sage-label--draft">3.1459</span>
-</button>
+
+  <br><br><br>
+  <h3 class="t-sage-heading-6">Icon Button</h3>
+
+  <strong class="t-sage-body-small-med">Regular</strong>
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "sage-btn--icon-only-add",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-only-send-message",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "sage-btn--icon-only-pen",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "sage-btn--icon-only-remove",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "",
+    size: "",
+    text: "Name Of Action"
+  %>
+
+  <br><br>
+  <strong class="t-sage-body-small-med">Small</strong>
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "sage-btn--icon-only-add",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "small",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-only-send-message",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "small",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "sage-btn--icon-only-pen",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "small",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "sage-btn--icon-only-remove",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "",
+    size: "small",
+    text: "Name Of Action"
+  %>
+
+  <br><br>
+  <strong class="t-sage-body-small-med">Tiny</strong>
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "primary",
+    icon_class: "sage-btn--icon-only-add",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "tiny",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "secondary",
+    icon_class: "sage-btn--icon-only-send-message",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "tiny",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "tertiary",
+    icon_class: "sage-btn--icon-only-pen",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: false,
+    link_url: "",
+    size: "tiny",
+    text: "Name Of Action"
+  %>
+
+  <!-- Primary button (icon-right) -->
+  <%= render "examples/elements/button/markup",
+    align_end: false,
+    color: "danger",
+    icon_class: "sage-btn--icon-only-remove",
+    icon_only: true,
+    is_disabled: false,
+    is_link_btn: true,
+    link_url: "",
+    size: "tiny",
+    text: "Name Of Action"
+  %>
+
+</div>

--- a/app/views/examples/objects/sortable/_markup.html.erb
+++ b/app/views/examples/objects/sortable/_markup.html.erb
@@ -6,8 +6,28 @@
       <p class="t-sage-body-xsmall">Batmobile</p>
     </div>
     <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
+      <%= render "examples/elements/button/markup",
+        align_end: false,
+        color: "tertiary",
+        icon_class: "sage-btn--icon-only-preview-on",
+        icon_only: true,
+        is_disabled: false,
+        is_link_btn: true,
+        link_url: "#",
+        size: "",
+        text: "Preview"
+      %>
+      <%= render "examples/elements/button/markup",
+        align_end: false,
+        color: "tertiary",
+        icon_class: "sage-btn--icon-only-pen",
+        icon_only: true,
+        is_disabled: false,
+        is_link_btn: true,
+        link_url: "#",
+        size: "",
+        text: "Edit"
+      %>
     </div>
   </section>
 
@@ -17,8 +37,28 @@
       <p class="t-sage-body-xsmall">Mary Jane's Oldsmobile</p>
     </div>
     <div class="sage-sortable__item-actions">
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-preview-on" href="#" data-js-tooltip="Preview">Preview</a>
-      <a class="sage-btn sage-btn--tertiary sage-btn--icon-only-pen" href="#" data-js-tooltip="Edit">Edit</a>
+      <%= render "examples/elements/button/markup",
+        align_end: false,
+        color: "tertiary",
+        icon_class: "sage-btn--icon-only-preview-on",
+        icon_only: true,
+        is_disabled: false,
+        is_link_btn: true,
+        link_url: "#",
+        size: "",
+        text: "Preview"
+      %>
+      <%= render "examples/elements/button/markup",
+        align_end: false,
+        color: "tertiary",
+        icon_class: "sage-btn--icon-only-pen",
+        icon_only: true,
+        is_disabled: false,
+        is_link_btn: true,
+        link_url: "#",
+        size: "",
+        text: "Edit"
+      %>
     </div>
   </section>
 

--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -51,7 +51,7 @@
         <td><code>t-sage-heading-1</code>
         <td>700</td>
         <td>29px</td>
-        <td>1.25</td>
+        <td>36px</td>
         <td>0.3px</td>
       </tr>
       <tr>
@@ -59,7 +59,7 @@
         <td><code>t-sage-heading-2</code>
         <td>700</td>
         <td>26px</td>
-        <td>1.25</td>
+        <td>32px</td>
         <td>0.3px</td>
       </tr>
       <tr>
@@ -67,7 +67,7 @@
         <td><code>t-sage-heading-3</code>
         <td>700</td>
         <td>23px</td>
-        <td>1.25</td>
+        <td>32px</td>
         <td>0.3px</td>
       </tr>
       <tr>
@@ -75,7 +75,7 @@
         <td><code>t-sage-heading-4</code>
         <td>600</td>
         <td>20px</td>
-        <td>1.25</td>
+        <td>28px</td>
         <td>0.3px</td>
       </tr>
       <tr>
@@ -83,7 +83,7 @@
         <td><code>t-sage-heading-5</code>
         <td>600</td>
         <td>18px</td>
-        <td>1.25</td>
+        <td>24px</td>
         <td>0.3px</td>
       </tr>
       <tr>
@@ -91,7 +91,7 @@
         <td><code>t-sage-heading-6</code>
         <td>600</td>
         <td>16px</td>
-        <td>1.25</td>
+        <td>20px</td>
         <td>0.3px</td>
       </tr>
       <tr>
@@ -99,7 +99,7 @@
         <td><code>t-sage-body</code>
         <td>400*</td>
         <td>16px</td>
-        <td>1.75</td>
+        <td>28px</td>
         <td>0.2px</td>
       </tr>
       <tr>
@@ -107,7 +107,7 @@
         <td><code>t-sage-body-small</code>
         <td>400*</td>
         <td>14px</td>
-        <td>1.75</td>
+        <td>24px</td>
         <td>0.2px</td>
       </tr>
       <tr>
@@ -115,7 +115,7 @@
         <td><code>t-sage-body-xsmall</code>
         <td>400*</td>
         <td>12px</td>
-        <td>1.75</td>
+        <td>20px</td>
         <td>0.2px</td>
       </tr>
     </tbody>

--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -50,7 +50,7 @@
         <td><span class="t-sage-heading-1">Heading 1</span></td>
         <td><code>t-sage-heading-1</code>
         <td>700</td>
-        <td>28.83px</td>
+        <td>29px</td>
         <td>1.25</td>
         <td>0.3px</td>
       </tr>
@@ -58,7 +58,7 @@
         <td><span class="t-sage-heading-2">Heading 2</span></td>
         <td><code>t-sage-heading-2</code>
         <td>700</td>
-        <td>25.63px</td>
+        <td>26px</td>
         <td>1.25</td>
         <td>0.3px</td>
       </tr>
@@ -66,7 +66,7 @@
         <td><span class="t-sage-heading-3">Heading 3</span></td>
         <td><code>t-sage-heading-3</code>
         <td>700</td>
-        <td>22.78px</td>
+        <td>23px</td>
         <td>1.25</td>
         <td>0.3px</td>
       </tr>
@@ -74,7 +74,7 @@
         <td><span class="t-sage-heading-4">Heading 4</span></td>
         <td><code>t-sage-heading-4</code>
         <td>600</td>
-        <td>20.25px</td>
+        <td>20px</td>
         <td>1.25</td>
         <td>0.3px</td>
       </tr>
@@ -106,7 +106,7 @@
         <td><span class="t-sage-body-small">Small Body*</span></td>
         <td><code>t-sage-body-small</code>
         <td>400*</td>
-        <td>14.22px</td>
+        <td>14px</td>
         <td>1.75</td>
         <td>0.2px</td>
       </tr>
@@ -114,7 +114,7 @@
         <td><span class="t-sage-body-xsmall">Extra Small Body*</span></td>
         <td><code>t-sage-body-xsmall</code>
         <td>400*</td>
-        <td>12.64px</td>
+        <td>12px</td>
         <td>1.75</td>
         <td>0.2px</td>
       </tr>

--- a/lib/sage-frontend/stylesheets/docs/_token.scss
+++ b/lib/sage-frontend/stylesheets/docs/_token.scss
@@ -48,11 +48,11 @@
       content: "#{$token}";
     }
   }
-  &-font-height::after {
+  &-line-height::after {
     content: "#{sage-line-height()}";
   }
   @each $name, $token in $sage-line-heights {
-    &-font-height-#{$name}::after {
+    &-line-height-#{$name}::after {
       content: "#{$token}";
     }
   }

--- a/lib/sage-frontend/stylesheets/system/core/_functions.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_functions.scss
@@ -6,10 +6,10 @@
 
 /* ==================================================
 ** Integer (pixel) to rem function
-Usage: `rem(12)`
+  Usage: `rem(12)`
 
-Converts an integer to a rem value based on 16 as the base size.
-arguments: $value | [integer]
+  Converts an integer to a rem value based on 16 as the base size.
+  arguments: $value | [integer]
 ================================================== */
 
 @function rem($value) {
@@ -19,12 +19,12 @@ arguments: $value | [integer]
 
 /* ==================================================
 ** Strip units from value
-Usage: `strip-unit(12px)`
+  Usage: `strip-unit(12px)`
 
-Converts an integer to a rem value based on 16 as the base size.
-<https://css-tricks.com/snippets/sass/strip-unit-function/>
-arguments: {Number} $number - Number to remove unit from
-@return {Number} - Unitless number
+  Converts an integer to a rem value based on 16 as the base size.
+  <https://css-tricks.com/snippets/sass/strip-unit-function/>
+    arguments: {Number} $number - Number to remove unit from
+    @return {Number} - Unitless number
 ================================================== */
 
 @function strip-unit($number) {
@@ -37,15 +37,15 @@ arguments: {Number} $number - Number to remove unit from
 
 /* ==================================================
 ** Generates a value based on the baseline grid
-Usage: `baseline(5)`
+  Usage: `baseline(5)`
 
-Given a baseline grid and a number of units, this function
-returns the product, resulting in the equivalent of that
-number of baselines' dimension.
-arguments:
-{Number} $num - Unitless number of baseline units
-{Number} $baseline - The baseline grid value
-@return {Number} - Product of the arguments
+  Given a baseline grid and a number of units, this function
+  returns the product, resulting in the equivalent of that
+  number of baselines' dimension.
+    arguments:
+    {Number} $num - Unitless number of baseline units
+    {Number} $baseline - The baseline grid value
+    @return {Number} - Product of the arguments
 ================================================== */
 
 $default-baseline: rem(4px) !default;

--- a/lib/sage-frontend/stylesheets/system/core/_functions.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_functions.scss
@@ -3,12 +3,13 @@
 
 ================================================== */
 
-/* ==================================================
-  ** Integer (pixel) to rem function
-  Usage: `rem(12)`
 
-  Converts an integer to a rem value based on 16 as the base size.
-  arguments: $value | [integer]
+/* ==================================================
+** Integer (pixel) to rem function
+Usage: `rem(12)`
+
+Converts an integer to a rem value based on 16 as the base size.
+arguments: $value | [integer]
 ================================================== */
 
 @function rem($value) {
@@ -17,19 +18,38 @@
 
 
 /* ==================================================
-  ** Strip units from value
-  Usage: `strip-unit(12px)`
+** Strip units from value
+Usage: `strip-unit(12px)`
 
-  Converts an integer to a rem value based on 16 as the base size.
-  <https://css-tricks.com/snippets/sass/strip-unit-function/>
-    arguments: {Number} $number - Number to remove unit from
-    @return {Number} - Unitless number
+Converts an integer to a rem value based on 16 as the base size.
+<https://css-tricks.com/snippets/sass/strip-unit-function/>
+arguments: {Number} $number - Number to remove unit from
+@return {Number} - Unitless number
 ================================================== */
 
 @function strip-unit($number) {
   @if type-of($number) == "number" and not unitless($number) {
     @return $number / ($number * 0 + 1);
   }
-
+  
   @return $number;
+}
+
+/* ==================================================
+** Generates a value based on the baseline grid
+Usage: `baseline(5)`
+
+Given a baseline grid and a number of units, this function
+returns the product, resulting in the equivalent of that
+number of baselines' dimension.
+arguments:
+{Number} $num - Unitless number of baseline units
+{Number} $baseline - The baseline grid value
+@return {Number} - Product of the arguments
+================================================== */
+
+$default-baseline: rem(4px) !default;
+
+@function baseline($num: 2, $baseline: $default-baseline) {
+  @return $num * $baseline;
 }

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -79,6 +79,13 @@ $sage-icon-li-margin-right: 0.4em !default;
     }
 
     .sage-icon-#{$icon-name}#{$suffix}::before {
+<<<<<<< HEAD
+=======
+      width: $size;
+      height: $size;
+      font-size: $size;
+      line-height: $size;
+>>>>>>> Tidy icon sizing
       @include icon-base($icon-name, $size-name);
       @extend %sage-icon-extensions;
     }

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -79,13 +79,6 @@ $sage-icon-li-margin-right: 0.4em !default;
     }
 
     .sage-icon-#{$icon-name}#{$suffix}::before {
-<<<<<<< HEAD
-=======
-      width: $size;
-      height: $size;
-      font-size: $size;
-      line-height: $size;
->>>>>>> Tidy icon sizing
       @include icon-base($icon-name, $size-name);
       @extend %sage-icon-extensions;
     }

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -155,6 +155,7 @@
   $size: map-get($sage-icon-sizes, $icon-size);
 
   display: inline-flex;
+  box-sizing: content-box;
   width: $size;
   height: $size;
   text-transform: none;

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -152,32 +152,19 @@
   arguments: $icon | null|[string]
 ================================================== */
 
-<<<<<<< HEAD
 @mixin icon-base($icon: null, $icon-size: md) {
   $size: map-get($sage-icon-sizes, $icon-size);
 
-=======
-@mixin icon-base($icon: null, $icon-font-size: md) {
->>>>>>> Tidy icon sizing
   display: inline-flex;
   width: $size;
   height: $size;
   text-transform: none;
-<<<<<<< HEAD
-=======
-  font-weight: normal;
-  font-style: normal;
->>>>>>> Tidy icon sizing
   font-family: "Sage";
   font-size: $size;
   font-style: normal;
   font-weight: normal;
   line-height: $size;
   speak: never;
-
-  /* Better Font Rendering =========== */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 
   /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -152,13 +152,22 @@
   arguments: $icon | null|[string]
 ================================================== */
 
+<<<<<<< HEAD
 @mixin icon-base($icon: null, $icon-size: md) {
   $size: map-get($sage-icon-sizes, $icon-size);
 
+=======
+@mixin icon-base($icon: null, $icon-font-size: md) {
+>>>>>>> Tidy icon sizing
   display: inline-flex;
   width: $size;
   height: $size;
   text-transform: none;
+<<<<<<< HEAD
+=======
+  font-weight: normal;
+  font-style: normal;
+>>>>>>> Tidy icon sizing
   font-family: "Sage";
   font-size: $size;
   font-style: normal;

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -38,7 +38,6 @@
   padding: 0;
   appearance: none;
   font-family: inherit;
-  line-height: 1;
   color: inherit;
   box-shadow: none;
   background-color: transparent;

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -170,6 +170,10 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
   @if ($icon) {
     content: sage-icon($icon);
   }

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -15,11 +15,13 @@ $t-base-spec: (
 );
 
 $t-body-small-spec: map-merge($t-base-spec, (
-  size: sage-font-size(sm)
+  size: sage-font-size(sm),
+  leading: sage-line-height(sm),
 ));
 
 $t-body-xsmall-spec: map-merge($t-base-spec, (
-  size: sage-font-size(xs)
+  size: sage-font-size(xs),
+  leading: sage-line-height(xs),
 ));
 
 // The following map is used to generate both `.t-` classeses for each
@@ -30,25 +32,25 @@ $type-specs: (
   "heading-1": (
     weight: sage-font-weight(bold),
     size: sage-font-size(4xl),
-    leading: sage-line-height(sm),
+    leading: sage-line-height(xl),
     kerning: sage-letter-spacing(sm),
   ),
   "heading-2": (
     weight: sage-font-weight(bold),
     size: sage-font-size(3xl),
-    leading: sage-line-height(sm),
+    leading: sage-line-height(lg),
     kerning: sage-letter-spacing(sm),
   ),
   "heading-3": (
     weight: sage-font-weight(bold),
     size: sage-font-size(2xl),
-    leading: sage-line-height(sm),
+    leading: sage-line-height(lg),
     kerning: sage-letter-spacing(sm),
   ),
   "heading-4": (
     weight: sage-font-weight(semibold),
     size: sage-font-size(xl),
-    leading: sage-line-height(sm),
+    leading: sage-line-height(md),
     kerning: sage-letter-spacing(sm)
   ),
   "heading-5": (
@@ -60,7 +62,7 @@ $type-specs: (
   "heading-6": (
     weight: sage-font-weight(semibold),
     size: $sage-body-font-size,
-    leading: sage-line-height(sm),
+    leading: sage-line-height(xs),
     kerning: sage-letter-spacing(sm)
   ),
 

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -32,7 +32,7 @@ $sage-body-font-monospace: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Lib
 // Text
 $sage-body-font-size: 1rem !default; // 16px
 $sage-body-font-weight: sage-font-weight() !default;
-$sage-body-font-line-height: sage-line-height(lg) !default;
+$sage-body-font-line-height: sage-line-height(md) !default;
 $sage-body-font-color: sage-color(charcoal, 400) !default;
 $sage-body-letter-spacing: sage-letter-spacing(xs) !default;
 $sage-body-margin-bottom: sage-spacing() !default;
@@ -45,7 +45,7 @@ $sage-heading-margin-bottom: sage-spacing() !default;
 // ==================================================
 // GRID
 // ==================================================
-
+$sage-grid-baseline: $default-baseline !default;
 $sage-grid-columns: 12 !default;
 $sage-grid-gap: sage-spacing(sm) !default;
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -96,8 +96,8 @@
 }
 
 .sage-btn--small {
-  padding-top: sage-spacing(3xs);
-  padding-bottom: sage-spacing(3xs);
+  padding-top: 0;
+  padding-bottom: 0;
   font-size: sage-font-size(sm);
 }
 
@@ -287,7 +287,7 @@
         }
 
         &.sage-btn--tiny::before {
-          padding-right: 6px;
+          padding-right: rem(4px);
         }
       }
     }
@@ -305,7 +305,7 @@
         }
 
         &.sage-btn--tiny::before {
-          padding-left: 6px;
+          padding-left: rem(4px);
         }
       }
     }
@@ -313,9 +313,11 @@
     // --- Standalone Icon Buttons
     @else if $direction == only {
       .sage-btn--icon-only-#{$icon-name} {
-        width: rem(36);
-        padding-left: rem(10);
-        padding-right: rem(10);
+        justify-content: center;
+        width: rem(36px);
+        padding-right: rem(6px);
+        padding-left: rem(6px);
+        text-align: center;
 
         &::before {
           @include icon-base($icon-name);
@@ -326,7 +328,7 @@
 
         &.sage-btn--tiny {
           width: auto;
-          padding: 4px;
+          padding: rem(4px);
         }
       }
     }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -314,9 +314,7 @@
     @else if $direction == only {
       .sage-btn--icon-only-#{$icon-name} {
         justify-content: center;
-        width: rem(36px);
-        padding-right: rem(6px);
-        padding-left: rem(6px);
+        padding: rem(12px);
         text-align: center;
 
         &::before {
@@ -324,6 +322,10 @@
 
           transform: scale(1.1);
           align-self: center;
+        }
+
+        &.sage-btn--small {
+          padding: rem(6px);
         }
 
         &.sage-btn--tiny {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -17,7 +17,7 @@
   align-self: flex-start;
   align-items: baseline;
   position: relative;
-  padding: rem(12px) sage-spacing(sm);
+  padding: rem(6px) sage-spacing(sm);
   margin-left: sage-spacing(2xs);
   letter-spacing: $sage-btn-letter-spacing;
   color: sage-color(charcoal, 500);
@@ -96,8 +96,8 @@
 }
 
 .sage-btn--small {
-  padding-top: calc(#{sage-spacing(xs)} + #{rem(1px)}); // adds 1px to offset odd line-height #
-  padding-bottom: sage-spacing(xs);
+  padding-top: sage-spacing(3xs);
+  padding-bottom: sage-spacing(3xs);
   font-size: sage-font-size(sm);
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -287,7 +287,7 @@
         }
 
         &.sage-btn--tiny::before {
-          padding-right: rem(4px);
+          padding-right: sage-spacing(2xs);
         }
       }
     }
@@ -305,7 +305,7 @@
         }
 
         &.sage-btn--tiny::before {
-          padding-left: rem(4px);
+          padding-left: sage-spacing(2xs);
         }
       }
     }
@@ -328,7 +328,7 @@
 
         &.sage-btn--tiny {
           width: auto;
-          padding: rem(4px);
+          padding: sage-spacing(2xs);
         }
       }
     }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
@@ -45,7 +45,6 @@
   padding-right: $sage-inputfield-padding-label;
   color: inherit;
   font-weight: sage-font-weight(semibold);
-  line-height: initial;
   white-space: nowrap;
   background-color: $sage-inputfield-bg-label;
   pointer-events: none;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
@@ -135,7 +135,7 @@
 }
 
 .sage-input__message {
-  @extend %t-sage-body-small;
+  @extend %t-sage-body-xsmall;
 
   .sage-input--error & {
     color: $sage-inputfield-color-error;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_select.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_select.scss
@@ -36,7 +36,6 @@ $-sage-selectfield-color-error: $sage-inputfield-color-error;
   transform: translateY(-50%);
   color: $-sage-selectfield-color-default;
   white-space: nowrap;
-  line-height: initial;
   pointer-events: none;
 
   @include position(($-sage-selectfield-height / 2), unset, unset, $-sage-selectfield-padding-x);

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -13,6 +13,7 @@ $-label-warning-color: sage-color(yellow, 200) !default;
 $-label-danger-color: sage-color(red, 200) !default;
 $-label-padding: 0 sage-spacing(xs) !default;
 $-label-border-radius: sage-border(radius) !default;
+$-label-inset-border: 0 0 0 1px inset;
 
 $-label-colors: (
   draft: (
@@ -65,10 +66,6 @@ $-label-colors: (
   text-align: center;
   white-space: nowrap;
   border-radius: $-label-border-radius;
-  // Use outline since border is inside not outside
-  outline-width: rem(1px);
-  outline-style: solid;
-  outline-offset: -1px;
 }
 
 @each $-color-name, $-color-settings in $-label-colors {
@@ -77,19 +74,19 @@ $-label-colors: (
 
     color: map-get($-color-settings, text);
     background-color: map-get($-color-settings, background);
-    outline-color: map-get($-color-settings, border);
+    box-shadow: $-label-inset-border map-get($-color-settings, border);
 
     &.sage-label--subtle {
       color: map-get($-subtle-settings, text);
       background-color: map-get($-subtle-settings, background);
-      outline-color: map-get($-subtle-settings, border);
+      box-shadow: $-label-inset-border map-get($-subtle-settings, border);
     }
 
     .sage-btn & {
       &:focus,
       &:active {
         background-color: inherit;
-        outline-color: transparent;
+        box-shadow: $-label-inset-border transparent;
       }
     }
   }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -65,8 +65,10 @@ $-label-colors: (
   text-align: center;
   white-space: nowrap;
   border-radius: $-label-border-radius;
-  border-width: rem(1px);
-  border-style: solid;
+  // Use outline since border is inside not outside
+  outline-width: rem(1px);
+  outline-style: solid;
+  outline-offset: -1px;
 }
 
 @each $-color-name, $-color-settings in $-label-colors {
@@ -75,19 +77,19 @@ $-label-colors: (
 
     color: map-get($-color-settings, text);
     background-color: map-get($-color-settings, background);
-    border-color: map-get($-color-settings, border);
+    outline-color: map-get($-color-settings, border);
 
     &.sage-label--subtle {
       color: map-get($-subtle-settings, text);
       background-color: map-get($-subtle-settings, background);
-      border-color: map-get($-subtle-settings, border);
+      outline-color: map-get($-subtle-settings, border);
     }
 
     .sage-btn & {
       &:focus,
       &:active {
         background-color: inherit;
-        border-color: transparent;
+        outline-color: transparent;
       }
     }
   }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_meter.scss
@@ -36,7 +36,6 @@ $-meter-bar-divider-color: sage-color(white);
 .sage-meter__label,
 .sage-meter__description {
   @extend %t-sage-body-xsmall;
-  line-height: 1;
 }
 
 .sage-meter__description {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_switch.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_switch.scss
@@ -20,7 +20,6 @@
 .sage-switch__message {
   width: 100%;
   padding: 0 0 0 ($sage-switch-width + $sage-switch-label-left-spacing);
-  line-height: 1;
 
   @extend %t-sage-body-xsmall;
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_table.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_table.scss
@@ -61,7 +61,6 @@ $-sage-table-sort-indicator-direction: rem(7px);
     padding: $sage-table-cell-padding-sm;
     padding: var(--table-cell-padding);
     color: inherit;
-    line-height: sage-line-height(md);
 
     &:first-child {
       padding-left: sage-spacing(sm) / 2;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_alert.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_alert.scss
@@ -36,7 +36,6 @@ $-alert-colors: (
 .sage-alert__title {
   @extend %t-sage-body-semi;
   color: sage-color(charcoal, 500);
-  line-height: sage-line-height(md);
 
   @each $name, $color in $-alert-colors {
     .sage-alert--#{$name} & {
@@ -75,7 +74,6 @@ $-alert-colors: (
   width: rem(27.65px);
   padding: 0;
   font-size: sage-font-size(2xl);
-  line-height: 1;
   background-color: transparent;
   border: 0;
   appearance: none;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_banner.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_banner.scss
@@ -18,7 +18,6 @@ $-banner-colors: (
   height: $sage-banner-height;
   width: 100%;
   padding: sage-spacing(xs) sage-spacing(sm);
-  line-height: sage-line-height(md);
   color: $sage-banner-text-color;
   background: sage-color(primary);
 }
@@ -45,7 +44,6 @@ $-banner-colors: (
   margin-bottom: 0;
   margin-right: sage-spacing(xs);
   color: inherit;
-  line-height: inherit;
 }
 
 .sage-banner__icon {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
@@ -11,6 +11,7 @@
 
 .sage-tabs__tab {
   margin-right: sage-spacing();
+  padding-bottom: sage-spacing(2xs);
   color: $sage-tabs-default-color;
   transition: color $sage-tabs-default-transition;
 
@@ -36,7 +37,6 @@
 
 .sage-tabs__tab--active {
   position: relative;
-  padding-bottom: sage-spacing(xs);
   color: $sage-tabs-active-color;
 
   &::after {

--- a/lib/sage-frontend/stylesheets/system/tokens/_font_size.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_font_size.scss
@@ -4,12 +4,12 @@
 }
 
 $sage-font-sizes: (
-  xs: rem(12.64px),
-  sm: rem(14.22px),
+  xs: rem(12px),
+  sm: rem(14px),
   md: rem(16px),
   lg: rem(18px),
-  xl: rem(20.25px),
-  2xl: rem(22.78px),
-  3xl: rem(25.63px),
-  4xl: rem(28.83px)
+  xl: rem(20px),
+  2xl: rem(23px),
+  3xl: rem(26px),
+  4xl: rem(29px)
 );

--- a/lib/sage-frontend/stylesheets/system/tokens/_line_height.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_line_height.scss
@@ -4,7 +4,10 @@
 }
 
 $sage-line-heights: (
-  sm: 1.25,
-  md: 1.5,
-  lg: 1.75
+  2xs: baseline(4),
+  xs: baseline(5),
+  sm: baseline(6),
+  md: baseline(7),
+  lg: baseline(8),
+  xl: baseline(9),
 );

--- a/lib/sage-frontend/stylesheets/system/vendor/_reboot.scss
+++ b/lib/sage-frontend/stylesheets/system/vendor/_reboot.scss
@@ -52,12 +52,12 @@ h4,
 h5,
 h6 {
   margin-top: 0;
-  margin-bottom: 10px; /* NOTE: margin-bottom must be '10px' to avoid conflicts with Bootstrap reset inside Ladera */
+  margin-bottom: 0;
 }
 
 p {
   margin-top: 0;
-  margin-bottom: 10px; /* NOTE: margin-bottom must be '10px' to avoid conflicts with Bootstrap reset inside Ladera */
+  margin-bottom: 0;
 }
 
 li {


### PR DESCRIPTION
## Description
Per recent discussions with design we are implementing a change to type specs as follows:

- Font sizes still follow the modular scale ratio of 1.125 but round to the nearest whole pixel to avoid subpixel rendering and measurement discrepancies
- Line heights lock to a 4px baseline grid and switch to use px/rem rather than a pure ratio of the font size.

Initial run through a few components that needed updates including:

- Buttons
- Labels
- Tabs

NOTE: Some components will need further adjustments in order to match measurements. They are documented under the [Type Spec Update Milestone](https://github.com/Kajabi/sage/milestone/4)