### PR TITLE
[WIP] SageRails: Rename `component.value` & `component.content` -> `component.children` to align with SageFrontend react naming convention

### DIFF
--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -12,7 +12,7 @@ colors = [
 <% colors.each do | color | %>
   <%= sage_component SageLabel, {
     color: color,
-    value: color.capitalize
+    content: color.capitalize
   } %>
 <% end %>
 
@@ -21,7 +21,7 @@ colors = [
   <%= sage_component SageLabel, {
     color: color,
     style: "subtle",
-    value: color.capitalize
+    content: color.capitalize
   } %>
 <% end %>
 
@@ -30,19 +30,19 @@ colors = [
   <%= sage_component SageLabel, {
     color: color,
     style: "bold",
-    value: color.capitalize
+    content: color.capitalize
   } %>
 <% end %>
 
 <h5>With Icons</h5>
 <%= sage_component SageLabel, {
   color: "draft",
-  value: "Add",
+  content: "Add",
   icon: { style: "left", name: "add-small" }
 } %>
 <%= sage_component SageLabel, {
   color: "draft",
-  value: "Tag",
+  content: "Tag",
   icon: { style: "right", name: "tag" }
 } %>
 
@@ -51,7 +51,7 @@ colors = [
   <%= sage_component SageLabel, {
     color: color,
     interactive: true,
-    value: color.capitalize,
+    content: color.capitalize,
     icon: { style: "right", name: "caret-down" }
   } %>
 <% end %>

--- a/app/views/examples/objects/catalog_item/_preview.html.erb
+++ b/app/views/examples/objects/catalog_item/_preview.html.erb
@@ -8,34 +8,34 @@
       style: "tertiary",
       size: "tiny",
       icon: { name: "comment", style: "left" },
-      value: "5 Golden Eggs",
+      content: "5 Golden Eggs",
     } %>
     <%= sage_component SageButton, {
       style: "tertiary",
       size: "tiny",
       icon: { name: "users", style: "left" },
-      value: "3 Geese A-Laying",
+      content: "3 Geese A-Laying",
     } %>
     <%= sage_component SageButton, {
       style: "tertiary",
       size: "tiny",
       icon: { name: "coupon", style: "left" },
-      value: "1 Partridge In A Pear Tree",
+      content: "1 Partridge In A Pear Tree",
     } %>
     <%= content_for :sage_aside do %>
       <%= sage_component SageDropdown, {
         align: "right",
         items: [{
-          value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+          content: sage_component(SageLabel, { color: "success", content: "Publish" }),
           attributes: { "href": "#" },
         }, {
-          value: sage_component(SageLabel, { color: "info", value: "Drip" }),
+          content: sage_component(SageLabel, { color: "info", content: "Drip" }),
           attributes: { "href": "#" },
         }, {
-          value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
+          content: sage_component(SageLabel, { color: "draft", content: "Draft" }),
           attributes: { "href": "#" },
         }, {
-          value: "Delete Category",
+          content: "Delete Category",
           icon: "trash",
           style: "danger",
           attributes: { "href": "#" },
@@ -44,14 +44,14 @@
         <%= sage_component SageLabel, {
           color: "info",
           interactive: true,
-          value: "Drip",
+          content: "Drip",
           icon: { style: "right", name: "caret-down" }
         } %>
       <% end %>
       <%= sage_component SageDropdown, {
         align: "right",
         items: [{
-          value: "Edit Item",
+          content: "Edit Item",
           icon: "pen",
           attributes: {
             "href": "#",
@@ -61,7 +61,7 @@
         <%= sage_component SageButton, {
           style: "tertiary",
           icon: { name: "dot-menu-horizontal", style: "only" },
-          value: "Edit",
+          content: "Edit",
           align: "end"
         } %>
       <% end %>

--- a/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/app/views/examples/objects/dropdown/_preview.html.erb
@@ -1,21 +1,21 @@
 <h5>Menu Button</h5>
 <%= sage_component SageDropdown, {
   items: [{
-    value: "Edit",
+    content: "Edit",
     icon: "pen",
     attributes: { "href": "#" },
   }, {
-    value: "New",
+    content: "New",
     icon: "add",
     style: "primary",
     attributes: { "href": "#" },
    }, {
-    value: "Share Element",
+    content: "Share Element",
     icon: "url",
     modifiers: ["border-before"],
     attributes: { "href": "#" },
    }, {
-    value: "Take A Dangerous Action",
+    content: "Take A Dangerous Action",
     icon: "remove-circle",
     style: "danger",
     attributes: { "href": "#" },
@@ -23,7 +23,7 @@
 } do %>
   <%= sage_component SageButton, {
     style: "primary",
-    value: "Add An Element"
+    content: "Add An Element"
   } %>
 <% end %>
 
@@ -33,16 +33,16 @@
   <%= sage_component SageDropdown, {
     align: "right",
     items: [{
-      value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+      content: sage_component(SageLabel, { color: "success", content: "Publish" }),
       attributes: { "href": "#" },
     }, {
-      value: sage_component(SageLabel, { color: "info", value: "Drip" }),
+      content: sage_component(SageLabel, { color: "info", content: "Drip" }),
       attributes: { "href": "#" },
     }, {
-      value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
+      content: sage_component(SageLabel, { color: "draft", content: "Draft" }),
       attributes: { "href": "#" },
     }, {
-      value: "Delete Category",
+      content: "Delete Category",
       icon: "trash",
       style: "danger",
       attributes: { "href": "#" },
@@ -51,7 +51,7 @@
     <%= sage_component SageLabel, {
       color: "info",
       interactive: true,
-      value: "Drip",
+      content: "Drip",
       icon: { style: "right", name: "caret-down" }
     } %>
   <% end %>
@@ -64,21 +64,21 @@
   trigger_type: "select",
   align: "right",
   items: [{
-    value: "-- None --"
+    content: "-- None --"
   }, {
-    value: "Option 1",
+    content: "Option 1",
    }, {
-    value: "Option 2",
+    content: "Option 2",
    }, {
-    value: "Option 3",
+    content: "Option 3",
   }, {
-    value: "Muted",
+    content: "Muted",
     style: "muted"
   }]
 } do %>
   <%= sage_component SageButton, {
     style: "tertiary",
-    value: "",
+    content: "",
     css_classes: "sage-dropdown__trigger-selected-value",
     icon: { style: "right", name: "caret-down" }
   } %>
@@ -92,21 +92,21 @@
   trigger_type: "select-labeled",
   align: "right",
   items: [{
-    value: "-- None --"
+    content: "-- None --"
   }, {
-    value: "Option 1",
+    content: "Option 1",
    }, {
-    value: "Option 2",
+    content: "Option 2",
    }, {
-    value: "Option 3",
+    content: "Option 3",
   }, {
-    value: "Muted",
+    content: "Muted",
     style: "muted"
   }]
 } do %>
   <%= sage_component SageButton, {
     style: "tertiary",
-    value: "",
+    content: "",
     css_classes: "sage-dropdown__trigger-selected-value",
     icon: { style: "right", name: "caret-down" }
   } %>

--- a/app/views/pages/sandbox.html.erb
+++ b/app/views/pages/sandbox.html.erb
@@ -4,5 +4,5 @@
 <% end %>
 
 <%= sage_component SagePanel, {} do %>
-  <%= sage_component SageButton, { style: "primary", value: "This is a sage component rails test" } %>
+  <%= sage_component SageButton, { style: "primary", content: "This is a sage component rails test" } %>
 <% end %>

--- a/lib/sage_rails/app/helpers/sage_component_helper.rb
+++ b/lib/sage_rails/app/helpers/sage_component_helper.rb
@@ -2,7 +2,7 @@ module SageComponentHelper
   def sage_component(component, props, &block)
     component.new({
       context: self,
-      content: block_given? ? capture(&block) : nil
+      children: block_given? ? capture(&block) : nil
     }.merge(props)).render
   end
 

--- a/lib/sage_rails/app/sage_components/sage_button.rb
+++ b/lib/sage_rails/app/sage_components/sage_button.rb
@@ -5,7 +5,7 @@ class SageButton < SageComponent
   attr_accessor :icon
   attr_accessor :disabled
   attr_accessor :attributes
-  attr_accessor :value
+  attr_accessor :content
   attr_accessor :full_width
   attr_accessor :css_classes
 end

--- a/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/lib/sage_rails/app/sage_components/sage_component.rb
@@ -1,7 +1,7 @@
 class SageComponent
   include ActiveModel::Model
   attr_accessor :context
-  attr_accessor :content
+  attr_accessor :children
 
   def generated_css_classes
     @generated_css_classes ||= ""

--- a/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/lib/sage_rails/app/sage_components/sage_label.rb
@@ -3,5 +3,5 @@ class SageLabel < SageComponent
   attr_accessor :style
   attr_accessor :interactive
   attr_accessor :icon
-  attr_accessor :value
+  attr_accessor :content
 end

--- a/lib/sage_rails/app/sage_components/sage_status_icon.rb
+++ b/lib/sage_rails/app/sage_components/sage_status_icon.rb
@@ -1,4 +1,4 @@
 class SageStatusIcon < SageComponent
-  attr_accessor :value
+  attr_accessor :content
   attr_accessor :icon
 end

--- a/lib/sage_rails/app/views/sage_components/_sage_assistant.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_assistant.html.erb
@@ -4,7 +4,7 @@
     <span class="visually-hidden">Toggle main menu</span>
   </button>
   <%= image_tag "nav_logo_white.png", class: "sage-assistant__branding" %>
-  <div class="sage-assistant__body"><%= component.content %></div>
+  <div class="sage-assistant__body"><%= component.children %></div>
   <div class="sage-assistant__actions">
     <% if content_for?(:super_admin_actions) %>
       <div id="super-admin-actions" class="btn-group">

--- a/lib/sage_rails/app/views/sage_components/_sage_banner.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_banner.html.erb
@@ -27,7 +27,7 @@
       <%= component.link[:name] %>
     </a>
   <% end %>
-  <%= component.content if component.content.present? %>
+  <%= component.children if component.children.present? %>
 </div>
 
 <% if component.context_ladera_top %>

--- a/lib/sage_rails/app/views/sage_components/_sage_body.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_body.html.erb
@@ -1,3 +1,3 @@
 <body class="sage-page <%= component.style_class ? "#{component.style_class}" : "" %>">
-  <%= component.content %>
+  <%= component.children %>
 </body>

--- a/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -19,12 +19,12 @@
 >
   <% if component.icon&.dig(:style) == "only" %>
     <span class="visually-hidden">
-      <%= component.value.html_safe %>
+      <%= component.content.html_safe %>
     </span>
   <% else %>
     <span class="sage-btn__truncate-text">
-      <%# if the component.value is an empty string, add a `&nbsp;` to prevent height collapse %>
-      <%= (component.value.strip.empty? ? "&nbsp;" : component.value).html_safe %>
+      <%# if the component.content is an empty string, add a `&nbsp;` to prevent height collapse %>
+      <%= (component.content.strip.empty? ? "&nbsp;" : component.content).html_safe %>
     </span>
   <% end %>
 </<%= html_tag %>>

--- a/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
@@ -13,6 +13,6 @@
   <div class="sage-card__body">
     <h2 class="sage-card__title t-sage-heading-5"><%= component.title %></h2>
     <p class="sage-card__text"><%= component.text %></p>
-    <%= component.content %>
+    <%= component.children %>
   </div>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
@@ -4,9 +4,9 @@
       <%= component.title %>
     </a>
   </h1>
-  <% if component.content.present? %>
+  <% if component.children.present? %>
     <div class="sage-catalog-item__content">
-      <%= component.content %>
+      <%= component.children %>
     </div>
   <% end %>
   <% if content_for? :sage_aside %>

--- a/lib/sage_rails/app/views/sage_components/_sage_container.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_container.html.erb
@@ -1,3 +1,3 @@
 <div class="sage-container<%= " sage-container--#{component.size}" if defined?(component.size) %>">
-  <%= component.content %>
+  <%= component.children %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_content.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_content.html.erb
@@ -1,3 +1,3 @@
 <div class="sage-content">
-  <%= component.content %>
+  <%= component.children %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_description.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_description.html.erb
@@ -11,5 +11,5 @@
       <dd class="sage-description__data"><%= component.data %></dd>
     <% end %>
   <% end %>
-  <%= component.content %>
+  <%= component.children %>
 </dl>

--- a/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -12,7 +12,7 @@
       <%= "sage-dropdown__trigger--#{component.trigger_type}" if component.trigger_type %>
     "
   >
-    <%= component.content %>
+    <%= component.children %>
   </div>
   <nav class="sage-dropdown__panel">
     <ul class="sage-dropdown__menu" role="menu" aria-label="options_menu">
@@ -42,7 +42,7 @@
               <%= "sage-dropdown__item-control--icon-#{item[:icon]}" if item[:icon] %>
             "
           >
-            <%= item[:value].html_safe %>
+            <%= item[:content].html_safe %>
           </a>
         </li>
       <% end %>

--- a/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="sage-form-section__content">
     <div class="sage-form-section__panel">
-      <%= component.content %>
+      <%= component.children %>
     </div>
   </div>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
@@ -1,3 +1,3 @@
 <div class="sage-col--<%= component.breakpoint %>-<%= component.size %>">
-  <%= component.content %>
+  <%= component.children %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_grid_row.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_grid_row.html.erb
@@ -1,3 +1,3 @@
 <div class="sage-row">
-  <%= component.content %>
+  <%= component.children %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_header.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_header.html.erb
@@ -1,3 +1,3 @@
 <header class="sage-header">
-  <%= component.content %>
+  <%= component.children %>
 </header>

--- a/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -12,9 +12,9 @@
 >
   <% if component.icon&.dig(:style) == "only" %>
     <span class="visually-hidden">
-      <%= component.value.html_safe %>
+      <%= component.content.html_safe %>
     </span>
   <% else %>
-    <%= component.value.html_safe %>
+    <%= component.content.html_safe %>
   <% end %>
 </<%= html_tag %>>

--- a/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -7,8 +7,8 @@
   data-js-modal="<%= component.id %>"
 >
   <section class="sage-modal__container" data-js-modal-container>
-    <% if component.content.present? %>
-      <%= component.content %>
+    <% if component.children.present? %>
+      <%= component.children %>
     <% else %>
       <%= sage_component SageModalContent, {} do %>
         <%= sage_component SageLoader, { style: "spinner" } %>

--- a/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <div class="sage-modal__content">
-  <%= component.content %>
+  <%= component.children %>
 </div>
 
 <% if content_for?(:sage_footer) %>

--- a/lib/sage_rails/app/views/sage_components/_sage_nav.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_nav.html.erb
@@ -1,3 +1,3 @@
 <div class="sage-nav">
-  <%= component.content %>
+  <%= component.children %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -19,5 +19,5 @@
       </p>
     </nav>
   <% end %>
-  <%= component.content %>
+  <%= component.children %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel.html.erb
@@ -19,7 +19,7 @@
     </header>
   <% end %>
   <div class="sage-panel__body">
-    <%= component.content %>
+    <%= component.children %>
   </div>
   <% if content_for?(:sage_footer) %>
     <footer class="sage-panel__footer">

--- a/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div class="sage-sidebar <%= component.size ? "sage-sidebar--#{component.size}" : "" %>" id="sage-sidebar-menu" data-js-sidebar="sage-sidebar-menu" id="sage-sidebar-menu">
   <div class="sage-sidebar__body">
-    <%= component.content %>
+    <%= component.children %>
   </div>
   <div class="sage-sidebar__footer">
     <%= yield :sage_sidebar_footer %>

--- a/lib/sage_rails/app/views/sage_components/_sage_sortable.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_sortable.html.erb
@@ -2,8 +2,8 @@
   class="sage-sortable"
   data-js-sortable="<%= component.resource_name %>"
 >
-  <% if component.content.present? %>
-    <%= component.content %>
+  <% if component.children.present? %>
+    <%= component.children %>
   <% elsif content_for?(:sage_empty)%>
     <%= content_for :sage_empty %>
   <% end %>

--- a/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
@@ -8,6 +8,6 @@
     <h2 class="t-sage-body-xsmall"><%= component.label %></h2>
   </div>
   <div class="sage-sortable__item-actions">
-    <%= component.content %>
+    <%= component.children %>
   </div>
 </section>

--- a/lib/sage_rails/app/views/sage_components/_sage_stage.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_stage.html.erb
@@ -1,3 +1,3 @@
 <div class="sage-stage">
-  <%= component.content %>
+  <%= component.children %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_status_icon.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_status_icon.html.erb
@@ -3,9 +3,9 @@
     sage-status-icon
     <%= "sage-status-icon--#{component.icon}" %>
   "
-  data-js-tooltip="<%= component.value %>"
+  data-js-tooltip="<%= component.content %>"
 >
   <span class="visually-hidden">
-    <%= component.value %>
+    <%= component.content %>
   </span>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_tabs_pane.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_tabs_pane.html.erb
@@ -1,3 +1,3 @@
 <section class="sage-tabs-pane" data-js-tabs-pane="<%= component.id %>" id="<%= component.id %>" role="tabpanel">
-  <%= component.content %>
+  <%= component.children %>
 </section>


### PR DESCRIPTION
This will require a **find-and-replace on Kajabi-Products** but will align the attribute interface with SageRails with React's required prop naming schema of `props.children`.

This is an idea-spike spun out of a naming discussion with @philschanely: https://github.com/Kajabi/sage/pull/420#pullrequestreview-494789765

SageRails syntax now (generally) matches SageReact syntax:

#### JSX
```jsx
<SageDropdown items={[{
  children: "Edit Item,
}, {
  children: <SageLabel children="Draft" />
}]>
  <SageButton children="Edit" color={{BUTTON_COLORS.PRIMARY}} />
</SageDropdown>
```

#### HTML.ERB
```html.erb
<%= sage_component SageDropdown, {
  items: [{
    children: "Edit Item",
  }, {
    children: sage_component(SageLabel, { children: "Draft" })
}] do %>
  <%= sage_component SageButton, {
    color: "tertiary",
    children: "Edit",
  } %>
<% end %>
```