### PR TITLE
Downgrade spring to match Product's version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the
   # background. Read more: https://github.com/rails/spring
-  gem 'spring'
+  # Use Spring ~1.3.3, Product's Spring version, to prevent needing to frequently restart Spring
+  gem "spring", "~> 1.3.3"
 end
 
 gem "lockup", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    spring (2.1.0)
+    spring (1.3.6)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -154,7 +154,7 @@ DEPENDENCIES
   rails (= 4.2.11.1)
   sage!
   sass-rails (~> 5.0)
-  spring
+  spring (~> 1.3.3)
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   webpacker (~> 4.x)


### PR DESCRIPTION
## Description
```
/Users/andrewmcintee/.gem/ruby/2.4.9/gems/bundler-1.17.3/lib/bundler/runtime.rb:319:in `check_for_activated_spec!': You have already activated spring 2.1.0, but your Gemfile requires spring 1.3.3. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```
Happens pretty frequently while in Kajabi-Products. Spring gets stuck running and has to been manually quit/uninstalled so that Product's Spring can run. `bundle exec` doesn't help as the error message suggests.
