### PR TITLE
Tooltip Sizing Adjustment 

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_tooltip.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_tooltip.scss
@@ -8,7 +8,6 @@
   display: flex;
   position: absolute;
   z-index: $sage-tooltip-zindex;
-  min-width: max-content;
   max-width: $sage-tooltip-maxwidth;
   padding: $sage-tooltip-padding;
   text-align: center;


### PR DESCRIPTION
## Description
When having a longer amount of text within a tooltip the text currently does not wrap as expected due to the size being affected by the `min-width: max-content`. 

This update removes the `min-width`, which resolves the issue and causes the text to wrap based on the default width applied or with the option `data-js-tooltip-size`.

### Screenshot
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-09-29 at 1 31 02 PM](https://user-images.githubusercontent.com/1175111/94613016-ccb93700-0258-11eb-80cb-760923402ff0.png)|![Screen Shot 2020-09-29 at 1 31 25 PM](https://user-images.githubusercontent.com/1175111/94613058-da6ebc80-0258-11eb-92b3-5c528ba7234d.png)|

## Test notes
You will have to manually add a long string of text to the `/tooltip/_preview.html.erb` file or you may also update the text within the `data-js-tooltip` applied to any of the tooltip elements using dev tools. 


## Related
- NA
