### PR TITLE
[BUG] Input group button height

### DIFF
--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -34,7 +34,6 @@
 ================================================== */
 
 @mixin button-style-reset {
-  display: inline-block;
   padding: 0;
   appearance: none;
   font-family: inherit;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_input_group.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_input_group.scss
@@ -18,6 +18,7 @@ $-pw-font-size-sm: sage-font-size(sm);
 }
 
 .sage-input-group__button {
+  display: block;
   position: absolute;
   transform: translateY(-50%);
   top: 50%;


### PR DESCRIPTION
## Description
Buttons inside of Input groups no longer extend vertically to match container height.

## Screenshots
<!-- If applicable, add screenshots to help explain your problem -->
|  expected   |  actual  |
|--------|--------|
|![input-group-button-expected](https://user-images.githubusercontent.com/816579/90063389-29a76080-dc9e-11ea-8b07-6b3499442882.png)|![input-group-button-actual](https://user-images.githubusercontent.com/816579/90063397-2e6c1480-dc9e-11ea-90b9-5739ddfcf65b.png)|
