### PR TITLE
Form Inputs Focus

### DIFF
--- a/app/views/examples/objects/card/_markup.html.erb
+++ b/app/views/examples/objects/card/_markup.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-card<%= is_compact ? " sage-card--compact" : "" %><%= is_spaced ? " sage-card--spaced" : "" %><%= is_type_center ? " sage-card--type-center" : "" %>">
+<div class="sage-card<%= is_compact ? " sage-card--compact" : "" %><%= is_spaced ? " sage-card--spaced" : "" %><%= is_center ? " sage-card--center" : "" %>">
   <% if has_img %>
   <%= image_pack_tag("#{img_path}", class: "sage-card__img", alt: "#{img_alt}") %>
   <% end %>

--- a/app/views/examples/objects/card/_preview.html.erb
+++ b/app/views/examples/objects/card/_preview.html.erb
@@ -1,7 +1,7 @@
 <div class="sage-row">
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ Image",
@@ -16,7 +16,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ Image",
@@ -31,7 +31,7 @@
   </div>
   <div class="sage-col--md-12">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: true,
       is_spaced: false,
       title: "Compact Card w/ Image",
@@ -44,7 +44,7 @@
       img_alt: "Alternative text for image"
     %>
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: true,
       is_spaced: false,
       title: "Compact Card w/ Image",
@@ -59,7 +59,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: false,
       is_spaced: true,
       title: "Spaced Card w/ Image",
@@ -74,7 +74,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: false,
       is_spaced: true,
       title: "Spaced Card w/ Image",
@@ -89,7 +89,7 @@
   </div>
   <div class="sage-col--md-12">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: true,
       is_spaced: true,
       title: "Spaced & Compact w/ Image",
@@ -102,7 +102,7 @@
       img_alt: "Alternative text for image"
     %>
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: true,
       is_spaced: true,
       title: "Spaced & Compact w/ Image",
@@ -117,7 +117,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ No Image",
@@ -132,7 +132,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
-      is_type_center: false,
+      is_center: false,
       is_compact: false,
       is_spaced: false,
       title: "Card w/ No Image",
@@ -169,7 +169,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= render "examples/objects/card/markup",
-      is_type_center: true,
+      is_center: true,
       is_compact: false,
       is_spaced: false,
       title: "Centered Card Text",

--- a/lib/sage-frontend/javascript/system/modal.js
+++ b/lib/sage-frontend/javascript/system/modal.js
@@ -42,6 +42,7 @@ Sage.modal = (function() {
   function openModal(modalId) {
     let modal = document.querySelector(`[${SELECTOR_MODAL}="${modalId}"]`);
     modal.classList.add('sage-modal--active');
+    modal.setAttribute("open", "");
   }
 
   function dispatchCloseAll() {
@@ -50,6 +51,7 @@ Sage.modal = (function() {
 
   function closeModal(el) {
     el.classList.remove('sage-modal--active');
+    el.removeAttribute("open");
   }
 
   function eventHandlerCloseAll() {

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -133,8 +133,8 @@ $sage-inputfield-box-shadow-size: 0 0 0 rem(1px) !default;
 
 // Sizing
 $sage-inputfield-height: rem(40px) !default;
-$sage-inputfield-padding: rem(12px) !default;
-$sage-inputfield-padding-x: rem(8px) !default;
+$sage-inputfield-padding: rem(16px) !default;
+$sage-inputfield-padding-x: rem(12px) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
 $sage-inputfield-padding-filled: rem(4px) !default;
 $sage-inputfield-padding-label: rem(4px) !default;

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -140,7 +140,7 @@ $sage-inputfield-padding-filled: rem(4px) !default;
 $sage-inputfield-padding-label: rem(4px) !default;
 
 // Spacing
-$sage-inputfield-spacing: sage-spacing(lg) !default;
+$sage-inputfield-spacing: sage-spacing() !default;
 
 // Colors
 $sage-inputfield-color-default: sage-color(charcoal) !default;

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -134,7 +134,7 @@ $sage-inputfield-box-shadow-size: 0 0 0 rem(1px) !default;
 // Sizing
 $sage-inputfield-height: rem(40px) !default;
 $sage-inputfield-padding: rem(16px) !default;
-$sage-inputfield-padding-x: rem(12px) !default;
+$sage-inputfield-label-offset: rem(12px) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
 $sage-inputfield-padding-filled: rem(4px) !default;
 $sage-inputfield-padding-label: rem(4px) !default;

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -133,7 +133,7 @@ $sage-inputfield-box-shadow-size: 0 0 0 rem(1px) !default;
 
 // Sizing
 $sage-inputfield-height: rem(40px) !default;
-$sage-inputfield-padding: rem(16px) !default;
+$sage-inputfield-padding: sage-spacing(sm) !default;
 $sage-inputfield-label-offset: rem(12px) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
 $sage-inputfield-padding-filled: rem(4px) !default;

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -134,10 +134,10 @@ $sage-inputfield-box-shadow-size: 0 0 0 rem(1px) !default;
 // Sizing
 $sage-inputfield-height: rem(40px) !default;
 $sage-inputfield-padding: rem(12px) !default;
-$sage-inputfield-padding-x: rem(16px) !default;
+$sage-inputfield-padding-x: rem(8px) !default;
 $sage-inputfield-padding-offset: $sage-inputfield-padding - $sage-inputfield-border-width;
 $sage-inputfield-padding-filled: rem(4px) !default;
-$sage-inputfield-padding-label: rem(3px) !default;
+$sage-inputfield-padding-label: rem(4px) !default;
 
 // Spacing
 $sage-inputfield-spacing: sage-spacing(lg) !default;

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -382,7 +382,7 @@ $sage-tooltip-shadow: sage-shadow(xl) !default;
 $sage-tooltip-padding: sage-spacing(2xs) sage-spacing(sm) !default;
 $sage-tooltip-small-padding: sage-spacing(2xs) sage-spacing(xs) !default;
 $sage-tooltip-large-padding: sage-spacing(xs) sage-spacing(xs) !default;
-$sage-tooltip-zindex: sage-z_index(modal) !default;
+$sage-tooltip-zindex: sage-z_index(overlay) !default;
 $sage-tooltip-maxwidth: rem(200px) !default;
 $sage-tooltip-large-maxwidth: rem(320px) !default;
 

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -157,6 +157,7 @@ $sage-inputfield-bg-disabled: sage-color(grey, 100) !default;
 
 // Border
 $sage-textarea-border-color: $sage-inputfield-border-color !default;
+$sage-textarea-border-color-hover: sage-color(grey, 500) !default;
 $sage-textarea-border-radius: $sage-inputfield-border-radius !default;
 $sage-textarea-border-width: $sage-inputfield-border-width !default;
 $sage-textarea-box-shadow-size: $sage-inputfield-box-shadow-size !default;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
@@ -50,7 +50,7 @@
   pointer-events: none;
   opacity: 0;
 
-  @include position(($sage-inputfield-height / 2), unset, unset, $sage-inputfield-padding-x);
+  @include position(($sage-inputfield-height / 2), unset, unset, $sage-inputfield-label-offset);
 
   @media screen and (min-width: sage-breakpoint(sm-min)) {
     white-space: normal;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
@@ -29,11 +29,11 @@
 }
 
 .sage-input__affix--prefix {
-  left: 8px;
+  left: sage-spacing(xs);
 }
 
 .sage-input__affix--suffix {
-  right: 8px;
+  right: sage-spacing(xs);
 }
 
 .sage-input__label {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
@@ -106,6 +106,7 @@
 
   &:valid:not(:placeholder-shown) {
     outline: none;
+    background: transparent; // Prevent some browsers from coloring the background on 'valid'
 
     @include placeholder {
       opacity: 0;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_input.scss
@@ -27,7 +27,7 @@
     cursor: default;
   }
 }
-  
+
 .sage-input__affix--prefix {
   left: 8px;
 }
@@ -84,9 +84,27 @@
     color: inherit;
   }
 
+  &:hover:not(:disabled) {
+    border-color: currentColor;
+  }
+
   &:focus:not(:disabled),
   &:active:not(:disabled) {
-    border-color: currentColor;
+    outline: none;
+    border-color: $sage-inputfield-color-success;
+    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-success;
+
+    @include placeholder {
+      opacity: 0;
+    }
+
+    ~ .sage-input__label {
+      @include floating-label-active();
+      color: $sage-inputfield-color-success;
+    }
+  }
+
+  &:valid:not(:placeholder-shown) {
     outline: none;
 
     @include placeholder {
@@ -95,23 +113,6 @@
 
     ~ .sage-input__label {
       @include floating-label-active();
-    }
-  }
-
-  /* Separated so IE/Edge does not ignore focus styles. Note that Edge will not support these states */
-  &:valid:not(:placeholder-shown),
-  &:required:not(:placeholder-shown) {
-    ~ .sage-input__label {
-      @include floating-label-active();
-    }
-  }
-
-  &:valid:not(:placeholder-shown) {
-    border-color: $sage-inputfield-color-success;
-    box-shadow: $sage-inputfield-box-shadow-size $sage-inputfield-color-success;
-
-    ~ .sage-input__label {
-      color: $sage-inputfield-color-success;
     }
   }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_select.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_select.scss
@@ -6,7 +6,7 @@
 
 $-sage-selectfield-height: $sage-inputfield-height;
 $-sage-selectfield-bg-label: $sage-inputfield-bg-label;
-$-sage-selectfield-padding-x: $sage-inputfield-padding-x;
+$-sage-selectfield-padding-x: $sage-inputfield-padding;
 $-sage-selectfield-filled-top-padding: rem(6);
 $-sage-selectfield-padding-label: $sage-inputfield-padding-label;
 $-sage-selectfield-bottom-spacing: $sage-inputfield-spacing;
@@ -14,7 +14,8 @@ $-sage-selectfield-bottom-spacing: $sage-inputfield-spacing;
 $-sage-selectfield-border-radius: $sage-inputfield-border-radius;
 $-sage-selectfield-border-width: $sage-inputfield-border-width;
 $-sage-selectfield-border-color: $sage-inputfield-border-color;
-$-sage-selectfield-border-color-hover: sage-color(grey, 400);
+$-sage-selectfield-border-color-hover: sage-color(charcoal);
+$-sage-selectfield-border-color-selected: sage-color(grey, 400);
 $-sage-selectfield-border-box-shadow-size: $sage-inputfield-box-shadow-size;
 
 $-sage-selectfield-color-default: $sage-inputfield-color-default;
@@ -37,17 +38,21 @@ $-sage-selectfield-color-error: $sage-inputfield-color-error;
   color: $-sage-selectfield-color-default;
   white-space: nowrap;
   pointer-events: none;
+  padding: 0 $-sage-selectfield-padding-label;
 
-  @include position(($-sage-selectfield-height / 2), unset, unset, $-sage-selectfield-padding-x);
+  @include position(($-sage-selectfield-height / 2), unset, unset, ($-sage-selectfield-padding-x - $-sage-selectfield-padding-label));
 
   .sage-select--value-selected & {
     @extend %t-sage-body-xsmall-semi;
 
     transform: translateY(calc(#{-$-sage-selectfield-height} + 50%));
-    padding: 0 $-sage-selectfield-padding-label;
-    color: $-sage-selectfield-color-success;
     background-color: $-sage-selectfield-bg-label;
     transition: transform 0.15s ease-in-out, color 0.15s ease-out;
+  }
+
+  .sage-select--value-selected:not(.sage-select--error) :focus + &,
+  .sage-select--value-selected:not(.sage-select--error) :active + & {
+    color: $-sage-selectfield-color-success;
   }
 
   .sage-select--error & {
@@ -76,6 +81,7 @@ $-sage-selectfield-color-error: $sage-inputfield-color-error;
   background: transparent;
   outline: none;
   cursor: pointer;
+  transition: border $sage-transition;
 
   // Firefox allows setting the color of <options> within a <select>.
   // This prevents color from being inherited from <select>.
@@ -85,8 +91,7 @@ $-sage-selectfield-color-error: $sage-inputfield-color-error;
 
   .sage-select--value-selected & {
     color: $-sage-selectfield-color-default;
-    border-color: $-sage-selectfield-color-success;
-    box-shadow: $-sage-selectfield-border-box-shadow-size $-sage-selectfield-color-success;
+    border-color: $-sage-selectfield-border-color-selected;
   }
 
   .sage-select--error & {
@@ -94,17 +99,30 @@ $-sage-selectfield-color-error: $sage-inputfield-color-error;
     box-shadow: $-sage-selectfield-border-box-shadow-size $-sage-selectfield-color-error;
   }
 
-  &:focus,
-  &:active,
   &:hover {
-    border-color: $-sage-selectfield-border-color-hover;
+    border-color: $-sage-selectfield-border-color-selected;
 
     ~ .sage-select__arrow::before {
       color: $-sage-selectfield-color-success;
     }
 
-    .sage-select--error & ~ .sage-select__arrow::before {
-      color: $-sage-selectfield-color-error;
+    .sage-select--error & {
+      border-color: $-sage-selectfield-color-error;
+    }
+  }
+
+  &:focus,
+  &:active {
+    border-color: $-sage-selectfield-color-success;
+    box-shadow: $-sage-selectfield-border-box-shadow-size $-sage-selectfield-color-success;
+
+    ~ .sage-select__arrow::before {
+      color: $-sage-selectfield-color-success;
+    }
+
+    .sage-select--error & {
+      border-color: $-sage-selectfield-color-error;
+      box-shadow: $-sage-selectfield-border-box-shadow-size $-sage-selectfield-color-error;
     }
   }
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_textarea.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_textarea.scss
@@ -37,7 +37,7 @@
 
 .sage-textarea__field {
   @mixin floating-label-textarea-active {
-    transform: translateY(-$sage-textarea-padding);
+    transform: translateY($sage-textarea-label-padding - $sage-textarea-padding);
     transition: opacity 0.1s ease-in, transform 0.15s ease-in-out, color 0.15s ease-out;
     opacity: 1;
   }
@@ -57,9 +57,15 @@
     color: inherit;
   }
 
+  &:hover:not(:active):not(:focus),
+  &:active:not(:disabled) {
+    border-color: sage-color(grey, 400);
+  }
+
   &:focus:not(:disabled),
   &:active:not(:disabled) {
-    border-color: currentColor;
+    border-color: $sage-textarea-color-success;
+    box-shadow: $sage-textarea-box-shadow-size $sage-textarea-color-success;
     outline: none;
 
     @include placeholder {
@@ -68,6 +74,7 @@
 
     ~ .sage-textarea__label {
       @include floating-label-textarea-active();
+      color: $sage-textarea-color-success;
     }
   }
 
@@ -79,13 +86,8 @@
     }
   }
 
-  &:valid:not(:placeholder-shown) {
-    border-color: $sage-textarea-color-success;
-    box-shadow: $sage-textarea-box-shadow-size $sage-textarea-color-success;
-
-    ~ .sage-textarea__label {
-      color: $sage-textarea-color-success;
-    }
+  &:valid:not(:placeholder-shown):not(:focus):not(:active) {
+    border-color: currentColor;
   }
 
   // TODO: add support for Simpleform classes

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_modal.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_modal.scss
@@ -77,7 +77,7 @@ $-modal-padding-y: sage-spacing(md);
 }
 
 .sage-modal__header {
-  margin: sage-spacing(lg) $-modal-padding-x $-modal-padding-y;
+  margin: $-modal-padding-y $-modal-padding-x;
 
   > :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Description
- Input Focus Styles: Match to figma
- Select Input Focus Styles: Match to Form Input and Figma
- Modal Padding: Match to figma
- Modal Tabs: Match to figma

### Minor
- Modal: Add  attr `open` to `<dialog>` (ref: https://github.com/Kajabi/kajabi-products/pull/15110#discussion_r463291582)
- Adjust tooltip z-index
- Update Sage Card docs preview with `center` modifier

## Screenshots
![image](https://user-images.githubusercontent.com/565743/89053602-7b0e3200-d325-11ea-9a60-cf8cc9b4d49a.png)