### PR TITLE
Add copy button, text, and card

### DIFF
--- a/app/helpers/elements_helper.rb
+++ b/app/helpers/elements_helper.rb
@@ -12,14 +12,6 @@ module ElementsHelper
   def sage_elements
     [
       # Sage Generated Elements
-        {
-          title: "copy_text",
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", 
-          scss: "todo",
-          rails: "todo",
-          react: "todo",
-          a11y: "todo",
-        },
       {
         title: "breadcrumbs",
         description: "Breadcrumbs provide a sense of where we are in the site structure with hyperlinks to previous areas in that structure. Our element also provides a specific \"Back link\" variation",
@@ -59,6 +51,15 @@ module ElementsHelper
         rails: "done",
         react: "todo",
         a11y: "todo"
+      },
+      {
+        title: "copy_text",
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", 
+        use_legacy_html_code_source: false,
+        scss: "todo",
+        rails: "todo",
+        react: "todo",
+        a11y: "todo",
       },
       {
         title: "description",

--- a/app/helpers/elements_helper.rb
+++ b/app/helpers/elements_helper.rb
@@ -54,12 +54,12 @@ module ElementsHelper
       },
       {
         title: "copy_text",
-        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", 
+        description: "A small set of components to use in places where \"copy\" text is provided such as in a Copy Button or a block of text to be copied elsewhere.", 
         use_legacy_html_code_source: false,
-        scss: "todo",
-        rails: "todo",
-        react: "todo",
-        a11y: "todo",
+        scss: "done",
+        rails: "done",
+        react: "done",
+        a11y: "done",
       },
       {
         title: "description",

--- a/app/helpers/elements_helper.rb
+++ b/app/helpers/elements_helper.rb
@@ -12,6 +12,14 @@ module ElementsHelper
   def sage_elements
     [
       # Sage Generated Elements
+        {
+          title: "copy_text",
+          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", 
+          scss: "todo",
+          rails: "todo",
+          react: "todo",
+          a11y: "todo",
+        },
       {
         title: "breadcrumbs",
         description: "Breadcrumbs provide a sense of where we are in the site structure with hyperlinks to previous areas in that structure. Our element also provides a specific \"Back link\" variation",

--- a/app/views/examples/elements/copy_text/_preview.html.erb
+++ b/app/views/examples/elements/copy_text/_preview.html.erb
@@ -1,14 +1,12 @@
 <h5>Copy Text (inline)</h5>
-<%= sage_component SageCopyText, { value: "me.ns.cloudflare.com" } %>
+<%= sage_component SageCopyText, { value: "me.ns.cloudflare.com", semibold: true } %>
 
 <h5>Copy Text (block)</h5>
 <%= sage_component SageCopyTextCard, {} do %>
-  <p>me.ns.cloudflare.com</p>
-  <p>me.ns.cloudflare.com</p>
-  <p>me.ns.cloudflare.com</p>
+  <p><b>Reply:</b> me.ns.cloudflare.com</p>
   <p>me.ns.cloudflare.com</p>
   <p>me.ns.cloudflare.com</p>
 <% end %>
 
 <h5>Copy Button</h5>
-<%= sage_component SageCopyButton, { value: "me.ns.cloudflare.com" } %>
+<%= sage_component SageCopyButton, { value: "me.ns.cloudflare.com", semibold: true } %>

--- a/app/views/examples/elements/copy_text/_preview.html.erb
+++ b/app/views/examples/elements/copy_text/_preview.html.erb
@@ -1,0 +1,14 @@
+<h5>Copy Text (inline)</h5>
+<%= sage_component SageCopyText, { value: "me.ns.cloudflare.com" } %>
+
+<h5>Copy Text (block)</h5>
+<%= sage_component SageCopyTextCard, {} do %>
+  <p>me.ns.cloudflare.com</p>
+  <p>me.ns.cloudflare.com</p>
+  <p>me.ns.cloudflare.com</p>
+  <p>me.ns.cloudflare.com</p>
+  <p>me.ns.cloudflare.com</p>
+<% end %>
+
+<h5>Copy Button</h5>
+<%= sage_component SageCopyButton, { value: "me.ns.cloudflare.com" } %>

--- a/app/views/examples/elements/copy_text/_props.html.erb
+++ b/app/views/examples/elements/copy_text/_props.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td>Prop Name</td>
+  <td>The description of the property goes here.</td>
+  <td>String</td>
+  <td>Default</td>
+</tr>

--- a/app/views/examples/elements/copy_text/_props.html.erb
+++ b/app/views/examples/elements/copy_text/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td>Prop Name</td>
-  <td>The description of the property goes here.</td>
-  <td>String</td>
-  <td>Default</td>
+  <td>semibold</td>
+  <td>Wether or not the whole block should be set at the Semibold weight, since a number of implementations use this.</td>
+  <td>Boolean</td>
+  <td>false</td>
 </tr>

--- a/app/views/examples/elements/copy_text/_rules_do.html.erb
+++ b/app/views/examples/elements/copy_text/_rules_do.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should do with this element go here.</li>
+</ul>

--- a/app/views/examples/elements/copy_text/_rules_do.html.erb
+++ b/app/views/examples/elements/copy_text/_rules_do.html.erb
@@ -1,3 +1,4 @@
 <ul>
-  <li>Rules for what you should do with this element go here.</li>
+  <li>Use inline <code>&lt;b&gt;</code> tag to add bolding to select portions of these blocks.</li>
+  <li>Provide a local max-width as desired in order to limit overflowing text. Truncation is setup and ready for this.</li>
 </ul>

--- a/app/views/examples/elements/copy_text/_rules_dont.html.erb
+++ b/app/views/examples/elements/copy_text/_rules_dont.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Rules for what you should not do with this element go here.</li>
+</ul>

--- a/app/views/examples/elements/copy_text/_rules_dont.html.erb
+++ b/app/views/examples/elements/copy_text/_rules_dont.html.erb
@@ -1,3 +1,3 @@
 <ul>
-  <li>Rules for what you should not do with this element go here.</li>
+  <li>Manually apply bolding to an entire block of any of these components; use <code>semibold</code> prop to accomplish this effect instead.</li>
 </ul>

--- a/lib/sage-frontend/javascript/system/copy-button.js
+++ b/lib/sage-frontend/javascript/system/copy-button.js
@@ -14,6 +14,7 @@ Sage.copyButton = (function() {
     el.select();
     document.execCommand('copy');
     document.body.removeChild(el);
+    ev.currentTarget.focus();
   };
 
 

--- a/lib/sage-frontend/stylesheets/system/core/_typography.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_typography.scss
@@ -155,6 +155,11 @@ a {
   }
 }
 
+b,
+strong {
+  font-weight: sage-font-weight(semibold);
+}
+
 hr {
   margin: sage-spacing() 0;
   border: 0;

--- a/lib/sage-frontend/stylesheets/system/index.scss
+++ b/lib/sage-frontend/stylesheets/system/index.scss
@@ -29,6 +29,7 @@
 @import "patterns/elements/button";
 @import "patterns/elements/checkbox";
 @import "patterns/elements/choice";
+@import "patterns/elements/copy_text";
 @import "patterns/elements/description";
 @import "patterns/elements/form_input";
 @import "patterns/elements/form_select";

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
@@ -9,7 +9,7 @@ $-copy-text-color: sage-color(charcoal, 400);
 $-copy-text-color-hover: sage-color(charcoal, 500);
 
 @mixin sage-copy-text() {
-  @extend %t-sage-body-small-semi;
+  @extend %t-sage-body-small;
 
   color: sage-color(charcoal, 400);
   background-color: sage-color(grey, 200);
@@ -36,7 +36,7 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
 }
 
 .sage-copy-text-card {
-  @include sage-grid-card;
+  @include sage-grid-stack;
   @include sage-copy-text;
 
   padding: $sage-card-padding;
@@ -61,4 +61,10 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
   &:hover::before {
     color: $-copy-text-color-hover;
   }
+}
+
+.sage-copy-btn--semibold,
+.sage-copy-text--semibold,
+.sage-copy-text-card--semibold {
+  @extend %t-sage-body-small-semi;
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
@@ -63,7 +63,6 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
   }
 }
 
-.sage-copy-btn--semibold,
 .sage-copy-text--semibold,
 .sage-copy-text-card--semibold {
   @extend %t-sage-body-small-semi;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
@@ -1,0 +1,64 @@
+/* ==================================================
+  ** copy_text
+  type: element
+
+================================================== */
+
+$-copy-text-border: 1px solid sage-color(grey, 400);
+$-copy-text-color: sage-color(charcoal, 400);
+$-copy-text-color-hover: sage-color(charcoal, 500);
+
+@mixin sage-copy-text() {
+  @extend %t-sage-body-small-semi;
+
+  color: sage-color(charcoal, 400);
+  background-color: sage-color(grey, 200);
+  border: $-copy-text-border;
+  border-radius: sage-border(radius);
+}
+
+.sage-copy-text {
+  @include sage-copy-text;
+
+  display: inline-block;
+  padding: 0 sage-spacing(xs);
+
+  .sage-copy-btn & {
+    transition: $sage-transition;
+    transition-property: color, background-color;
+  }
+
+  .sage-copy-btn:hover & {
+    color: $-copy-text-color-hover;
+    background-color: sage-color(grey, 100);
+    border-color: sage-color(grey, 500);
+  }
+}
+
+.sage-copy-text-card {
+  @include sage-grid-card;
+  @include sage-copy-text;
+
+  padding: $sage-card-padding;
+}
+
+.sage-copy-btn {
+  @include sage-button-style-reset();
+  @include sage-focus-outline($-copy-text-color-hover);
+
+  display: inline-flex;
+  flex-flow: row-reverse;
+  align-items: center;
+  padding-right: sage-spacing(2xs);
+
+  &::before {
+    @include sage-icon-base(copy);
+
+    margin-left: sage-spacing(xs);
+    color: $-copy-text-color;
+  }
+
+  &:hover::before {
+    color: $-copy-text-color-hover;
+  }
+}

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
@@ -11,6 +11,8 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
 @mixin sage-copy-text() {
   @extend %t-sage-body-small;
 
+  @include truncate();
+
   color: sage-color(charcoal, 400);
   background-color: sage-color(grey, 200);
   border: $-copy-text-border;

--- a/lib/sage_rails/app/sage_components/sage_copy_button.rb
+++ b/lib/sage_rails/app/sage_components/sage_copy_button.rb
@@ -1,3 +1,4 @@
 class SageCopyButton < SageComponent
   attr_accessor :value
+  attr_accessor :semibold
 end

--- a/lib/sage_rails/app/sage_components/sage_copy_button.rb
+++ b/lib/sage_rails/app/sage_components/sage_copy_button.rb
@@ -1,0 +1,3 @@
+class SageCopyButton < SageComponent
+  attr_accessor :value
+end

--- a/lib/sage_rails/app/sage_components/sage_copy_text.rb
+++ b/lib/sage_rails/app/sage_components/sage_copy_text.rb
@@ -1,0 +1,3 @@
+class SageCopyText < SageComponent
+  attr_accessor :value
+end

--- a/lib/sage_rails/app/sage_components/sage_copy_text.rb
+++ b/lib/sage_rails/app/sage_components/sage_copy_text.rb
@@ -1,3 +1,4 @@
 class SageCopyText < SageComponent
   attr_accessor :value
+  attr_accessor :semibold
 end

--- a/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
+++ b/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
@@ -1,0 +1,2 @@
+class SageCopyTextCard < SageComponent
+end

--- a/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
+++ b/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
@@ -1,2 +1,3 @@
 class SageCopyTextCard < SageComponent
+  attr_accessor :semibold
 end

--- a/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
@@ -1,0 +1,3 @@
+<button class="sage-copy-btn" data-js-copy-button="<%= component.value.html_safe %>">
+  <%= sage_component SageCopyText, { value: component.value } %>
+</button>

--- a/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
@@ -1,3 +1,6 @@
-<button class="sage-copy-btn" data-js-copy-button="<%= component.value.html_safe %>">
-  <%= sage_component SageCopyText, { value: component.value } %>
+<button
+  class="sage-copy-btn"
+  data-js-copy-button="<%= component.value.html_safe %>"
+>
+  <%= sage_component SageCopyText, { value: component.value, semibold: component.semibold.present? && component.semibold } %>
 </button>

--- a/lib/sage_rails/app/views/sage_components/_sage_copy_text.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_copy_text.html.erb
@@ -1,0 +1,3 @@
+<span class="sage-copy-text">
+  <%= component.value.html_safe %>
+</span>

--- a/lib/sage_rails/app/views/sage_components/_sage_copy_text.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_copy_text.html.erb
@@ -1,3 +1,3 @@
-<span class="sage-copy-text">
+<span class="sage-copy-text <%= "sage-copy-text--semibold" if component.semibold.present? && component.semibold %>">
   <%= component.value.html_safe %>
 </span>

--- a/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
@@ -1,0 +1,3 @@
+<div class="sage-copy-text-card">
+  <%= component.content.html_safe %>
+</div>

--- a/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
@@ -1,3 +1,3 @@
-<div class="sage-copy-text-card">
+<div class="sage-copy-text-card <%= "sage-copy-text-card--semibold" if component.semibold.present? && component.semibold %>">
   <%= component.content.html_safe %>
 </div>


### PR DESCRIPTION
## Description

Adds new styles for SageCopyText (inline), SageCopyTextCard (block) and an actual SageCopyButton (`sage-copy-btn`) to handly succinct styling for these related visual elements.

See Elements > Copy Text

### Screenshots

![Screen Shot 2020-10-05 at 12 51 53 PM](https://user-images.githubusercontent.com/17955295/95108692-97559300-0709-11eb-90ef-8809d2067ae1.png)

Non-blocking related PR drafted here: TBD