### PR TITLE
Sage Build Navbars Polish

### DIFF
--- a/app/views/examples/objects/card/_markup.html.erb
+++ b/app/views/examples/objects/card/_markup.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-card<%= is_compact ? " sage-card--compact" : "" %><%= is_spaced ? " sage-card--spaced" : "" %>">
+<div class="sage-card<%= is_compact ? " sage-card--compact" : "" %><%= is_spaced ? " sage-card--spaced" : "" %><%= is_type_center ? " sage-card--type-center" : "" %>">
   <% if has_img %>
   <%= image_pack_tag("#{img_path}", class: "sage-card__img", alt: "#{img_alt}") %>
   <% end %>

--- a/app/views/examples/objects/card/_preview.html.erb
+++ b/app/views/examples/objects/card/_preview.html.erb
@@ -1,6 +1,7 @@
 <div class="sage-row">
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ Image",
@@ -15,6 +16,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ Image",
@@ -29,6 +31,7 @@
   </div>
   <div class="sage-col--md-12">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: true,
       is_spaced: false,
       title: "Compact Card w/ Image",
@@ -41,6 +44,7 @@
       img_alt: "Alternative text for image"
     %>
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: true,
       is_spaced: false,
       title: "Compact Card w/ Image",
@@ -55,6 +59,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: false,
       is_spaced: true,
       title: "Spaced Card w/ Image",
@@ -69,6 +74,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: false,
       is_spaced: true,
       title: "Spaced Card w/ Image",
@@ -83,6 +89,7 @@
   </div>
   <div class="sage-col--md-12">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: true,
       is_spaced: true,
       title: "Spaced & Compact w/ Image",
@@ -95,6 +102,7 @@
       img_alt: "Alternative text for image"
     %>
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: true,
       is_spaced: true,
       title: "Spaced & Compact w/ Image",
@@ -109,6 +117,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ No Image",
@@ -123,6 +132,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
+      is_type_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ No Image",
@@ -135,7 +145,7 @@
       img_alt: ""
     %>
   </div>
-  <div class="sage-col--md-8">
+  <div class="sage-col--md-6">
     <div class="sage-card sage-card--spaced">
       <%= image_pack_tag("docs/card/card-placeholder-sm.png", class: "sage-card__img", alt: "") %>
       <h2 class="sage-card__title t-sage-heading-5">Card w/ Rich Text and Footer</h2>
@@ -156,5 +166,20 @@
         <a href="#" class="sage-btn sage-btn--primary">Next</a>
       </div>
     </div>
+  </div>
+  <div class="sage-col--md-6">
+    <%= render "examples/objects/card/markup",
+      is_type_center: true,
+      is_compact: false,
+      is_spaced: false,
+      title: "Centered Card Text",
+      text: "Diam in auctor sit quam laoreet imperdiet aliquam. Habitant nunc lacus semper lacus, nec a, sit enim.",
+      action_text: "Action Button",
+      action_style_primary: false,
+      action_style_tertiary: true,
+      has_img: false,
+      img_path: "",
+      img_alt: ""
+    %>
   </div>
 </div>

--- a/lib/sage-frontend/javascript/system/tabs.js
+++ b/lib/sage-frontend/javascript/system/tabs.js
@@ -18,8 +18,14 @@ Sage.tabs = (function() {
   function init(el) {
     el.addEventListener('click', tabClickHandler);
 
-    // Select the first tab on init
-    el.querySelector(`[${SELECTOR_TAB_ITEM}]`).click();
+    let elTabInitialActive = el.querySelector(`.${CLASS_TAB_ACTIVE}`);
+    if (elTabInitialActive) {
+      // If a Tab has `.sage-tabs-pane--active` on init, click it to trigger the Pane change
+      elTabInitialActive.click();
+    } else {
+      // If a tab isn't pre-selected on init, click the first one to make it active
+      el.querySelector(`[${SELECTOR_TAB_ITEM}]`).click();
+    }
   }
 
   function unbind(el) {

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -102,8 +102,9 @@ $sage-btn-secondary-text-color: sage-color(primary) !default;
 $sage-btn-tertiary-text-color: sage-color(charcoal, 300) !default;
 
 // Danger button
-$sage-btn-danger-bg-color: sage-color(red) !default;
-$sage-btn-danger-text-color: sage-color(white) !default;
+$sage-btn-danger-text-color: sage-color(red) !default;
+$sage-btn-danger-bg-active-color: sage-color(red, 200) !default;
+$sage-btn-danger-bg-hover-color: sage-color(red, 100) !default;
 
 // Menu button
 $sage-menubtn-toggle-size: rem(24px) !default;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -12,7 +12,7 @@
 @mixin button-style-base {
   @include button-style-reset();
   @extend %t-sage-body-med;
-  
+
   display: inline-flex;
   align-self: flex-start;
   align-items: baseline;
@@ -219,31 +219,27 @@
 
 .sage-btn--danger {
   color: $sage-btn-danger-text-color;
-  background: $sage-btn-danger-bg-color;
-  box-shadow: $sage-btn-shadow-base;
+  border: 0;
+  box-shadow: none;
 
   &::after {
-    z-index: sage-z-index();
-    border-color: $sage-btn-danger-bg-color;
-  }
-
-  &:hover,
-  &:focus,
-  &:active {
-    color: $sage-btn-danger-text-color;
+    border-color: $sage-btn-danger-text-color;
   }
 
   &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
-    background-color: saturate(lighten($sage-btn-danger-bg-color, 6%), 5%);
-    box-shadow: $sage-btn-shadow-hover;
+    color: $sage-btn-danger-text-color;
+    background-color: $sage-btn-danger-bg-hover-color;
   }
 
   &:focus {
-    box-shadow: $sage-btn-shadow-base;
+    color: $sage-btn-danger-text-color;
+    background: sage-color(white);
+    box-shadow: none;
   }
 
   &:active {
-    background-color: darken($sage-btn-danger-bg-color, 4%);
+    color: $sage-btn-danger-text-color;
+    background-color: $sage-btn-danger-bg-active-color;
     box-shadow: none;
   }
 
@@ -251,8 +247,8 @@
   &.disabled {
     @include button-style-disabled;
 
-    color: sage-color(red, 200);
-    background-color: sage-color(red, 100);
+    color: sage-color(primary, 200);
+    background-color: transparent;
   }
 }
 
@@ -341,4 +337,3 @@
 @include button-icon-generator(only);
 @include button-icon-generator(left);
 @include button-icon-generator(right);
-

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
@@ -72,6 +72,10 @@
   }
 }
 
+.sage-card--type-center {
+  text-align: center;
+}
+
 .sage-card--compact {
   display: flex;
   flex: none;


### PR DESCRIPTION
## Patches From PR Design Review


### TODO:
This is the final Build navbar polish based on Design review:
- [x] **Sage Tabs:** JS support for a prexisting tab to already be selected on load
- [x] **Sage Button:** New `danger` button style
- [x] **Sage Cards:** Centered text modifier
- [ ] ~**Sage Text Inputs:** Only display the Form Input blue border on `:focus` when not empty but don't display if not `:focus`~

☝️ need to chat with design to get solidify how we handle focus/active with all form inputs

-----

#### Sage form inputs context:
| -      | - |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/565743/88322335-93ab9600-ccee-11ea-8972-3b3ee4e2c70b.png)      | ![image](https://user-images.githubusercontent.com/565743/88322359-9dcd9480-ccee-11ea-98f1-1e47800bd54f.png)       |