### PR TITLE
[BUG] Index image breaks out of container on smaller screens

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -12,7 +12,7 @@
       <p>We think of our approach to UI at Kajabi in this way: We default to using Rails Components and a classic Rails approach to most problems and move to React where it counts.</p>
       <p>Rails does many things very well and gives us the ability to move quickly and solve complex problems with very simple, tried and true, code solutions. With that said, sometimes we come across a problem that we want to solve that the standard rails approach will just not be enough ( Think complex interactions with many versions of state ). In this case we move to React as our default approach to solving complex, Javascript heavy problems.</p>
       <p>Because our system contains two different approaches to UI creation, we utilize a SCSS Design System to provide the styles to both types of components (Think Bootstrap, but customized for our products). Our Design System provides the styles for the core components that make up the UI of our product.</p>
-      <%= image_pack_tag("docs/sage_structure.png", class: "sage-panel__img", style: "display: block; max-width: 500px; margin: 0 auto") %>
+      <%= image_pack_tag("docs/sage_structure.png", class: "sage-panel__img", style: "display: block; max-width: 500px; margin: 0 auto; width: 100%") %>
     </div>
   </div>
 </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -12,7 +12,7 @@
       <p>We think of our approach to UI at Kajabi in this way: We default to using Rails Components and a classic Rails approach to most problems and move to React where it counts.</p>
       <p>Rails does many things very well and gives us the ability to move quickly and solve complex problems with very simple, tried and true, code solutions. With that said, sometimes we come across a problem that we want to solve that the standard rails approach will just not be enough ( Think complex interactions with many versions of state ). In this case we move to React as our default approach to solving complex, Javascript heavy problems.</p>
       <p>Because our system contains two different approaches to UI creation, we utilize a SCSS Design System to provide the styles to both types of components (Think Bootstrap, but customized for our products). Our Design System provides the styles for the core components that make up the UI of our product.</p>
-      <%= image_pack_tag("docs/sage_structure.png", class: "sage-panel__img", style: "display: block; max-width: 500px; margin: 0 auto; width: 100%") %>
+      <%= image_pack_tag("docs/sage_structure.png", class: "sage-panel__img", style: "display:block;max-width:500px;margin:0 auto;width:100%;height:auto", size: "1000x1036") %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
The image on the index page breaks out of its container on smaller screens.

### Screenshots
|  Before   |  After  |
|--------|--------|
|![localhost_4000_pages_index](https://user-images.githubusercontent.com/1175111/91229853-5ff1d080-e6df-11ea-989c-43766cf71c5c.png)|![localhost_4000_pages_index (1)](https://user-images.githubusercontent.com/1175111/91229884-6a13cf00-e6df-11ea-803e-56534dc16f18.png)| 

### Steps for testing
* Open Foundations page
* Resize browser
* Verify image at the bottom of the page no longer escapes container.

## Related issues
- n/a
