### PR TITLE
Sidenav style updates

### DIFF
--- a/lib/sage-frontend/stylesheets/system/layout/_content.scss
+++ b/lib/sage-frontend/stylesheets/system/layout/_content.scss
@@ -8,6 +8,6 @@
   flex: 1;
   overflow: auto;
   padding: sage-spacing() 0;
-  background: sage-color(grey, 100);
+  background: sage-color(grey, 200);
   scroll-behavior: smooth;
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
@@ -3,6 +3,9 @@
   type: object
 
 ================================================== */
+$-sage-nav-color-text: sage-color(charcoal, 400);
+$-sage-nav-color-focus: sage-color(primary);
+$-sage-nav-color-background: sage-color(primary, 400);
 
 .sage-nav__list {
   margin: 0;
@@ -15,8 +18,10 @@
   align-items: center;
   margin-bottom: rem(2px);
   padding: sage-spacing(2xs) sage-spacing(xs);
-  color: sage-color(charcoal, 400);
+  color: $-sage-nav-color-text;
   border-radius: sage-border(radius);
+  transition: $sage-transition;
+  transition-property: background, box-shadow;
 
   &:not(.sage-nav__link--sub) {
     @extend %t-sage-body-med;
@@ -24,11 +29,16 @@
 
   &:hover,
   &:focus {
-    background: sage-color(grey, 300);
+    background: rgba($-sage-nav-color-background, 0.03);
+  }
+
+  &:focus {
+    box-shadow: inset 0 0 0 1px $-sage-nav-color-focus;
+    outline: none;
   }
 
   &:active {
-    background: sage-color(grey, 400);
+    background: rgba($-sage-nav-color-background, 0.12);
   }
 }
 
@@ -39,5 +49,5 @@
 }
 
 .sage-nav__link--active {
-  background: sage-color(sage, 200);
+  background: rgba($-sage-nav-color-background, 0.06);
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_nav.scss
@@ -16,6 +16,7 @@ $-sage-nav-color-background: sage-color(primary, 400);
 .sage-nav__link {
   display: flex;
   align-items: center;
+  height: rem(32px);
   margin-bottom: rem(2px);
   padding: sage-spacing(2xs) sage-spacing(xs);
   color: $-sage-nav-color-text;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
@@ -3,18 +3,20 @@
   type: object
 
 ================================================== */
+$-sidebar-top-offset: $sage-assistant-height;
+$-sidebar-color-background: sage-color(grey, 200);
 
 .sage-sidebar {
   display: flex;
   flex-direction: column;
   z-index: sage-z-index(nav);
   position: fixed;
-  top: $sage-assistant-height;
+  top: $-sidebar-top-offset;
   left: 0;
   transform: translateX(-100%);
-  height: calc(100% - #{$sage-assistant-height});
+  height: calc(100% - #{$-sidebar-top-offset});
   width: sage-sidebar(xl);
-  background: sage-color(grey, 200);
+  background: $-sidebar-color-background;
   border-right: sage-border();
   box-shadow: sage-shadow();
   overscroll-behavior-y: contain;
@@ -50,7 +52,6 @@
   @include overflow-scroll();
   flex: 1;
   padding: sage-spacing();
-
 }
 
 .sage-sidebar__footer::before {
@@ -61,7 +62,7 @@
   left: 0;
   right: 0;
   height: sage-spacing(sm);
-  background: linear-gradient(to top, sage-color(grey, 200) 0%, rgba(255, 255, 255, 0) 60%);
+  background: linear-gradient(to top, #{$-sidebar-color-background} 0%, rgba(255, 255, 255, 0) 60%);
 }
 
 .sage-sidebar__footer {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sidebar.scss
@@ -4,7 +4,7 @@
 
 ================================================== */
 $-sidebar-top-offset: $sage-assistant-height;
-$-sidebar-color-background: sage-color(grey, 200);
+$-sidebar-color-background: sage-color(white);
 
 .sage-sidebar {
   display: flex;


### PR DESCRIPTION
## Description
<!-- REQUIRED: Add a short description of the work to be done -->
- Revises sidebar nav/link styles to match [updated Figma comps](https://www.figma.com/file/xlUFoRTjsFePavVT85SmLL/Sage-Design-System-v1.0?node-id=2322%3A6093)
- Sidebar and content backgrounds updated to more closely align with `kajabi-products` styling

|  In use   |  Display states  |
|--------|--------|
|<img src="https://user-images.githubusercontent.com/816579/87234982-85bf5200-c38b-11ea-9e54-22fb8d02e233.png" width="340">|![sidenav-states](https://user-images.githubusercontent.com/816579/87478454-a6cbb100-c5de-11ea-9edc-699f13ddb30a.png)|

|  before   |  after  |  app view |
|--------|--------|--------|
|![sidenav-before](https://user-images.githubusercontent.com/816579/87484166-58241400-c5ea-11ea-887d-09d91b32eeb4.png)|![sidenav-after](https://user-images.githubusercontent.com/816579/87484175-5eb28b80-c5ea-11ea-85e6-74a2bf4b4b29.png)|![app-current](https://user-images.githubusercontent.com/816579/87484259-94f00b00-c5ea-11ea-8b7f-c3753852ca03.png)|



## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- n/a
