### PR TITLE
Revise sage type implementation

### DIFF
--- a/app/views/examples/elements/button/_preview.html.erb
+++ b/app/views/examples/elements/button/_preview.html.erb
@@ -52,7 +52,7 @@
   text: "Button (icon-right)"
 %>
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Primary (disabled)</h3>
 
 <!-- Primary button (disabled) -->
@@ -107,7 +107,7 @@
   text: "Link (icon-right)"
 %>
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Secondary</h3>
 
 <!-- Secondary button -->
@@ -162,7 +162,7 @@
   text: "Link (icon-right)"
 %>
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Secondary (disabled)</h3>
 
 <!-- Secondary button (disabled) -->
@@ -217,7 +217,7 @@
   text: "Button (icon-right)"
 %>
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Tertiary</h3>
 
 <!-- Tertiary button -->
@@ -272,7 +272,7 @@
   text: "Button (icon-right)"
 %>
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Tertiary (disabled)</h3>
 
 <!-- Tertiary button disabled -->
@@ -327,7 +327,7 @@
   text: "Link (icon-right)"
 %>
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Danger</h3>
 
 <!-- Danger button -->
@@ -383,7 +383,7 @@
 %>
 
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Danger (disabled)</h3>
 
 <!-- Danger button (disabled) -->
@@ -426,7 +426,7 @@
 %>
 
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Flex Align End</h3>
 
 <!-- Primary button (icon-right) -->
@@ -456,7 +456,7 @@
 %>
 
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Small</h3>
 
 <!-- Primary small -->
@@ -499,7 +499,7 @@
 %>
 
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Tiny Button (Limited use)</h3>
 
 <button class="sage-btn sage-btn--tertiary sage-btn--icon-left-tag sage-btn--tiny">
@@ -510,7 +510,7 @@
 </button>
 
 
-<br><br><br>
+
 <h3 class="t-sage-heading-6">Icon Button</h3>
 
 <strong class="t-sage-body-small-med">Regular</strong>
@@ -566,7 +566,7 @@
   text: "Name Of Action"
 %>
 
-<br><br>
+
 <strong class="t-sage-body-small-med">Small</strong>
 <!-- Primary button (icon-right) -->
 <%= render "examples/elements/button/markup",
@@ -620,7 +620,7 @@
   text: "Name Of Action"
 %>
 
-<br><br>
+
 <strong class="t-sage-body-small-med">Tiny</strong>
 <!-- Primary button (icon-right) -->
 <%= render "examples/elements/button/markup",

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -1,3 +1,4 @@
+<h5>Default</h5>
 <%= render "examples/elements/label/markup",
 type: "draft",
 is_subtle: false
@@ -14,8 +15,8 @@ is_subtle: false
 type: "danger",
 is_subtle: false
 %>
-<br/>
-<br/>
+
+<h5>Subtle</h5>
 <%= render "examples/elements/label/markup",
 type: "draft",
 is_subtle: true

--- a/app/views/examples/elements/tooltip/_preview.html.erb
+++ b/app/views/examples/elements/tooltip/_preview.html.erb
@@ -1,4 +1,4 @@
-<!-- Dark tooltips -->
+<h5>Dark Tooltips</h5>
 <%= render "examples/elements/tooltip/markup",
 position: "top",
 text: "Nascetur ridiculus mus",
@@ -24,9 +24,7 @@ theme: "",
 size: ""
 %>
 
-<br/><br/>
-
-<!-- Light tooltips -->
+<h5>Light Tooltips</h5>
 <%= render "examples/elements/tooltip/markup",
 position: "top",
 text: "Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.",

--- a/lib/sage-frontend/stylesheets/docs/_token.scss
+++ b/lib/sage-frontend/stylesheets/docs/_token.scss
@@ -21,7 +21,7 @@
 
   &::after {
     max-width: max-content;
-    font-family: $sage-body-font-monospace;
+    font-family: $docs-font-monospace;
   }
 
   &-border::after {

--- a/lib/sage-frontend/stylesheets/docs/_variables.scss
+++ b/lib/sage-frontend/stylesheets/docs/_variables.scss
@@ -12,6 +12,7 @@
 //   --something: something;
 // }
 
+$docs-font-monospace: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace !default;
 
 // ==================================================
 // STATUS KEY

--- a/lib/sage-frontend/stylesheets/system/core/_fonts.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_fonts.scss
@@ -3,12 +3,15 @@
 
 ================================================== */
 
+$-body-font-path: "../../fonts/inter" !default; // pathname of font directory
+$-body-font-version: 3.12 !default;
+
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: local("Inter-Thin"), url("#{$sage-body-font-path}/Inter-Thin.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-Thin.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-Thin"), url("#{$-body-font-path}/Inter-Thin.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-Thin.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -16,7 +19,7 @@
   font-style: italic;
   font-weight: 100;
   font-display: swap;
-  src: local("Inter-ThinItalic"), url("#{$sage-body-font-path}/Inter-ThinItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-ThinItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-ThinItalic"), url("#{$-body-font-path}/Inter-ThinItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-ThinItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -24,7 +27,7 @@
   font-style: normal;
   font-weight: 200;
   font-display: swap;
-  src: local("Inter-ExtraLight"), url("#{$sage-body-font-path}/Inter-ExtraLight.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-ExtraLight.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-ExtraLight"), url("#{$-body-font-path}/Inter-ExtraLight.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-ExtraLight.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -32,7 +35,7 @@
   font-style: italic;
   font-weight: 200;
   font-display: swap;
-  src: local("Inter-ExtraLightItalic"), url("#{$sage-body-font-path}/Inter-ExtraLightItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-ExtraLightItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-ExtraLightItalic"), url("#{$-body-font-path}/Inter-ExtraLightItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-ExtraLightItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -40,7 +43,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: local("Inter-Light"), url("#{$sage-body-font-path}/Inter-Light.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-Light.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-Light"), url("#{$-body-font-path}/Inter-Light.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-Light.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -48,7 +51,7 @@
   font-style: italic;
   font-weight: 300;
   font-display: swap;
-  src: local("Inter-LightItalic"), url("#{$sage-body-font-path}/Inter-LightItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-LightItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-LightItalic"), url("#{$-body-font-path}/Inter-LightItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-LightItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -56,7 +59,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: local("Inter-Regular"), url("#{$sage-body-font-path}/Inter-Regular.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-Regular.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-Regular"), url("#{$-body-font-path}/Inter-Regular.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-Regular.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -64,7 +67,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: local("Inter-Italic"), url("#{$sage-body-font-path}/Inter-Italic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-Italic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-Italic"), url("#{$-body-font-path}/Inter-Italic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-Italic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -72,7 +75,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: local("Inter-Medium"), url("#{$sage-body-font-path}/Inter-Medium.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-Medium.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-Medium"), url("#{$-body-font-path}/Inter-Medium.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-Medium.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -80,7 +83,7 @@
   font-style: italic;
   font-weight: 500;
   font-display: swap;
-  src: local("Inter-MediumItalic"), url("#{$sage-body-font-path}/Inter-MediumItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-MediumItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-MediumItalic"), url("#{$-body-font-path}/Inter-MediumItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-MediumItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -88,7 +91,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: local("Inter-SemiBold"), url("#{$sage-body-font-path}/Inter-SemiBold.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-SemiBold.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-SemiBold"), url("#{$-body-font-path}/Inter-SemiBold.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-SemiBold.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -96,7 +99,7 @@
   font-style: italic;
   font-weight: 600;
   font-display: swap;
-  src: local("Inter-SemiBoldItalic"), url("#{$sage-body-font-path}/Inter-SemiBoldItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-SemiBoldItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-SemiBoldItalic"), url("#{$-body-font-path}/Inter-SemiBoldItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-SemiBoldItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -104,7 +107,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: local("Inter-Bold"), url("#{$sage-body-font-path}/Inter-Bold.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-Bold.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-Bold"), url("#{$-body-font-path}/Inter-Bold.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-Bold.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -112,7 +115,7 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: local("Inter-BoldItalic"), url("#{$sage-body-font-path}/Inter-BoldItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-BoldItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-BoldItalic"), url("#{$-body-font-path}/Inter-BoldItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-BoldItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -120,7 +123,7 @@
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src: local("Inter-ExtraBold"), url("#{$sage-body-font-path}/Inter-ExtraBold.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-ExtraBold.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-ExtraBold"), url("#{$-body-font-path}/Inter-ExtraBold.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-ExtraBold.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -128,7 +131,7 @@
   font-style: italic;
   font-weight: 800;
   font-display: swap;
-  src: local("Inter-ExtraBoldItalic"), url("#{$sage-body-font-path}/Inter-ExtraBoldItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-ExtraBoldItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-ExtraBoldItalic"), url("#{$-body-font-path}/Inter-ExtraBoldItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-ExtraBoldItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -136,7 +139,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: local("Inter-Black"), url("#{$sage-body-font-path}/Inter-Black.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-Black.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-Black"), url("#{$-body-font-path}/Inter-Black.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-Black.woff?v=#{$-body-font-version}") format("woff");
 }
 
 @font-face {
@@ -144,7 +147,7 @@
   font-style: italic;
   font-weight: 900;
   font-display: swap;
-  src: local("Inter-BlackItalic"), url("#{$sage-body-font-path}/Inter-BlackItalic.woff2?v=#{$sage-body-font-version}") format("woff2"), url("#{$sage-body-font-path}/Inter-BlackItalic.woff?v=#{$sage-body-font-version}") format("woff");
+  src: local("Inter-BlackItalic"), url("#{$-body-font-path}/Inter-BlackItalic.woff2?v=#{$-body-font-version}") format("woff2"), url("#{$-body-font-path}/Inter-BlackItalic.woff?v=#{$-body-font-version}") format("woff");
 }
 
 /* ==================================================
@@ -163,7 +166,7 @@ Usage:
   font-style: normal;
   font-named-instance: "Regular";
   font-display: swap;
-  src: url("#{$sage-body-font-path}/Inter-roman.var.woff2?v=#{$sage-body-font-version}") format("woff2");
+  src: url("#{$-body-font-path}/Inter-roman.var.woff2?v=#{$-body-font-version}") format("woff2");
 }
 
 @font-face {
@@ -172,7 +175,7 @@ Usage:
   font-style: italic;
   font-named-instance: "Italic";
   font-display: swap;
-  src: url("#{$sage-body-font-path}/Inter-italic.var.woff2?v=#{$sage-body-font-version}") format("woff2");
+  src: url("#{$-body-font-path}/Inter-italic.var.woff2?v=#{$-body-font-version}") format("woff2");
 }
 
 /* Legacy naming compatibility */
@@ -182,7 +185,7 @@ Usage:
   font-style: normal;
   font-named-instance: "Regular";
   font-display: swap;
-  src: url("#{$sage-body-font-path}/Inter-roman.var.woff2?v=#{$sage-body-font-version}") format("woff2");
+  src: url("#{$-body-font-path}/Inter-roman.var.woff2?v=#{$-body-font-version}") format("woff2");
 }
 
 @font-face {
@@ -191,7 +194,7 @@ Usage:
   font-style: italic;
   font-named-instance: "Italic";
   font-display: swap;
-  src: url("#{$sage-body-font-path}/Inter-italic.var.woff2?v=#{$sage-body-font-version}") format("woff2");
+  src: url("#{$-body-font-path}/Inter-italic.var.woff2?v=#{$-body-font-version}") format("woff2");
 }
 
 
@@ -214,5 +217,5 @@ explicitly, e.g.
   font-weight: 100 900;
   font-style: oblique 0deg 10deg;
   font-display: swap;
-  src: url("#{$sage-body-font-path}/Inter.var.woff2?v=#{$sage-body-font-version}") format("woff2");
+  src: url("#{$-body-font-path}/Inter.var.woff2?v=#{$-body-font-version}") format("woff2");
 }

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -160,7 +160,7 @@ hr {
   border-top: sage-border();
 }
 
-// Generat text color modifiers
+// Generate text color modifiers
 @each $color-name, $color-slider in $sage-colors {
   // Default color values
   $color-value: sage-color($color-name);

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -3,122 +3,9 @@
 
 ================================================== */
 
-// ==================================================
-// TYPE SPECS
-// ==================================================
-
-$t-base-spec: (
-  weight: $sage-body-font-weight,
-  size: $sage-body-font-size,
-  leading: $sage-body-font-line-height,
-  kerning: $sage-body-letter-spacing
-);
-
-$t-body-small-spec: map-merge($t-base-spec, (
-  size: sage-font-size(sm),
-  leading: sage-line-height(sm),
-));
-
-$t-body-xsmall-spec: map-merge($t-base-spec, (
-  size: sage-font-size(xs),
-  leading: sage-line-height(xs),
-));
-
-// The following map is used to generate both `.t-` classeses for each
-// entry as well as `%t-` of the same for limited use with `@extend`
-
-$type-specs: (
-  // Headings
-  "heading-1": (
-    weight: sage-font-weight(bold),
-    size: sage-font-size(4xl),
-    leading: sage-line-height(xl),
-    kerning: sage-letter-spacing(sm),
-  ),
-  "heading-2": (
-    weight: sage-font-weight(bold),
-    size: sage-font-size(3xl),
-    leading: sage-line-height(lg),
-    kerning: sage-letter-spacing(sm),
-  ),
-  "heading-3": (
-    weight: sage-font-weight(bold),
-    size: sage-font-size(2xl),
-    leading: sage-line-height(lg),
-    kerning: sage-letter-spacing(sm),
-  ),
-  "heading-4": (
-    weight: sage-font-weight(semibold),
-    size: sage-font-size(xl),
-    leading: sage-line-height(md),
-    kerning: sage-letter-spacing(sm)
-  ),
-  "heading-5": (
-    weight: sage-font-weight(semibold),
-    size: sage-font-size(lg),
-    leading: sage-line-height(sm),
-    kerning: sage-letter-spacing(sm)
-  ),
-  "heading-6": (
-    weight: sage-font-weight(semibold),
-    size: $sage-body-font-size,
-    leading: sage-line-height(xs),
-    kerning: sage-letter-spacing(sm)
-  ),
-
-  // Body
-  "body": $t-base-spec,
-  "body-med": map-merge($t-base-spec, (
-    weight: sage-font-weight(medium)
-  )),
-  "body-semi": map-merge($t-base-spec, (
-    weight: sage-font-weight(semibold)
-  )),
-  "body-bold": map-merge($t-base-spec, (
-    weight: sage-font-weight(bold)
-  )),
-
-  // Body Small
-  "body-small": $t-body-small-spec,
-  "body-small-med": map-merge($t-body-small-spec, (
-    weight: sage-font-weight(medium)
-  )),
-  "body-small-semi": map-merge($t-body-small-spec, (
-    weight: sage-font-weight(semibold)
-  )),
-  "body-small-bold": map-merge($t-body-small-spec, (
-    weight: sage-font-weight(bold)
-  )),
-
-  // Body XSmall
-  "body-xsmall": $t-body-xsmall-spec,
-  "body-xsmall-med": map-merge($t-body-xsmall-spec, (
-    weight: sage-font-weight(medium)
-  )),
-  "body-xsmall-semi": map-merge($t-body-xsmall-spec, (
-    weight: sage-font-weight(semibold)
-  )),
-  "body-xsmall-bold": map-merge($t-body-xsmall-spec, (
-    weight: sage-font-weight(bold)
-  )),
-
-  // Additional custom specs
-);
-
-// Automate setting up base specs to extend in context.
-@each $spec-name, $spec in $type-specs {
-  %t-sage-#{$spec-name} {
-    font-weight: map-get($spec, weight);
-    font-size: map-get($spec, size);
-    letter-spacing: map-get($spec, kerning);
-    line-height: map-get($spec, leading);
-  }
-
-  .t-sage-#{$spec-name} {
-    @extend %t-sage-#{$spec-name};
-  }
-}
-
+// Font definitions
+$-body-font-stack: "Inter", -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", sans-serif !default;
+$-body-margin-bottom: sage-spacing(sm) !default;
 
 // ==================================================
 // MIXINS
@@ -138,16 +25,23 @@ $type-specs: (
 // STYLES
 // ==================================================
 
+// Automate setting up classes that extend the specs
+@each $spec-name, $spec in $type-specs {
+  .t-sage-#{$spec-name} {
+    @extend %t-sage-#{$spec-name};
+  }
+}
+
 body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-size-adjust: 100%;
   color: $sage-body-font-color;
-  font-family: $sage-body-font-stack;
+  font-family: $-body-font-stack;
 
   @supports (font-variation-settings: normal) {
-    font-family: "Inter var", $sage-body-font-stack;
+    font-family: "Inter var", $-body-font-stack;
   }
 }
 
@@ -160,7 +54,7 @@ body {
   > ol:not([class]),
   > dl:not([class]),
   > [class*="t-sage-body"] {
-    @include t-block-spacing($sage-body-margin-bottom);
+    @include t-block-spacing($-body-margin-bottom);
   }
 
   // Heading-like elements get spacing below as well
@@ -234,7 +128,8 @@ body {
     }
   }
 
-  li:not([class]),
+  > ul li:not([class]),
+  > ol li:not([class]),
   > p:not([class]) {
     @extend %t-sage-body;
   }
@@ -265,6 +160,7 @@ hr {
   border-top: sage-border();
 }
 
+// Generat text color modifiers
 @each $color-name, $color-slider in $sage-colors {
   // Default color values
   $color-value: sage-color($color-name);
@@ -282,15 +178,7 @@ hr {
   }
 
   // Specific color values
-  $-color-levels: (
-    100,
-    200,
-    300,
-    400,
-    500
-  );
-
-  @each $-level in $-color-levels {
+  @each $-level, $-value in $color-slider {
     .t-sage--color-#{$color-name}-#{$-level} {
       color: sage-color($color-name, $-level);
     }

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -26,7 +26,7 @@ $-body-margin-bottom: sage-spacing(sm) !default;
 // ==================================================
 
 // Automate setting up classes that extend the specs
-@each $spec-name, $spec in $type-specs {
+@each $spec-name, $spec in $sage-type-specs {
   .t-sage-#{$spec-name} {
     @extend %t-sage-#{$spec-name};
   }

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -155,33 +155,33 @@ body {
 .sage-type {
 
   // Body-like elements get spacing below
-  p:not([class]),
-  ul:not([class]),
-  ol:not([class]),
-  dl:not([class]),
-  [class*="t-sage-body"] {
+  > p:not([class]),
+  > ul:not([class]),
+  > ol:not([class]),
+  > dl:not([class]),
+  > [class*="t-sage-body"] {
     @include t-block-spacing($sage-body-margin-bottom);
   }
 
   // Heading-like elements get spacing below as well
-  h1:not([class]),
-  h2:not([class]),
-  h3:not([class]),
-  h4:not([class]),
-  h5:not([class]),
-  h6:not([class]),
-  [class*="t-sage-heading-"] {
+  > h1:not([class]),
+  > h2:not([class]),
+  > h3:not([class]),
+  > h4:not([class]),
+  > h5:not([class]),
+  > h6:not([class]),
+  > [class*="t-sage-heading-"] {
     color: $sage-heading-font-color;
 
     @include t-block-spacing($sage-heading-margin-bottom);
   }
 
   // Elements with no classes extend related type specs
-  h1:not([class]) {
+  > h1:not([class]) {
     @extend %t-sage-heading-1;
   }
 
-  h2:not([class]) {
+  > h2:not([class]) {
     @extend %t-sage-heading-2;
 
     &:not(:first-child) {
@@ -189,11 +189,11 @@ body {
     }
   }
 
-  .t-sage-heading-2:not(:first-child) {
+  > .t-sage-heading-2:not(:first-child) {
     margin-top: sage-spacing(lg);
   }
 
-  h3:not([class]) {
+  > h3:not([class]) {
     @extend %t-sage-heading-3;
 
     &:not(:first-child) {
@@ -201,7 +201,7 @@ body {
     }
   }
 
-  h4:not([class]) {
+  > h4:not([class]) {
     @extend %t-sage-heading-4;
 
     &:not(:first-child) {
@@ -209,7 +209,7 @@ body {
     }
   }
 
-  h5:not([class]) {
+  > h5:not([class]) {
     @extend %t-sage-heading-5;
 
     &:not(:first-child) {
@@ -217,7 +217,7 @@ body {
     }
   }
 
-  h6:not([class]) {
+  > h6:not([class]) {
     @extend %t-sage-heading-6;
 
     &:not(:first-child) {
@@ -225,27 +225,27 @@ body {
     }
   }
 
-  .t-sage-heading-3,
-  .t-sage-heading-4,
-  .t-sage-heading-5,
-  .t-sage-heading-6 {
+  > .t-sage-heading-3,
+  > .t-sage-heading-4,
+  > .t-sage-heading-5,
+  > .t-sage-heading-6 {
     &:not(:first-child) {
       margin-top: sage-spacing();
     }
   }
 
   li:not([class]),
-  p:not([class]) {
+  > p:not([class]) {
     @extend %t-sage-body;
   }
 
   // Hyperlinks get some default coloring applied
-  a:not([class]),
-  a[class*="sage-link"] {
+  > a:not([class]),
+  > a[class*="sage-link"] {
     color: sage-color(primary);
   }
 
-  table:not(:last-child) {
+  > table:not(:last-child) {
     margin-top: sage-spacing();
     margin-bottom: sage-spacing();
   }
@@ -266,6 +266,7 @@ hr {
 }
 
 @each $color-name, $color-slider in $sage-colors {
+  // Default color values
   $color-value: sage-color($color-name);
 
   @if ($color-name == charcoal) {
@@ -278,5 +279,20 @@ hr {
 
   .t-sage--color-#{$color-name} {
     color: $color-value;
+  }
+
+  // Specific color values
+  $-color-levels: (
+    100,
+    200,
+    300,
+    400,
+    500
+  );
+
+  @each $-level in $-color-levels {
+    .t-sage--color-#{$color-name}-#{$-level} {
+      color: sage-color($color-name, $-level);
+    }
   }
 }

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -27,7 +27,6 @@ $sage-transition: 0.1s ease-in-out !default;
 $sage-body-font-size: rem(16px) !default;
 $sage-body-font-color: sage-color(charcoal, 400) !default;
 $sage-body-letter-spacing: sage-letter-spacing(xs) !default;
-// -----======|||0|||======------ //
 
 // Headings
 $sage-heading-font-color: sage-color(charcoal, 500) !default;

--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -22,20 +22,12 @@ $sage-transition: 0.1s ease-in-out !default;
 // TYPOGRAPHY
 // ==================================================
 
-// Font definitions
-$sage-body-font-name: "Inter" !default;
-$sage-body-font-stack: $sage-body-font-name, -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", sans-serif !default;
-$sage-body-font-path: "../../fonts/inter" !default;  // pathname of font directory
-$sage-body-font-version: 3.12 !default;
-$sage-body-font-monospace: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace !default;
 
 // Text
-$sage-body-font-size: 1rem !default; // 16px
-$sage-body-font-weight: sage-font-weight() !default;
-$sage-body-font-line-height: sage-line-height(md) !default;
+$sage-body-font-size: rem(16px) !default;
 $sage-body-font-color: sage-color(charcoal, 400) !default;
 $sage-body-letter-spacing: sage-letter-spacing(xs) !default;
-$sage-body-margin-bottom: sage-spacing(sm) !default;
+// -----======|||0|||======------ //
 
 // Headings
 $sage-heading-font-color: sage-color(charcoal, 500) !default;

--- a/lib/sage-frontend/stylesheets/system/index.scss
+++ b/lib/sage-frontend/stylesheets/system/index.scss
@@ -17,6 +17,7 @@
 @import "tokens/shadow";
 @import "tokens/sidebar";
 @import "tokens/spacing";
+@import "tokens/type_specs";
 @import "tokens/z_index";
 
 // Mixins

--- a/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
@@ -110,6 +110,8 @@ $sage-type-specs: (
 ================================================== */
 
 @mixin sage-type-spec($spec-name) {
+  $spec-map: map-get($sage-type-specs, $spec-name);
+
   font-weight: map-get($spec-map, weight);
   font-size: map-get($spec-map, size);
   letter-spacing: map-get($spec-map, kerning);

--- a/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
@@ -1,0 +1,112 @@
+// ==================================================
+// TYPE SPECS
+// ==================================================
+
+$t-base-spec: (
+  weight: sage-font-weight(),
+  size: sage-font-size(),
+  leading: sage-line-height(md),
+  kerning: sage-letter-spacing(xs)
+);
+
+$t-body-small-spec: map-merge($t-base-spec, (
+  size: sage-font-size(sm),
+  leading: sage-line-height(sm),
+));
+
+$t-body-xsmall-spec: map-merge($t-base-spec, (
+  size: sage-font-size(xs),
+  leading: sage-line-height(xs),
+));
+
+// The following map is used to generate both `%t-` classeses for each entry.
+// These are used to create base classes as well as to apply type specs in
+// context with `@extend %t-` etc.
+
+$type-specs: (
+  // Headings
+  "heading-1": (
+    weight: sage-font-weight(bold),
+    size: sage-font-size(4xl),
+    leading: sage-line-height(xl),
+    kerning: sage-letter-spacing(sm),
+  ),
+  "heading-2": (
+    weight: sage-font-weight(bold),
+    size: sage-font-size(3xl),
+    leading: sage-line-height(lg),
+    kerning: sage-letter-spacing(sm),
+  ),
+  "heading-3": (
+    weight: sage-font-weight(bold),
+    size: sage-font-size(2xl),
+    leading: sage-line-height(lg),
+    kerning: sage-letter-spacing(sm),
+  ),
+  "heading-4": (
+    weight: sage-font-weight(semibold),
+    size: sage-font-size(xl),
+    leading: sage-line-height(md),
+    kerning: sage-letter-spacing(sm)
+  ),
+  "heading-5": (
+    weight: sage-font-weight(semibold),
+    size: sage-font-size(lg),
+    leading: sage-line-height(sm),
+    kerning: sage-letter-spacing(sm)
+  ),
+  "heading-6": (
+    weight: sage-font-weight(semibold),
+    size: sage-font-size(),
+    leading: sage-line-height(xs),
+    kerning: sage-letter-spacing(sm)
+  ),
+
+  // Body
+  "body": $t-base-spec,
+  "body-med": map-merge($t-base-spec, (
+    weight: sage-font-weight(medium)
+  )),
+  "body-semi": map-merge($t-base-spec, (
+    weight: sage-font-weight(semibold)
+  )),
+  "body-bold": map-merge($t-base-spec, (
+    weight: sage-font-weight(bold)
+  )),
+
+  // Body Small
+  "body-small": $t-body-small-spec,
+  "body-small-med": map-merge($t-body-small-spec, (
+    weight: sage-font-weight(medium)
+  )),
+  "body-small-semi": map-merge($t-body-small-spec, (
+    weight: sage-font-weight(semibold)
+  )),
+  "body-small-bold": map-merge($t-body-small-spec, (
+    weight: sage-font-weight(bold)
+  )),
+
+  // Body XSmall
+  "body-xsmall": $t-body-xsmall-spec,
+  "body-xsmall-med": map-merge($t-body-xsmall-spec, (
+    weight: sage-font-weight(medium)
+  )),
+  "body-xsmall-semi": map-merge($t-body-xsmall-spec, (
+    weight: sage-font-weight(semibold)
+  )),
+  "body-xsmall-bold": map-merge($t-body-xsmall-spec, (
+    weight: sage-font-weight(bold)
+  )),
+
+  // Additional custom specs
+);
+
+// Set up base specs as extendables
+@each $spec-name, $spec in $type-specs {
+  %t-sage-#{$spec-name} {
+    font-weight: map-get($spec, weight);
+    font-size: map-get($spec, size);
+    letter-spacing: map-get($spec, kerning);
+    line-height: map-get($spec, leading);
+  }
+}

--- a/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
@@ -2,19 +2,19 @@
 // TYPE SPECS
 // ==================================================
 
-$t-base-spec: (
+$-t-base-spec: (
   weight: sage-font-weight(),
   size: sage-font-size(),
   leading: sage-line-height(md),
   kerning: sage-letter-spacing(xs)
 );
 
-$t-body-small-spec: map-merge($t-base-spec, (
+$-t-body-small-spec: map-merge($-t-base-spec, (
   size: sage-font-size(sm),
   leading: sage-line-height(sm),
 ));
 
-$t-body-xsmall-spec: map-merge($t-base-spec, (
+$-t-body-xsmall-spec: map-merge($-t-base-spec, (
   size: sage-font-size(xs),
   leading: sage-line-height(xs),
 ));
@@ -23,7 +23,7 @@ $t-body-xsmall-spec: map-merge($t-base-spec, (
 // These are used to create base classes as well as to apply type specs in
 // context with `@extend %t-` etc.
 
-$type-specs: (
+$sage-type-specs: (
   // Headings
   "heading-1": (
     weight: sage-font-weight(bold),
@@ -63,38 +63,38 @@ $type-specs: (
   ),
 
   // Body
-  "body": $t-base-spec,
-  "body-med": map-merge($t-base-spec, (
+  "body": $-t-base-spec,
+  "body-med": map-merge($-t-base-spec, (
     weight: sage-font-weight(medium)
   )),
-  "body-semi": map-merge($t-base-spec, (
+  "body-semi": map-merge($-t-base-spec, (
     weight: sage-font-weight(semibold)
   )),
-  "body-bold": map-merge($t-base-spec, (
+  "body-bold": map-merge($-t-base-spec, (
     weight: sage-font-weight(bold)
   )),
 
   // Body Small
-  "body-small": $t-body-small-spec,
-  "body-small-med": map-merge($t-body-small-spec, (
+  "body-small": $-t-body-small-spec,
+  "body-small-med": map-merge($-t-body-small-spec, (
     weight: sage-font-weight(medium)
   )),
-  "body-small-semi": map-merge($t-body-small-spec, (
+  "body-small-semi": map-merge($-t-body-small-spec, (
     weight: sage-font-weight(semibold)
   )),
-  "body-small-bold": map-merge($t-body-small-spec, (
+  "body-small-bold": map-merge($-t-body-small-spec, (
     weight: sage-font-weight(bold)
   )),
 
   // Body XSmall
-  "body-xsmall": $t-body-xsmall-spec,
-  "body-xsmall-med": map-merge($t-body-xsmall-spec, (
+  "body-xsmall": $-t-body-xsmall-spec,
+  "body-xsmall-med": map-merge($-t-body-xsmall-spec, (
     weight: sage-font-weight(medium)
   )),
-  "body-xsmall-semi": map-merge($t-body-xsmall-spec, (
+  "body-xsmall-semi": map-merge($-t-body-xsmall-spec, (
     weight: sage-font-weight(semibold)
   )),
-  "body-xsmall-bold": map-merge($t-body-xsmall-spec, (
+  "body-xsmall-bold": map-merge($-t-body-xsmall-spec, (
     weight: sage-font-weight(bold)
   )),
 
@@ -102,11 +102,11 @@ $type-specs: (
 );
 
 // Set up base specs as extendables
-@each $spec-name, $spec in $type-specs {
+@each $spec-name, $spec-map in $sage-type-specs {
   %t-sage-#{$spec-name} {
-    font-weight: map-get($spec, weight);
-    font-size: map-get($spec, size);
-    letter-spacing: map-get($spec, kerning);
-    line-height: map-get($spec, leading);
+    font-weight: map-get($spec-map, weight);
+    font-size: map-get($spec-map, size);
+    letter-spacing: map-get($spec-map, kerning);
+    line-height: map-get($spec-map, leading);
   }
 }

--- a/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_type_specs.scss
@@ -19,7 +19,7 @@ $-t-body-xsmall-spec: map-merge($-t-base-spec, (
   leading: sage-line-height(xs),
 ));
 
-// The following map is used to generate both `%t-` classeses for each entry.
+// The following map is used to generate both `%t-` classes for each entry.
 // These are used to create base classes as well as to apply type specs in
 // context with `@extend %t-` etc.
 
@@ -101,12 +101,24 @@ $sage-type-specs: (
   // Additional custom specs
 );
 
+/* ==================================================
+  ** Type spec
+  Usage: `@include sage-type-spec("body-small");`
+
+  Implements a type spec where used.
+  arguments: $thickness: [string name of the desired type spec]
+================================================== */
+
+@mixin sage-type-spec($spec-name) {
+  font-weight: map-get($spec-map, weight);
+  font-size: map-get($spec-map, size);
+  letter-spacing: map-get($spec-map, kerning);
+  line-height: map-get($spec-map, leading);
+}
+
 // Set up base specs as extendables
 @each $spec-name, $spec-map in $sage-type-specs {
   %t-sage-#{$spec-name} {
-    font-weight: map-get($spec-map, weight);
-    font-size: map-get($spec-map, size);
-    letter-spacing: map-get($spec-map, kerning);
-    line-height: map-get($spec-map, leading);
+    @include sage-type-spec($spec-name);
   }
 }


### PR DESCRIPTION
## Description
This PR pushes more on the spacing issues we've encountered in the docs site when `sage-type` is added on a container. Theory is that this can be revised to affect only direct children.

Also refactors a bit to make a new token file isolating the type specs there. I do a smidge of variable refactoring to reduce/move global type variables. 