### PR TITLE
Panel adjustments

### DIFF
--- a/app/views/examples/objects/panel/_markup.html.erb
+++ b/app/views/examples/objects/panel/_markup.html.erb
@@ -1,4 +1,7 @@
-<div class="sage-panel<%= " sage-panel--accordion" if defined?(is_accordion) && is_accordion %><%= " sage-panel--#{style}" if defined?(style) %><%= " sage-panel--#{color}" if defined?(color) %><%= " sage-panel--#{size}" if defined?(size) %>">
+<div
+  class="sage-panel<%= " sage-panel--accordion" if defined?(is_accordion) && is_accordion %><%= " sage-panel--#{style}" if defined?(style) %><%= " sage-panel--#{color}" if defined?(color) %><%= " sage-panel--#{size}" if defined?(size) %>"
+  style="width: <%= defined?(width) ? width : "auto" %>"
+>
   <div
     class="sage-panel__header"
     <%= "data-js-accordion=\"header\"" if defined?(is_accordion) && is_accordion %>

--- a/app/views/examples/objects/panel/_preview.html.erb
+++ b/app/views/examples/objects/panel/_preview.html.erb
@@ -66,7 +66,7 @@
 <h4>Inline/Scrolling Layout</h4>
 <div class="sage-panel-scroll-container">
   <div class="sage-panel-group sage-panel-group--labeled">
-    <p class="sage-panel-group__label t-sage-body-med">Group 1</p>
+    <p class="sage-panel-group__title t-sage-body-med">Group 1</p>
     <div class="sage-panel-group__items">
       <%= render "examples/objects/panel/markup",
         header: "Muted Color",
@@ -85,7 +85,7 @@
     </div>
   </div>
   <div class="sage-panel-group sage-panel-group--labeled">
-    <p class="sage-panel-group__label t-sage-body-med">Group 2</p>
+    <p class="sage-panel-group__title t-sage-body-med">Group 2</p>
     <div class="sage-panel-group__items">
       <%= render "examples/objects/panel/markup",
         header: "Default Color",

--- a/app/views/examples/objects/panel/_preview.html.erb
+++ b/app/views/examples/objects/panel/_preview.html.erb
@@ -73,14 +73,16 @@
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
         color: "muted",
-        size: "sm"
+        size: "sm",
+        width: "200px"
       %>
       <%= render "examples/objects/panel/markup",
         header: "Danger Color",
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
         color: "danger",
-        size: "sm"
+        size: "sm",
+        width: "200px"
       %>
     </div>
   </div>
@@ -91,25 +93,29 @@
         header: "Default Color",
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
-        size: "sm"
+        size: "sm",
+        width: "200px"
       %>
       <%= render "examples/objects/panel/markup",
         header: "Default Color",
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
-        size: "sm"
+        size: "sm",
+        width: "200px"
       %>
       <%= render "examples/objects/panel/markup",
         header: "Default Color",
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
-        size: "sm"
+        size: "sm",
+        width: "200px"
       %>
       <%= render "examples/objects/panel/markup",
         header: "Default Color",
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
-        size: "sm"
+        size: "sm",
+        width: "200px"
       %>
     </div>
   </div>

--- a/app/views/examples/objects/panel/_rules_do.html.erb
+++ b/app/views/examples/objects/panel/_rules_do.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <li>
+    Provide width boundaries for the panels when using the scrolling container format.
+  </li>
+</ul>

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -254,3 +254,15 @@
   $stripped-color-value: str-replace("#{$color}", "#", "%23");
   background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='#{$border-radius}' ry='#{$border-radius}' stroke='#{$stripped-color-value}' stroke-width='#{$thickness * 2}' stroke-dasharray='#{$dash}%2c#{$gap + $thickness * 4}' stroke-dashoffset='#{$offset}' stroke-linecap='square'/%3e%3c/svg%3e");
 }
+
+/* ==================================================
+  ** Truncate to a single line
+  Usage: `@include sage-truncate;`
+
+  Truncates text of the given element to a single line.
+================================================== */
+@mixin sage-truncate() {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -29,6 +29,7 @@ $-body-margin-bottom: sage-spacing(sm) !default;
 @each $spec-name, $spec in $sage-type-specs {
   .t-sage-#{$spec-name} {
     @extend %t-sage-#{$spec-name};
+    color: inherit;
   }
 }
 

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -196,3 +196,7 @@ hr {
 .t-sage--align-justify {
   text-align: justify;
 }
+
+.t-sage--truncate {
+  @include sage-truncate;
+}

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -34,9 +34,6 @@ $-panel-spacing-sm: sage-spacing(xs);
   }
 
   .sage-panel-scroll-container & {
-    min-width: 160px;
-    max-width: 200px;
-
     &:not(:last-child) {
       margin-right: sage-spacing(sm);
       margin-bottom: 0;
@@ -136,7 +133,7 @@ $-panel-spacing-sm: sage-spacing(xs);
 
     @else {
       .sage-panel--#{$-color-name} &,
-      .sage-panel-gropu--#{$-color-name} & {
+      .sage-panel-group--#{$-color-name} & {
         color: map-get($-values, text-color);
       }
     }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -22,7 +22,6 @@ $-panel-transition: 0.2s linear;
 $-panel-spacing-sm: sage-spacing(xs);
 
 .sage-panel {
-  margin-bottom: sage-spacing(lg);
   background: $sage-panel-bg-color;
   border-radius: $sage-panel-border-radius;
 
@@ -34,17 +33,14 @@ $-panel-spacing-sm: sage-spacing(xs);
     margin-bottom: sage-spacing(xs);
   }
 
-  .sage-panel-group--inline &,
-  .sage-panel-group__items & {
-    margin-bottom: 0;
-  }
-
-  .sage-panel-group__items &:not(:last-child) {
-    margin-right: sage-spacing(sm);
-  }
-
   .sage-panel-scroll-container & {
-    min-width: 180px;
+    min-width: 160px;
+    max-width: 200px;
+
+    &:not(:last-child) {
+      margin-right: sage-spacing(sm);
+      margin-bottom: 0;
+    }
   }
 }
 
@@ -57,7 +53,8 @@ $-panel-spacing-sm: sage-spacing(xs);
     }
 
     @else {
-      &.sage-panel--#{$-color-name} {
+      &.sage-panel--#{$-color-name},
+      .sage-panel-group--#{$-color-name} & {
         border: 1px solid map-get($-values, border-color);
       }
     }
@@ -67,6 +64,10 @@ $-panel-spacing-sm: sage-spacing(xs);
 .sage-panel__body {
   position: relative;
   padding: $sage-panel-padding;
+
+  > *:not(:last-child) {
+    margin-bottom: sage-spacing(xs);
+  }
 
   > :last-child {
     margin-bottom: 0;
@@ -134,7 +135,8 @@ $-panel-spacing-sm: sage-spacing(xs);
     }
 
     @else {
-      .sage-panel--#{$-color-name} & {
+      .sage-panel--#{$-color-name} &,
+      .sage-panel-gropu--#{$-color-name} & {
         color: map-get($-values, text-color);
       }
     }
@@ -191,7 +193,8 @@ $-panel-spacing-sm: sage-spacing(xs);
     }
 
     @else {
-      .sage-panel--#{$-color-name} & {
+      .sage-panel--#{$-color-name} &,
+      .sage-panel-group--#{$-color-name} & {
         color: map-get($-values, text-color);
       }
     }
@@ -235,15 +238,13 @@ $-panel-spacing-sm: sage-spacing(xs);
   }
 }
 
-.sage-panel-group--inline {
-  display: flex;
-}
-
 .sage-panel-group__items {
-  display: flex;
+  .sage-panel-scroll-container & {
+    display: flex;
+  }
 }
 
-.sage-panel-group__label {
+.sage-panel-group__title {
   margin-bottom: sage-spacing(xs);
 }
 


### PR DESCRIPTION
## Description

This PR adds some improvements to the Panel styles according to specs:

- Allows for a panel-group to be labeled but not inline unless also inside a scroll-container
- Allows for panel-group to have a color modifier that affects contents the same way a color modifier on the panel itself does
- Improves color inheritance to override Ladera defaults
- Fixes spacing below inline panels
- Adds a truncate utility class `t-sage--truncate` to make single-line text with `...` when no room remains in its container.

NOTE: Accompanying adjustments will need to be made in `products`.