### PR TITLE
[BUG] Switch/checkbox/radio error state styling

### DIFF
--- a/app/views/examples/elements/radio/_markup.html.erb
+++ b/app/views/examples/elements/radio/_markup.html.erb
@@ -1,4 +1,4 @@
-<div class="sage-radio">
+<div class="sage-radio<%= has_error ? " sage-radio--error" : "" %>">
   <input id="<%= id %>" type="radio" class="sage-radio__input" name="<%= name %>" value="<%= value %>"<%= checked ? " checked" : "" %><%= disabled ? " disabled" : "" %><%= required ? " required" : "" %>>
   <label for="<%= id %>" class="sage-radio__label"><%= label_text %></label>
 </div>

--- a/app/views/examples/elements/radio/_preview.html.erb
+++ b/app/views/examples/elements/radio/_preview.html.erb
@@ -6,7 +6,8 @@ value: "1",
 label_text: "Option 1",
 checked: true,
 disabled: false,
-required: false
+required: false,
+has_error: false
 %>
 <%= render "examples/elements/radio/markup",
 id: "r2",
@@ -15,7 +16,8 @@ value: "2",
 label_text: "Option 2",
 checked: false,
 disabled: false,
-required: false
+required: false,
+has_error: false
 %>
 <!-- Disabled -->
 <%= render "examples/elements/radio/markup",
@@ -25,7 +27,8 @@ value: "3",
 label_text: "Disabled",
 checked: false,
 disabled: true,
-required: false
+required: false,
+has_error: false
 %>
 <!-- Checked & Disabled -->
 <%= render "examples/elements/radio/markup",
@@ -35,7 +38,8 @@ value: "4",
 label_text: "Checked & Disabled",
 checked: true,
 disabled: true,
-required: false
+required: false,
+has_error: false
 %>
 <!-- Errror -->
 <%= render "examples/elements/radio/markup",
@@ -45,5 +49,6 @@ value: "5",
 label_text: "Error",
 checked: false,
 disabled: false,
-required: true
+required: true,
+has_error: true
 %>

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_checkbox.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_checkbox.scss
@@ -147,13 +147,11 @@
       border-right-color: sage-color(red);
       border-bottom-color: sage-color(red);
     }
-    &.sage-checkbox__input {
-      &:hover:not(:checked):not(:disabled){
-        border-color: sage-color(red);
-      }
-      &::before {
-        border-color: sage-color(red);
-      }
+    &:hover:not(:checked):not(:disabled) {
+      border-color: sage-color(red);
+    }
+    &::before {
+      border-color: sage-color(red);
     }
   }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_checkbox.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_checkbox.scss
@@ -12,7 +12,7 @@
     align-items: flex-start;
     margin-bottom: $sage-form-element-spacing;
   }
-  
+
   .sage-list & {
     margin-bottom: $sage-form-element-spacing / 2;
   }
@@ -146,6 +146,14 @@
     &::after {
       border-right-color: sage-color(red);
       border-bottom-color: sage-color(red);
+    }
+    &.sage-checkbox__input {
+      &:hover:not(:checked):not(:disabled){
+        border-color: sage-color(red);
+      }
+      &::before {
+        border-color: sage-color(red);
+      }
     }
   }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
@@ -148,10 +148,10 @@
   .sage-radio__input {
     border-color: sage-color(red);
     &:checked {
-      background-color: sage-color(red);
       color: sage-color(red);
+      background-color: sage-color(red);
     }
-    &:after {
+    &::after {
       background-color: sage-color(white);
     }
   }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
@@ -114,15 +114,6 @@
     }
   }
 
-  &:invalid {
-    background: sage-color(red, 100);
-    border-color: sage-color(red);
-
-    + .sage-radio__label {
-      color: sage-color(red);
-    }
-  }
-
   &:disabled {
     background: $sage-radio-color-disabled;
     border-color: $sage-radio-color-disabled-checked;
@@ -147,5 +138,24 @@
 
   &:not(.sage-radio--standalone) {
     margin-top: 6px;
+  }
+}
+
+.sage-radio--error {
+  .sage-radio__label {
+    color: sage-color(red);
+  }
+  .sage-radio__input {
+    border-color: sage-color(red);
+    &:checked {
+      background-color: sage-color(red);
+      color: sage-color(red);
+    }
+    &:after {
+      background-color: sage-color(white);
+    }
+  }
+  :hover:not(:checked):not(:disabled) {
+    border-color: sage-color(red);
   }
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_switch.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_switch.scss
@@ -88,10 +88,15 @@
   .sage-switch--error &,
   &:invalid {
     background-color: sage-color(red);
-
     ~ .sage-switch__label,
     ~ .sage-switch__message {
       color: sage-color(red);
+    }
+    &:checked {
+      background-color: sage-color(red);
+    }
+    &::before{
+      border-color: sage-color(red);
     }
   }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_switch.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_switch.scss
@@ -95,7 +95,7 @@
     &:checked {
       background-color: sage-color(red);
     }
-    &::before{
+    &::before {
       border-color: sage-color(red);
     }
   }


### PR DESCRIPTION
## Description
Checked switch in error does not show styles as expected. Currently, turn to default color for the background and focus styling.

**Update:** 
@philschanely also noticed some minor issues with checkboxes and radios and a fix for these will be included as well. 
(hat tip to Phil! 🎩 )

### Screenshots
|  Switches Before   |  Switches After  |
|--------|--------|
|![switch-error](https://user-images.githubusercontent.com/1175111/91228313-de993e80-e6dc-11ea-82bb-c8155dfac2a8.png)|![switch-error-fix](https://user-images.githubusercontent.com/1175111/91229178-48661800-e6de-11ea-88a1-fb38db943038.png)| 

|  Checkbox Before   |  Checkbox After  |
|--------|--------|
|![checkbox-error](https://user-images.githubusercontent.com/1175111/91329153-ab0df100-e77c-11ea-8c5c-9bb4a852f7e9.png)|![checkbox-error-fix](https://user-images.githubusercontent.com/1175111/91329170-afd2a500-e77c-11ea-9274-da3f2cf27239.png)| 

|  Radio Before   |  Radio After  |
|--------|--------|
|![radio-error](https://user-images.githubusercontent.com/1175111/91353376-0d2c1d80-e7a0-11ea-9db5-6a0d95d799e4.png)|![radio-error-fix](https://user-images.githubusercontent.com/1175111/91353397-14ebc200-e7a0-11ea-94c9-b4bf3e77e4ea.png)| 

## Related issues
- n/a