### PR TITLE
Adjust link element external icon spacing

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_link.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_link.scss
@@ -1,7 +1,8 @@
 .sage-link--launch,
 .sage-type a[target="_blank"]:not(.sage-link--no-launch) {
   &::after {
-    margin: 0 sage-spacing(2xs);
+    margin-left: sage-spacing(2xs);
+    margin-right: sage-spacing(2xs);
     @include icon-base(launch, sm);
   }
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_link.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_link.scss
@@ -1,7 +1,7 @@
 .sage-link--launch,
 .sage-type a[target="_blank"]:not(.sage-link--no-launch) {
   &::after {
-    margin-left: sage-spacing(xs);
+    margin: 0 sage-spacing(2xs);
     @include icon-base(launch, sm);
   }
 }


### PR DESCRIPTION
## Description
When the link element is an external link the icon spacing needs adjustment on the right side for consistent spacing when the link is inline with other text. Currently the spacing is a bit tight on the right.

### Screenshots
Note: screenshots are from project currently in progress in kajabi-products

|  Before   |  After  |
|--------|--------|
| ![Screen Shot 2020-07-27 at 4 28 13 PM](https://user-images.githubusercontent.com/1175111/88601903-7cd6ad80-d026-11ea-852a-ce308c9106fc.png)|![Screen Shot 2020-07-27 at 4 58 52 PM](https://user-images.githubusercontent.com/1175111/88603700-806c3380-d02a-11ea-8612-4e4c67e84179.png)| 

## Related issues
- n/a