### PR TITLE
Add modal container token to docs and update spacing

### DIFF
--- a/app/helpers/tokens_helper.rb
+++ b/app/helpers/tokens_helper.rb
@@ -17,6 +17,7 @@ module TokensHelper
       {
         category: "container",
         tokens: [
+          { name: "modal" },
           { name: "sm" },
           { name: "md" },
           { name: "fluid" },

--- a/lib/sage-frontend/stylesheets/docs/_token.scss
+++ b/lib/sage-frontend/stylesheets/docs/_token.scss
@@ -15,12 +15,12 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  padding: sage-spacing(xs) sage-spacing();
+  padding: sage-spacing(xs) sage-spacing(sm);
   font-size: sage-font-size(sm);
   border-bottom: sage-border();
 
   &::after {
-    max-width: calc(100% / 3);
+    max-width: max-content;
     font-family: $sage-body-font-monospace;
   }
 


### PR DESCRIPTION
## Description
- Add modal container size token to docs
- Fix bothersome spacing when displaying long tokens

![image](https://user-images.githubusercontent.com/565743/89545738-bc915800-d7d1-11ea-8000-452e4af737b1.png)
