### PR TITLE
Misc tidying for version bump

### DIFF
--- a/app/views/examples/objects/panel/_preview.html.erb
+++ b/app/views/examples/objects/panel/_preview.html.erb
@@ -65,14 +65,13 @@
 
 <h4>Inline/Scrolling Layout</h4>
 <div class="sage-panel-scroll-container">
-  <div class="sage-panel-group sage-panel-group--labeled">
-    <p class="sage-panel-group__title t-sage-body-med">Group 1</p>
+  <div class="sage-panel-group sage-panel-group--muted sage-panel-group--labeled">
+    <p class="sage-panel-group__title t-sage-body-semi">Group 1</p>
     <div class="sage-panel-group__items">
       <%= render "examples/objects/panel/markup",
         header: "Muted Color",
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
-        color: "muted",
         size: "sm",
         width: "200px"
       %>
@@ -80,14 +79,13 @@
         header: "Danger Color",
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         style: "flat",
-        color: "danger",
         size: "sm",
         width: "200px"
       %>
     </div>
   </div>
   <div class="sage-panel-group sage-panel-group--labeled">
-    <p class="sage-panel-group__title t-sage-body-med">Group 2</p>
+    <p class="sage-panel-group__title t-sage-body-semi">Group 2</p>
     <div class="sage-panel-group__items">
       <%= render "examples/objects/panel/markup",
         header: "Default Color",

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -31,6 +31,7 @@
   box-shadow: none;
   transition: none;
   cursor: not-allowed;
+  pointer-events: none;
 
   &:hover:not(:focus):not(:active):not(:disabled):not(.disabled),
   &:focus,

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -249,6 +249,18 @@ $-panel-spacing-sm: sage-spacing(xs);
 
 .sage-panel-group__title {
   margin-bottom: sage-spacing(xs);
+
+  @each $-color-name, $-values in $-panel-colors {
+    @if $-color-name == default {
+      color: map-get($-values, text-color);
+    }
+
+    @else {
+      .sage-panel-group--#{$-color-name} & {
+        color: map-get($-values, text-color);
+      }
+    }
+  }
 }
 
 


### PR DESCRIPTION
## Description

This PR makes a few needed tweaks in preparation for a version bump:

- Fixes inherited color bug on Panel Group titles. Now a color modifier on the group will apply the color as expected to appropriate descendants.

<img width="675" alt="Screen Shot 2020-08-31 at 10 50 14 PM" src="https://user-images.githubusercontent.com/17955295/91789495-c0e83f80-ebdc-11ea-8a82-dace55c32cbe.png">

- Adds pointer-events: none to disabled buttons