### PR TITLE
Misc rails comp tweaks

### DIFF
--- a/app/helpers/elements_helper.rb
+++ b/app/helpers/elements_helper.rb
@@ -15,12 +15,12 @@ module ElementsHelper
       {
         title: "breadcrumbs",
         description: "Breadcrumbs provide a sense of where we are in the site structure with hyperlinks to previous areas in that structure. Our element also provides a specific \"Back link\" variation",
-        use_legacy_html_code_source: true,
+        use_legacy_html_code_source: false,
         scss: "done",
         docs: "done",
-        rails: "todo",
-        react: "todo",
-        a11y: "todo"
+        rails: "done",
+        react: "done",
+        a11y: "done"
       },
       {
         title: "button",

--- a/app/views/examples/elements/breadcrumbs/_preview.html.erb
+++ b/app/views/examples/elements/breadcrumbs/_preview.html.erb
@@ -1,5 +1,5 @@
 <h4>Default</h4>
-<%= render "examples/elements/breadcrumbs/markup",
+<%= sage_component SageBreadcrumbs, {
   items: [
     {
       text: 'Test 1',
@@ -14,10 +14,10 @@
       url: 'http://example.com/3'
     }
   ]
-%>
+} %>
 
 <h4>Back Link Variation</h4>
-<%= render "examples/elements/breadcrumbs/markup",
+<%= sage_component SageBreadcrumbs, {
   has_back_icon: true,
   items: [
     {
@@ -25,10 +25,10 @@
       url: '#'
     }
   ]
-%>
+} %>
 
 <h4>Progress Bar Variation</h4>
-<%= render "examples/elements/breadcrumbs/markup",
+<%= sage_component SageBreadcrumbs, {
   is_progressbar: true,
   items: [
     {
@@ -45,4 +45,4 @@
       url: 'http://example.com/3'
     }
   ]
-%>
+} %>

--- a/app/views/examples/elements/breadcrumbs/_props.html.erb
+++ b/app/views/examples/elements/breadcrumbs/_props.html.erb
@@ -4,3 +4,24 @@
   <td>Boolean</td>
   <td>false</td>
 </tr>
+<tr>
+  <td><pre>is_progressbar</pre></td>
+  <td>Whether or not to show the breadcrumbs in a progress like fashion.</td>
+  <td>Boolean</td>
+  <td>false</td>
+</tr>
+<tr>
+  <td><pre>items</pre></td>
+  <td>The set of items to display.</td>
+  <td>Array of items following schema</td>
+  <td>
+    <strong>Schema:</strong>
+    <pre>
+{
+  url: {string},
+  text: {string},
+  is_current: {boolean},
+}
+    </pre>  
+  </td>
+</tr>

--- a/app/views/examples/elements/choice/_preview.html.erb
+++ b/app/views/examples/elements/choice/_preview.html.erb
@@ -19,7 +19,9 @@
 
 <h3 class="t-sage-heading-6">Arrow Variation</h3>
 <%= sage_component SageChoice, {
-    target: "example",
+    attributes: {
+      href: "//example.com"
+    },
     text: "Option 1",
     type: "arrow",
   }

--- a/app/views/examples/elements/copy_text/_rules_do.html.erb
+++ b/app/views/examples/elements/copy_text/_rules_do.html.erb
@@ -1,4 +1,4 @@
 <ul>
   <li>Use inline <code>&lt;b&gt;</code> tag to add bolding to select portions of these blocks.</li>
-  <li>Provide a local max-width as desired in order to limit overflowing text. Truncation is setup and ready for this.</li>
+  <li>Provide a local max-width as desired in order to limit overflowing text. Truncation is setup and ready for this by default on the inline Copy Text, but can be turned on for the Copy Text Card with <code>truncate_contents</code> set to <code>true</code>.</li>
 </ul>

--- a/app/views/examples/elements/tab/_preview.html.erb
+++ b/app/views/examples/elements/tab/_preview.html.erb
@@ -1,5 +1,15 @@
+<h6>As a button with a target pane in mind</h6>
 <%= sage_component SageTab, {
     target: "example-tab1",
+    text: "Page 1"
+  }
+%>
+
+<h6>As a link with a route or site in mind</h6>
+<%= sage_component SageTab, {
+    attributes: {
+      href: "//example.com",
+    },
     text: "Page 1"
   }
 %>

--- a/app/views/examples/objects/card/_preview.html.erb
+++ b/app/views/examples/objects/card/_preview.html.erb
@@ -61,6 +61,16 @@
           You can thus add one of the Grid Templates or provide a custom grid template when needed.
           <!-- TODO: Link to come once patterns are settled -->
         </li>
+        <li>
+          <strong><em>Figure</em></strong> —
+          <code>.sage-card__figure</code>
+          can be used to display images, similar to Panel Figures.
+        </li>
+        <li>
+          <strong><em>Divider</em></strong> —
+          <code>.sage-card__divider</code>
+          can be used to display images, similar to Panel Dividers.
+        </li>
       </ul>
       Note: These can also be nested inside each other for compound configurations.
     </li>
@@ -123,5 +133,12 @@
         style: "left"
       }
     } %>
+  <% end %>
+  <strong>Divider (full bleed):</strong>
+  <%= sage_component SageCardDivider, { bleed: true } %>
+
+  <strong>Figure:</strong>
+  <%= sage_component SageCardFigure, {} do %>
+    <%= image_pack_tag("docs/card/card-placeholder-sm.png", alt: "") %>
   <% end %>
 <% end %>

--- a/app/views/examples/objects/panel/_preview.html.erb
+++ b/app/views/examples/objects/panel/_preview.html.erb
@@ -209,12 +209,13 @@ sample_copy = %(
   <%= sage_component SagePanelBlock, { type_block: true } do %>
     <%= sample_copy.html_safe %>
   <% end %>
-  <hr />
+  <%= sage_component SagePanelDivider, {} %>
   <%= sage_component SagePanelSubheader, { title: "Panel subheader here" } %>
   <%= sage_component SagePanelBlock, { type_block: true } do %>
     <%= sample_copy.html_safe %>
   <% end %>
 <% end %>
+<p>Dividers can also be set to extend to the panel edges with the <code>--full-bleed</code> modifier</p>
 
 <h5>Panel Figure <code>.sage-panel__figure</code></h5>
 <p>

--- a/app/views/examples/objects/tabs/_preview.html.erb
+++ b/app/views/examples/objects/tabs/_preview.html.erb
@@ -2,19 +2,29 @@
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
       id: "example-tabs1",
+      navigational: true,
       items: [
         {
           text: "Sub Page 1",
-          target: "basic-test1",
+          #target: "basic-test1",
+          attributes: {
+            href: "//example.com/basic-test1",
+          },
           active: true
         },
         {
           text: "Sub Page 2",
-          target: "basic-test2"
+          #target: "basic-test2"
+          attributes: {
+            href: "//example.com/basic-test2"
+          },
         },
         {
           text: "Sub Page 3",
-          target: "basic-test3"
+          #target: "basic-test3"
+          attributes: {
+            href: "//example.com/basic-test3"
+          },
         },
       ]
     }
@@ -108,25 +118,31 @@
   <% end %>
 </div>
 
-<h3 class="t-sage-heading-6">Choice tabs - arrows in stacked layout</h3>
+<h3 class="t-sage-heading-6">Choice tabs - arrows as links in stacked layout</h3>
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
       id: "example-tabs4",
       items: [
         {
           text: "Sub Page 1",
-          target: "stacked-test1",
+          attributes: {
+            href: "//example.com/#stacked-test1",
+          },
           active: true,
           type: "arrow"
         },
         {
           text: "Sub Page 2",
-          target: "stacked-test2",
+          attributes: {
+            href: "//example.com/#stacked-test2",
+          },
           type: "arrow"
         },
         {
           text: "Sub Page 3",
-          target: "stacked-test3",
+          attributes: {
+            href: "//example.com/#stacked-test3",
+          },
           type: "arrow"
         },
       ],

--- a/app/views/examples/objects/tabs/_preview.html.erb
+++ b/app/views/examples/objects/tabs/_preview.html.erb
@@ -6,7 +6,6 @@
       items: [
         {
           text: "Sub Page 1",
-          #target: "basic-test1",
           attributes: {
             href: "//example.com/basic-test1",
           },
@@ -14,14 +13,12 @@
         },
         {
           text: "Sub Page 2",
-          #target: "basic-test2"
           attributes: {
             href: "//example.com/basic-test2"
           },
         },
         {
           text: "Sub Page 3",
-          #target: "basic-test3"
           attributes: {
             href: "//example.com/basic-test3"
           },

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_choice.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_choice.scss
@@ -12,7 +12,7 @@ $item-arrow: "before";
 .sage-choice {
   @include sage-button-style-reset();
 
-  display: flex;
+  display: inline-flex;
   position: relative;
   align-items: center;
   flex-grow: 1;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
@@ -40,8 +40,17 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
 .sage-copy-text-card {
   @include sage-grid-stack;
   @include sage-copy-text;
-
+  
+  width: 100%;
   padding: $sage-card-padding;
+}
+
+.sage-copy-text-card--truncate-contents {
+  > * {
+    width: 100%;
+
+    @include truncate();
+  }
 }
 
 .sage-copy-btn {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
@@ -19,6 +19,23 @@
   }
 }
 
+.sage-card__divider {
+  margin: 0;
+  padding-top: rem(11px); // 16 - 1px element - 4px bottom padding
+  padding-bottom: rem(4px);
+  border: 0;
+
+  &::before {
+    content: "";
+    display: block;
+    border-top: 1px solid sage-color(grey, 300);
+  }
+}
+
+.sage-card__divider--full-bleed {
+  padding: 0;
+  margin: 0 -#{$sage-card-padding};
+}
 
 .sage-card__figure {
   display: flex;

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -14,8 +14,7 @@
   @include sage-grid-panel();
 }
 
-.sage-panel__divider,
-.sage-panel > hr {
+.sage-panel__divider {
   margin: 0;
   padding-top: rem(11px); // 16 - 1px element - 4px bottom padding
   padding-bottom: rem(4px);
@@ -29,7 +28,8 @@
 }
 
 .sage-panel__divider--full-bleed {
-  margin: 0 -#{$sage-panel-padding} -#{$sage-panel-grid-gap};
+  padding: 0;
+  margin: 0 -#{$sage-panel-padding};
 }
 
 .sage-panel__figure {

--- a/lib/sage_rails/app/sage_components/sage_body.rb
+++ b/lib/sage_rails/app/sage_components/sage_body.rb
@@ -1,3 +1,3 @@
 class SageBody < SageComponent
-  attr_accessor :style_class
+  attr_accessor :css_classes
 end

--- a/lib/sage_rails/app/sage_components/sage_breadcrumbs.rb
+++ b/lib/sage_rails/app/sage_components/sage_breadcrumbs.rb
@@ -1,0 +1,6 @@
+class SageBreadcrumbs < SageComponent
+  attr_accessor :items
+  attr_accessor :is_progressbar
+  attr_accessor :css_classes
+  attr_accessor :has_back_icon
+end

--- a/lib/sage_rails/app/sage_components/sage_card_divider.rb
+++ b/lib/sage_rails/app/sage_components/sage_card_divider.rb
@@ -1,0 +1,3 @@
+class SageCardDivider < SageComponent
+  attr_accessor :bleed
+end

--- a/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -6,4 +6,5 @@ class SageChoice < SageComponent
   attr_accessor :subtext
   attr_accessor :active
   attr_accessor :align_center
+  attr_accessor :attributes
 end

--- a/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
+++ b/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
@@ -1,3 +1,4 @@
 class SageCopyTextCard < SageComponent
   attr_accessor :semibold
+  attr_accessor :truncate_contents
 end

--- a/lib/sage_rails/app/sage_components/sage_tab.rb
+++ b/lib/sage_rails/app/sage_components/sage_tab.rb
@@ -2,4 +2,5 @@ class SageTab < SageComponent
   attr_accessor :target
   attr_accessor :text
   attr_accessor :active
+  attr_accessor :attributes
 end

--- a/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -5,4 +5,5 @@ class SageTabs < SageComponent
   attr_accessor :items
   attr_accessor :progressbar
   attr_accessor :align_items_center
+  attr_accessor :navigational
 end

--- a/lib/sage_rails/app/views/sage_components/_sage_body.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_body.html.erb
@@ -1,3 +1,3 @@
-<body class="sage-page <%= component.style_class ? "#{component.style_class}" : "" %>">
+<body class="sage-page <%= component.css_classes if component.css_classes.present? %>">
   <%= component.content %>
 </body>

--- a/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
@@ -1,0 +1,39 @@
+<% is_progressbar = component.is_progressbar.present? && component.is_progressbar %>
+<nav
+  aria-label="Breadcrumbs"
+  class="
+    sage-breadcrumbs
+    <%= "sage-breadcrumbs--progressbar" if is_progressbar %>
+    <%= css_classes if component.css_classes.present? %>
+  "
+>
+  <% if component.items.length() > 1 %>
+    <ul class="sage-breadcrumbs__list">
+      <% component.items.each_with_index do |item, i| %>
+        <li class="sage-breadcrumbs__item">
+          <a
+            href="<%= item[:url] %>"
+            class="
+              sage-breadcrumbs__link
+              <%= " sage-breadcrumbs__link--current" if defined?(item[:is_current]) && item[:is_current] || !component.is_progressbar && i == (component.items.length() - 1) %>
+            "
+          >
+            <% if i == 0 && defined?(has_back_icon) && has_back_icon %>
+              <i class="sage-breadcrumbs__icon sage-icon-arrow-left" aria-hidden="true"></i>
+            <% end %>
+            <%= item[:text] %>
+          </a>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+  <p class="sage-breadcrumbs__item">
+    <a href="<%= component.items[0][:url] %>" class="sage-breadcrumbs__link" aria-current="page">
+      <% if component.has_back_icon.present? && component.has_back_icon %>
+        <i class="sage-breadcrumbs__icon sage-icon-arrow-left" aria-hidden="true"></i>
+      <% end %>
+      <%= component.items[0][:text] %>
+    </a>  
+  </p>
+  <% end %>
+</nav>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_divider.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_divider.html.erb
@@ -1,0 +1,6 @@
+<hr
+  class="
+    sage-card__divider
+    <%= "sage-card__divider--full-bleed" if component.bleed %>
+  "
+/>

--- a/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -1,6 +1,14 @@
-<% css_active_class = "sage-choice--active" %>
-<button
-  type="button"
+<%
+css_active_class = "sage-choice--active" 
+is_button = !component.attributes&.has_key?(:href)
+html_tag = is_button ? "button" : "a"
+%>
+
+<<%= html_tag %>
+  <%= "type=button" if is_button %>
+  <% component.attributes.each do |key, value| %>
+    <%= "#{key}='#{value}'".html_safe %>
+  <% end if component.attributes&.is_a?(Hash) %>
   class="
     sage-choice
     <%= css_active_class if component.active %>
@@ -26,4 +34,4 @@
       <span class="sage-choice__subtext" aria-hidden="true"><%= component.subtext.html_safe %></span>
     <% end %>
   </div>
-</button>
+</<%= html_tag %>>

--- a/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
@@ -1,3 +1,8 @@
-<div class="sage-copy-text-card <%= "sage-copy-text-card--semibold" if component.semibold.present? && component.semibold %>">
+<div class="
+    sage-copy-text-card
+    <%= "sage-copy-text-card--semibold" if component.semibold.present? && component.semibold %>
+    <%= "sage-copy-text-card--truncate-contents" if component.truncate_contents.present? && component.truncate_contents %>
+  "
+>
   <%= component.content.html_safe %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
@@ -1,15 +1,22 @@
-<% css_active_class = "sage-tab--active" %>
+<% 
+css_active_class = "sage-tab--active"
+is_button = !component.attributes&.has_key?(:href)
+html_tag = is_button ? "button" : "a"
+%>
 
-<button
-  type="button"
+<<%= html_tag %>
+  <%= "type=button" if is_button %>
+  <% component.attributes.each do |key, value| %>
+    <%= "#{key}='#{value}'".html_safe %>
+  <% end if component.attributes&.is_a?(Hash) %>
   class="
     sage-tab <%= css_active_class if component.active %>"
   data-js-tabs-target="<%= component.target %>"
   data-sage-active-class="<%= css_active_class %>"
   role="tab"
-  aria-controls="<%= component.target %>"
+  aria-controls="<%= component.target.present? %>"
 >
   <% if component.text.present? %>
     <%= component.text.html_safe %>
   <% end %>
-</button>
+</<%= html_tag %>>

--- a/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -1,5 +1,5 @@
 <nav
-  data-js-tabs="<%= component.id %>"
+  <%= "data-js-tabs=\"#{component.id}\"" if !component.navigational %>
   class="sage-tabs
     <%= component.stacked.present? ? "sage-tabs--layout-stacked" : "sage-tabs--layout-default" %>
     <%= "sage-tabs--progressbar" if component.progressbar.present? && component.progressbar == true %>
@@ -15,13 +15,15 @@
         subtext: item[:subtext],
         active: item[:active],
         type: item[:type],
-        icon: item[:icon]
+        icon: item[:icon],
+        attributes: item[:attributes]
       %>
     <% else %>
       <%= sage_component SageTab,
         target: item[:target],
         text: item[:text],
-        active: item[:active]
+        active: item[:active],
+        attributes: item[:attributes]
       %>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Description

Makes a series of small tweaks as follows:

- Allow for hyperlinks in tab and choice
- Adjust width and truncation on Copy Text Card
- Add breadcrumbs as sage component
- Conform SageBody to `css_classes` prop. **NOTE:** Causes breaking change on `products` until the implementation of this component is synched with this change.
- Update panel divider full bleed and add card divider