### PR TITLE
Refactor Button outline -> mixin and SageLabel--interactive

### DIFF
--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -49,14 +49,18 @@ colors = [
   Draft
 </a>
 
-<a href="#" class="sage-label sage-label--interactive sage-label--success sage-label--icon-right-caret-down">
-  Published
-</a>
-
 <a href="#" class="sage-label sage-label--interactive sage-label--info sage-label--icon-right-caret-down">
   Drip
 </a>
 
+<a href="#" class="sage-label sage-label--interactive sage-label--success sage-label--icon-right-caret-down">
+  Published
+</a>
+
+<a href="#" class="sage-label sage-label--interactive sage-label--warning sage-label--icon-right-caret-down">
+  Warning
+</a>
+
 <a href="#" class="sage-label sage-label--interactive sage-label--danger sage-label--icon-right-caret-down">
-  Blocked
+  Locked
 </a>

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -42,3 +42,21 @@ colors = [
     icon_right: "tag"
   %>
 </div>
+
+<h5>Interactive</h5>
+
+<a href="#" class="sage-label sage-label--interactive sage-label--draft sage-label--icon-right-caret-down">
+  Draft
+</a>
+
+<a href="#" class="sage-label sage-label--interactive sage-label--success sage-label--icon-right-caret-down">
+  Published
+</a>
+
+<a href="#" class="sage-label sage-label--interactive sage-label--info sage-label--icon-right-caret-down">
+  Drip
+</a>
+
+<a href="#" class="sage-label sage-label--interactive sage-label--danger sage-label--icon-right-caret-down">
+  Blocked
+</a>

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -206,7 +206,6 @@
 
   &::after {
     content: "";
-    display: inline-block;
     position: absolute;
     left: 50%;
     top: 50%;

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -230,7 +230,7 @@
 }
 
 @mixin sage-focus-outline--update-color($outline-color) {
-  &:after {
+  &::after {
     border-color: $outline-color;
   }
 }

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -183,6 +183,59 @@
 }
 
 /* ==================================================
+** Button Outline
+  Usage:
+    Set up the custom outline:
+    @include sage-focus-outline--define($color)
+
+    Overwrite the custom outline color:
+    @include sage-focus-outline--define($color)
+
+  Sets a Sage-style custom focus outline to an interactive element.
+
+  arguments:
+    $color: [hex color to be used for the stroke color]
+================================================== */
+
+@mixin sage-focus-outline($outline-color) {
+  position: relative;
+
+  &:focus {
+    outline: none;
+  }
+
+  &::after {
+    content: "";
+    display: inline-block;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0) scale(0.94);
+    width: calc(100% + #{$sage-btn-focus-outline-width * 2px} + #{$sage-btn-focus-outline-spacing * 2});
+    height: calc(100% + #{$sage-btn-focus-outline-width * 2px} + #{$sage-btn-focus-outline-spacing * 2});
+    border: ($sage-btn-focus-outline-width * 1px) solid $outline-color;
+    border-radius: sage-border(radius-large);
+    transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  &:focus:not(:disabled):not(.disabled),
+  &:active:not(:disabled):not(.disabled) {
+    &::after {
+      transform: translate3d(-50%, -50%, 0) scale(1);
+      opacity: 1;
+    }
+  }
+}
+
+@mixin sage-focus-outline--update-color($outline-color) {
+  &:after {
+    border-color: $outline-color;
+  }
+}
+
+/* ==================================================
   ** Card
   Usage: `@include sage-card;`
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -43,6 +43,7 @@
 
 .sage-btn {
   @include button-style-base;
+  @include sage-focus-outline($sage-btn-focus-outline-color);
 
   .sage-input-group & {
     border-top-left-radius: 0;
@@ -53,36 +54,14 @@
     margin-right: 0;
   }
 
-  &::after {
-    content: "";
-    display: inline-block;
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate3d(-50%, -50%, 0) scale(0.94);
-    width: calc(100% + #{$sage-btn-focus-outline-width * 2px} + #{$sage-btn-focus-outline-spacing * 2});
-    height: calc(100% + #{$sage-btn-focus-outline-width * 2px} + #{$sage-btn-focus-outline-spacing * 2});
-    border: ($sage-btn-focus-outline-width * 1px) solid $sage-btn-focus-outline-color;
-    border-radius: sage-border(radius-large);
-    transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
-    pointer-events: none;
-    opacity: 0;
-  }
-
   &:focus {
     box-shadow: $sage-btn-shadow-base;
-    outline: none;
   }
 
   &:focus:not(:disabled):not(.disabled),
   &:active:not(:disabled):not(.disabled) {
-    &::after {
-      transform: translate3d(-50%, -50%, 0) scale(1);
-      opacity: 1;
-    }
-
-    .sage-dropdown__item > &::after {
-      opacity: 0;
+    .sage-dropdown__item > & {
+      @include sage-focus-outline--update-color(transparent);
     }
   }
 
@@ -124,12 +103,9 @@
 }
 
 .sage-btn--primary {
+  @include sage-focus-outline--update-color($sage-btn-primary-bg-color);
   color: $sage-btn-primary-text-color;
   background-color: $sage-btn-primary-bg-color;
-
-  &::after {
-    border-color: $sage-btn-primary-bg-color;
-  }
 
   &:hover:not(:focus):not(:active):not(:disabled):not(.disabled),
   &:focus,
@@ -161,14 +137,11 @@
 }
 
 .sage-btn--secondary {
+  @include sage-focus-outline--update-color(sage-color(primary));
   color: $sage-btn-secondary-text-color;
   background-color: sage-color(white);
   border: 0;
   box-shadow: none;
-
-  &::after {
-    border-color: sage-color(primary);
-  }
 
   &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
     color: $sage-btn-secondary-text-color;
@@ -201,14 +174,11 @@
 }
 
 .sage-btn--tertiary {
+  @include sage-focus-outline--update-color(sage-color(charcoal, 200));
   color: $sage-btn-tertiary-text-color;
   background-color: sage-color(white);
   border: 0;
   box-shadow: none;
-
-  &::after {
-    border-color: sage-color(charcoal, 200);
-  }
 
   &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
     color: $sage-btn-tertiary-text-color;
@@ -241,13 +211,10 @@
 }
 
 .sage-btn--danger {
+  @include sage-focus-outline--update-color($sage-btn-danger-text-color);
   color: $sage-btn-danger-text-color;
   border: 0;
   box-shadow: none;
-
-  &::after {
-    border-color: $sage-btn-danger-text-color;
-  }
 
   &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
     color: $sage-btn-danger-text-color;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -42,6 +42,16 @@ $-label-inset-border: 0 0 0 1px inset;
       background-color: sage-color-combo($-color-name, bold, background);
     }
 
+    &.sage-label--interactive {
+      cursor: pointer;
+
+      @include sage-focus-outline( sage-color-combo($-color-name, subtle, background) );
+
+      &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
+        background-color: darken(sage-color-combo($-color-name, default, background), 5%);
+      }
+    }
+
     .sage-btn & {
       &:focus,
       &:active {
@@ -54,16 +64,22 @@ $-label-inset-border: 0 0 0 1px inset;
 
 @each $-icon-name, $-icon-code in $sage-icons {
   .sage-label--icon-left-#{$-icon-name} {
+    flex-direction: row;
+    gap: sage-spacing(xs);
+
     &::before {
-      margin-right: sage-spacing(2xs);
-      @include sage-icon-base($-icon-name);
+      align-self: center;
+      @include sage-icon-base($-icon-name, sm);
     }
   }
 
   .sage-label--icon-right-#{$-icon-name} {
-    &::after {
-      margin-left: sage-spacing(2xs);
-      @include sage-icon-base($-icon-name);
+    flex-direction: row-reverse;
+    gap: sage-spacing(xs);
+
+    &::before {
+      align-self: center;
+      @include sage-icon-base($-icon-name, sm);
     }
   }
 }


### PR DESCRIPTION
- Refactors button outline logic to a mixin ( `sage-focus-outline($color)` )
- SageLabel--interactive

@philschanely and I ran through this solution and we both feel comfortable with refactoring the Button outline logic into a mixin.

Comps: https://www.figma.com/file/TO8XSqt6tgscFcShhkWVdm/Products-Admin?node-id=615%3A5427

![screencast 2020-09-22 12-31-48](https://user-images.githubusercontent.com/565743/93910883-b565d100-fccf-11ea-8917-315e8d970bec.gif)
