### PR TITLE
Stacked Tab Choice Button Layout Issue - Safari

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
@@ -26,6 +26,9 @@
   > * {
     margin-bottom: sage-spacing(sm);
   }
+  .sage-choice {
+    flex-basis: initial;
+  }
 }
 
 .sage-tabs-pane {


### PR DESCRIPTION
## Description
The choice button has a layout issue in Safari. The button is collapsed and does not display the full content.

### Screenshots

|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2020-08-19 at 10 53 28 AM](https://user-images.githubusercontent.com/1175111/90672067-6927fc80-e20a-11ea-9393-f9d80631b68c.png)| ![Screen Shot 2020-08-19 at 10 53 08 AM](https://user-images.githubusercontent.com/1175111/90672104-7a710900-e20a-11ea-8deb-7c917aae1e21.png)|

## Related
-  n/a
