### PR TITLE
Hotfix: Update Sage Form Section padding

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_form_section.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_form_section.scss
@@ -29,7 +29,12 @@
 }
 
 .sage-form-section__panel {
-  @extend %sage-panel;
+  position: relative;
+  padding: $sage-panel-padding;
+  margin-bottom: sage-spacing();
+  background: $sage-panel-bg-color;
+  border-radius: $sage-panel-border-radius;
+  box-shadow: $sage-panel-box-shadow;
 
   // Form Section Panels commonly wrap a <form> tag generated within rails.
   // In the event that a form tag is not present, ensure the children behave identically.


### PR DESCRIPTION
## Description

This is a regression from the Sage Panel markup update. The Sage Form Section depended on an extend of `%sage-panel`, since Sage Panel's padding has moved to its child element, `.sage-panel__body`, the Sage Form Section was left padding-less.

**This only affects Sage Super Admin**

### Screenshots

|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/87609863-b546c500-c6d1-11ea-95bf-cc05ba2f7c07.png)|![image](https://user-images.githubusercontent.com/565743/87609881-c2fc4a80-c6d1-11ea-8211-33de6f302266.png)|

