### PR TITLE
Migrate x-padding from SageContainer to SageContent

### DIFF
--- a/lib/sage-frontend/stylesheets/system/layout/_container.scss
+++ b/lib/sage-frontend/stylesheets/system/layout/_container.scss
@@ -1,7 +1,6 @@
 .sage-container {
   width: 100%;
   margin: 0 auto;
-  padding: 0 sage-spacing(md);
 
   &:not([class*="sage-container--"]) {
     max-width: sage-container(fluid);

--- a/lib/sage-frontend/stylesheets/system/layout/_content.scss
+++ b/lib/sage-frontend/stylesheets/system/layout/_content.scss
@@ -7,7 +7,11 @@
 .sage-content {
   flex: 1;
   overflow: auto;
-  padding: sage-spacing() 0;
+
+  // Ladera Integration Note:
+  // X-padding of 32px (`sage-spacing(lg)`) matches Ladera's `.content` wrapper padding value of `$spacing-outer`
+  padding: sage-spacing() sage-spacing(lg);
+
   background: sage-color(grey, 200);
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Description
Context: https://kajabi.slack.com/archives/CU5JG6N2E/p1598550684006500

This moves the x-padding from a SageContainer to SageContent to match Ladera's style of implementation with the `.content` wrapper holding the padding. This prevents the x-padding around the UI from doubling-up when using SageContainer in the context of Kajabi-Products for now. (Until we move to Sage wrappers `sage-stage`/`sage-content` in Products.)

This matches the x-padding in Ladera of `32px`, which will slightly increase the x-padding in the Docs.

--------

@monkeypox8 & @philschanely, I went ahead and whipped up a PR for this suggested change. Looking forward to chatting about this.