### PR TITLE
Documentation typo fixes

### DIFF
--- a/app/views/pages/color.html.erb
+++ b/app/views/pages/color.html.erb
@@ -48,7 +48,7 @@
     <h2 id="how">How we use color</h2>
   </div>
   <div class="sage-panel__body sage-type">
-    <p>You will notice <strong>pure black is not used at all as a text color</strong>. Instead, we rely on 400 for our darkest text color value. Our default text color is sage-color(charcoal, 400). To achive more depth use 300 to 400 shades for text on top of lighter background colors using 100 to 200 for their fill. You can also use 100 to 200 as the text color on darker backgrounds using from 300 to 400 for their fill. Pure white is used as a text color when the lightest shade (100) of a color will not pass color contrast tests. At the moment, this only occurs on the 300 shades of purple, primary, and red.</p>
+    <p>You will notice <strong>pure black is not used at all as a text color</strong>. Instead, we rely on 400 for our darkest text color value. Our default text color is sage-color(charcoal, 400). To achieve more depth use 300 to 400 shades for text on top of lighter background colors using 100 to 200 for their fill. You can also use 100 to 200 as the text color on darker backgrounds using from 300 to 400 for their fill. Pure white is used as a text color when the lightest shade (100) of a color will not pass color contrast tests. At the moment, this only occurs on the 300 shades of purple, primary, and red.</p>
     <h2 id="primary">Primary</h2>
     <p>These are the splashes of color that appear the most in Kajabi’s UI, and are the ones that determine the overall "look" of the app. Use these for things like primary actions, links, navigation items, icons, accent borders, or text we want to emphasize.</p>
     <%= render "color_values", color: "primary"%>

--- a/app/views/pages/typography.html.erb
+++ b/app/views/pages/typography.html.erb
@@ -27,7 +27,7 @@
     for a given context.
   </p>
   <p>
-    Setting styles individual styles manually should be avoided, but where needed, should be sure to use the appropriate
+    Setting individual styles manually should be avoided, but where needed, should be sure to use the appropriate
     <%= link_to "design tokens", pages_style_path(:token) %>.
     In the end, we prefer adding new entries to the type spec over including one-off styling.
   </p>


### PR DESCRIPTION
## Description
This PR addresses a couple of typos found on the following pages:

https://sage-design-system.kajabi.com/pages/style/color
https://sage-design-system.kajabi.com/pages/style/typography

### Screenshots

|  before  |  after  |
|--------|--------|
|<img width="1904" alt="Colors - BEFORE" src="https://user-images.githubusercontent.com/7331038/89314879-3695d580-d648-11ea-8b19-a226d4730d70.png">|<img width="1904" alt="Colors - AFTER" src="https://user-images.githubusercontent.com/7331038/89314872-33024e80-d648-11ea-8bd3-b7b12f29bbc3.png">|
|<img width="1904" alt="Typography - BEFORE" src="https://user-images.githubusercontent.com/7331038/89314936-42819780-d648-11ea-8e0a-c2a129677868.png">|<img width="1904" alt="Typography - AFTER" src="https://user-images.githubusercontent.com/7331038/89314920-3f86a700-d648-11ea-8642-0fcc5cc0f4d2.png">|