### PR TITLE
[BUG] Objects nav link in the sidebar scrolls to bottom of page

### DIFF
--- a/lib/sage-frontend/javascript/system/tabs.js
+++ b/lib/sage-frontend/javascript/system/tabs.js
@@ -78,7 +78,6 @@ Sage.tabs = (function() {
 
     elTab.classList.add(elTab.getAttribute(ACTIVE_CLASS_ATTRIBUTE));
     elTab.setAttribute(ATTRIBUTE_ARIA_SELECTED, true);
-    elTab.focus()
 
     let elPane = document.querySelector(`[${SELECTOR_TAB_PANE}="${paneId}"]`);
     let panesArray = Sage.util.nodelistToArray( elPane.parentElement.querySelectorAll(`[${SELECTOR_TAB_PANE}]`) );


### PR DESCRIPTION
## Description
Clicking on "Objects" in the sidebar scrolls the page to the bottom. This appears to be due to the Tabs object receiving focus in one of its controls on page load.
