### PR TITLE
Sync Radio buttons with spec 

### DIFF
--- a/lib/sage-frontend/stylesheets/system/core/_variables.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_variables.scss
@@ -213,10 +213,10 @@ $sage-radio-color-hover: sage-color(grey, 500) !default;
 $sage-radio-color-disabled: sage-color(grey, 100) !default;
 $sage-radio-color-disabled-checked: sage-color(grey, 300) !default;
 
-$sage-radio-button-size: rem(24px) !default;
+$sage-radio-button-size: rem(16px) !default;
 $sage-radio-border-radius: sage-border(radius-round) !default;
 $sage-radio-transition: 0.15s ease-in-out !default;
-$sage-radio-selected-indicator-size: rem(16px) !default;
+$sage-radio-selected-indicator-size: rem(7px) !default;
 $sage-radio-selected-indicator-color: sage-color(white) !default;
 
 // Focus state

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
@@ -84,7 +84,7 @@
     box-shadow: sage-shadow(sm);
 
     &::after {
-      transform: translate3d(-50%, -50%, 0) scale(0.5);
+      transform: translate3d(-50%, -50%, 0) scale(1);
       opacity: 1;
     }
   }
@@ -104,7 +104,7 @@
     }
 
     &::after {
-      transform: translate3d(-50%, -50%, 0) scale(0.5);
+      transform: translate3d(-50%, -50%, 0) scale(1);
       opacity: 1;
     }
   }


### PR DESCRIPTION
## Description
Radio button size no longer matches the Figma file. We have a `24px` size radio button, while the spec is now calling for `16px`.

|  Expected   |  Actual  |
|--------|--------|
|<img src="https://user-images.githubusercontent.com/816579/90296350-10d6b080-de40-11ea-9e90-9d5e08299ec4.png" width="300">|<img src="https://user-images.githubusercontent.com/816579/90296246-d705aa00-de3f-11ea-884c-8f19b42ce514.png" width="300">|

## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- n/a
