### PR TITLE
Fix tabs click handler bug

### DIFF
--- a/lib/sage-frontend/javascript/system/tabs.js
+++ b/lib/sage-frontend/javascript/system/tabs.js
@@ -33,7 +33,11 @@ Sage.tabs = (function() {
   }
 
   function tabClickHandler(evt) {
-    dispatchChange(this.getAttribute(SELECTOR_TABS), evt.target.getAttribute(SELECTOR_TAB_ITEM));
+    let target = evt.target.getAttribute(SELECTOR_TAB_ITEM);
+
+    if (target) {
+      dispatchChange(this.getAttribute(SELECTOR_TABS), evt.target.getAttribute(SELECTOR_TAB_ITEM));
+    }
   }
 
   function eventHandlerChange(evt) {


### PR DESCRIPTION
## Description
If the tabs parent is clicked it attempts to change the tab. Prevent those click events from taking an action.