### PR TITLE
Update SageRails SagePagination component

### DIFF
--- a/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -1,7 +1,16 @@
 class SagePagination < SageComponent
   attr_accessor :items
   attr_accessor :window
-  attr_accessor :pager_params
+  attr_accessor :additional_params
+
+  def initialize(attributes = {})
+    super
+    self.additional_params ||= {}
+  end
+
+  def pager_params=(new_pager_params)
+    self.additional_params = new_pager_params
+  end
 
   def prev_text
     "Back".html_safe

--- a/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -8,10 +8,6 @@ class SagePagination < SageComponent
     self.additional_params ||= {}
   end
 
-  def pager_params=(new_pager_params)
-    self.additional_params = new_pager_params
-  end
-
   def prev_text
     "Back".html_safe
   end

--- a/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -12,7 +12,7 @@
       </li>
       <% else %>
         <li class="sage-pagination__item">
-          <%= link_to_previous_page component.items, component.prev_text, class: "sage-pagination__page", params: component.pager_params %>
+          <%= link_to_previous_page component.items, component.prev_text, class: "sage-pagination__page", params: component.additional_params %>
         </li>
       <% end -%>
 
@@ -26,7 +26,7 @@
       </li>
       <% else %>
       <li class="sage-pagination__item">
-        <%= link_to_next_page component.items, component.next_text, class: "sage-pagination__page", params: component.pager_params %>
+        <%= link_to_next_page component.items, component.next_text, class: "sage-pagination__page", params: component.additional_params %>
       </li>
       <% end -%>
     </ul>


### PR DESCRIPTION
# Description

In https://github.com/Kajabi/kajabi-products/pull/15773, we're changing the `pager` helper so it no longer requires nor accepts `pager_params`. It wasn't needed in most cases, and Kaminari deprecated the way `pager_params` was being used. Instead, `pager` will optionally accept `additional_params`.

This PR updates `SagePagination` so it also optionally accepts `addtional_params`. It'll match `pager`'s behavior in kajabi-products and clear up the Kaminari deprecation warning.`additional_params` defaults to an empty hash so it plays nicely with Kaminari.

`SagePagination` still exposes the ability to set `pager_params` via `#pager_params=`. When `#pager_params=` is called, `additional_params` will be set instead. This will make it easier to switch from `pager_params` to `additional_params` in kajabi-products because both the old and new API will be supported.

## Test notes

There shouldn't be any change in behavior in any pagination links.


## Related
- https://github.com/Kajabi/kajabi-products/pull/15773
