### PR TITLE
Revise SageOutline to allow all elements to live at the same html depth

### DIFF
--- a/app/views/examples/objects/outline_item/_preview.html.erb
+++ b/app/views/examples/objects/outline_item/_preview.html.erb
@@ -1,6 +1,9 @@
 <% 3.times do %>
   <%= sage_component SageOutlineItem, {
     title: "Wonderful Denim Pants",
+    icon: "folder",
+    depth: 0,
+    category: true,
     status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
     actions_primary: [sage_component(SageButton, {
       value: "Add Content",
@@ -21,10 +24,13 @@
         attributes: { "data-js-tooltip": "Preview" }
       })
     ]
-  } do %>
+  } %>
+  <% 3.times do %>
     <%= sage_component SageOutlineItem, {
       title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
-      icon: "file",
+      icon: "video-on",
+      depth: 1,
+      category: false,
       status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
       actions_primary: [sage_component(SageButton, {
         value: "Add Content",
@@ -46,84 +52,59 @@
         })
       ]
     } %>
-    <% 3.times do %>
-      <%= sage_component SageOutlineItem, {
-        title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
-
-        icon: "video-on",
-        status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
-        actions_primary: [sage_component(SageButton, {
-          value: "Add Content",
-          style: "secondary",
-          icon: {style: "left", name: "add-circle"}
-        })],
-        actions_secondary: [
-          sage_component(SageButton, {
-            value: "Edit",
-            style: "tertiary",
-            icon: {style: "only", name: "pen"},
-            attributes: { "data-js-tooltip": "Edit" }
-          }),
-          sage_component(SageButton, {
-            value: "Preview",
-            style: "tertiary",
-            icon: {style: "only", name: "preview-on"},
-            attributes: { "data-js-tooltip": "Preview" }
-          })
-        ]
-      } %>
-    <% end %>
-      <%= sage_component SageOutlineItem, {
-        title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
-
-        status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
-        actions_primary: [sage_component(SageButton, {
-          value: "Add Content",
-          style: "secondary",
-          icon: {style: "left", name: "add-circle"}
-        })],
-        actions_secondary: [
-          sage_component(SageButton, {
-            value: "Edit",
-            style: "tertiary",
-            icon: {style: "only", name: "pen"},
-            attributes: { "data-js-tooltip": "Edit" }
-          }),
-          sage_component(SageButton, {
-            value: "Preview",
-            style: "tertiary",
-            icon: {style: "only", name: "preview-on"},
-            attributes: { "data-js-tooltip": "Preview" }
-          })
-        ]
-      }  do %>
-      <% 3.times do %>
-        <%= sage_component SageOutlineItem, {
-          title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
-
-          icon: "form",
-          status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
-          actions_primary: [sage_component(SageButton, {
-            value: "Add Content",
-            style: "secondary",
-            icon: {style: "left", name: "add-circle"}
-          })],
-          actions_secondary: [
-            sage_component(SageButton, {
-              value: "Edit",
-              style: "tertiary",
-              icon: {style: "only", name: "pen"},
-              attributes: { "data-js-tooltip": "Edit" }
-            }),
-            sage_component(SageButton, {
-              value: "Preview",
-              style: "tertiary",
-              icon: {style: "only", name: "preview-on"},
-              attributes: { "data-js-tooltip": "Preview" }
-            })
-          ]
-        } %>
-      <% end %>
-    <% end %>
+  <% end %>
+  <%= sage_component SageOutlineItem, {
+    title: "Wonderful Denim Pants",
+    icon: "arrow-corner",
+    depth: 1,
+    category: true,
+    status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+    actions_primary: [sage_component(SageButton, {
+      value: "Add Content",
+      style: "secondary",
+      icon: {style: "left", name: "add-circle"}
+    })],
+    actions_secondary: [
+      sage_component(SageButton, {
+        value: "Edit",
+        style: "tertiary",
+        icon: {style: "only", name: "pen"},
+        attributes: { "data-js-tooltip": "Edit" }
+      }),
+      sage_component(SageButton, {
+        value: "Preview",
+        style: "tertiary",
+        icon: {style: "only", name: "preview-on"},
+        attributes: { "data-js-tooltip": "Preview" }
+      })
+    ]
+  } %>
+  <% 3.times do %>
+    <%= sage_component SageOutlineItem, {
+      title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
+      icon: "video-on",
+      depth: 2,
+      category: false,
+      status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+      actions_primary: [sage_component(SageButton, {
+        value: "Add Content",
+        style: "secondary",
+        icon: {style: "left", name: "add-circle"}
+      })],
+      actions_secondary: [
+        sage_component(SageButton, {
+          value: "Edit",
+          style: "tertiary",
+          icon: {style: "only", name: "pen"},
+          attributes: { "data-js-tooltip": "Edit" }
+        }),
+        sage_component(SageButton, {
+          value: "Preview",
+          style: "tertiary",
+          icon: {style: "only", name: "preview-on"},
+          attributes: { "data-js-tooltip": "Preview" }
+        })
+      ]
+    } %>
   <% end %>
 <% end %>

--- a/app/views/examples/objects/outline_item/_preview.html.erb
+++ b/app/views/examples/objects/outline_item/_preview.html.erb
@@ -1,63 +1,35 @@
+<%= sage_component SageOutlineItem, {
+  title: "Wonderful Denim Pants",
+  icon: "folder",
+  depth: 0,
+  category: true,
+  status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+  actions_primary: [sage_component(SageButton, {
+    value: "Add Content",
+    style: "secondary",
+    icon: {style: "left", name: "add-circle"}
+  })],
+  actions_secondary: [
+    sage_component(SageButton, {
+      value: "Edit",
+      style: "tertiary",
+      icon: {style: "only", name: "pen"},
+      attributes: { "data-js-tooltip": "Edit" }
+    }),
+    sage_component(SageButton, {
+      value: "Preview",
+      style: "tertiary",
+      icon: {style: "only", name: "preview-on"},
+      attributes: { "data-js-tooltip": "Preview" }
+    })
+  ]
+} %>
 <% 3.times do %>
   <%= sage_component SageOutlineItem, {
-    title: "Wonderful Denim Pants",
-    icon: "folder",
-    depth: 0,
-    category: true,
-    status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
-    actions_primary: [sage_component(SageButton, {
-      value: "Add Content",
-      style: "secondary",
-      icon: {style: "left", name: "add-circle"}
-    })],
-    actions_secondary: [
-      sage_component(SageButton, {
-        value: "Edit",
-        style: "tertiary",
-        icon: {style: "only", name: "pen"},
-        attributes: { "data-js-tooltip": "Edit" }
-      }),
-      sage_component(SageButton, {
-        value: "Preview",
-        style: "tertiary",
-        icon: {style: "only", name: "preview-on"},
-        attributes: { "data-js-tooltip": "Preview" }
-      })
-    ]
-  } %>
-  <% 3.times do %>
-    <%= sage_component SageOutlineItem, {
-      title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
-      icon: "video-on",
-      depth: 1,
-      category: false,
-      status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
-      actions_primary: [sage_component(SageButton, {
-        value: "Add Content",
-        style: "secondary",
-        icon: {style: "left", name: "add-circle"}
-      })],
-      actions_secondary: [
-        sage_component(SageButton, {
-          value: "Edit",
-          style: "tertiary",
-          icon: {style: "only", name: "pen"},
-          attributes: { "data-js-tooltip": "Edit" }
-        }),
-        sage_component(SageButton, {
-          value: "Preview",
-          style: "tertiary",
-          icon: {style: "only", name: "preview-on"},
-          attributes: { "data-js-tooltip": "Preview" }
-        })
-      ]
-    } %>
-  <% end %>
-  <%= sage_component SageOutlineItem, {
-    title: "Wonderful Denim Pants",
-    icon: "arrow-corner",
+    title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
+    icon: "video-on",
     depth: 1,
-    category: true,
+    category: false,
     status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
     actions_primary: [sage_component(SageButton, {
       value: "Add Content",
@@ -79,32 +51,58 @@
       })
     ]
   } %>
-  <% 3.times do %>
-    <%= sage_component SageOutlineItem, {
-      title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
-      icon: "video-on",
-      depth: 2,
-      category: false,
-      status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
-      actions_primary: [sage_component(SageButton, {
-        value: "Add Content",
-        style: "secondary",
-        icon: {style: "left", name: "add-circle"}
-      })],
-      actions_secondary: [
-        sage_component(SageButton, {
-          value: "Edit",
-          style: "tertiary",
-          icon: {style: "only", name: "pen"},
-          attributes: { "data-js-tooltip": "Edit" }
-        }),
-        sage_component(SageButton, {
-          value: "Preview",
-          style: "tertiary",
-          icon: {style: "only", name: "preview-on"},
-          attributes: { "data-js-tooltip": "Preview" }
-        })
-      ]
-    } %>
-  <% end %>
+<% end %>
+<%= sage_component SageOutlineItem, {
+  title: "Wonderful Denim Pants",
+  icon: "arrow-corner",
+  depth: 1,
+  category: true,
+  status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+  actions_primary: [sage_component(SageButton, {
+    value: "Add Content",
+    style: "secondary",
+    icon: {style: "left", name: "add-circle"}
+  })],
+  actions_secondary: [
+    sage_component(SageButton, {
+      value: "Edit",
+      style: "tertiary",
+      icon: {style: "only", name: "pen"},
+      attributes: { "data-js-tooltip": "Edit" }
+    }),
+    sage_component(SageButton, {
+      value: "Preview",
+      style: "tertiary",
+      icon: {style: "only", name: "preview-on"},
+      attributes: { "data-js-tooltip": "Preview" }
+    })
+  ]
+} %>
+<% 3.times do %>
+  <%= sage_component SageOutlineItem, {
+    title: "Amazing Item Here, It Has A Very Long Name, Lorem Ipsum Sit Dolar",
+    icon: "video-on",
+    depth: 2,
+    category: false,
+    status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+    actions_primary: [sage_component(SageButton, {
+      value: "Add Content",
+      style: "secondary",
+      icon: {style: "left", name: "add-circle"}
+    })],
+    actions_secondary: [
+      sage_component(SageButton, {
+        value: "Edit",
+        style: "tertiary",
+        icon: {style: "only", name: "pen"},
+        attributes: { "data-js-tooltip": "Edit" }
+      }),
+      sage_component(SageButton, {
+        value: "Preview",
+        style: "tertiary",
+        icon: {style: "only", name: "preview-on"},
+        attributes: { "data-js-tooltip": "Preview" }
+      })
+    ]
+  } %>
 <% end %>

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -62,9 +62,8 @@ $-collapse-breakpoint-key: md-max;
   }
 
   &.sage-outline-item--is-dragging {
-    border-radius: sage-border(radius);
-    border-color: transparent;
-    box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(grey, 500);
+    border: unset;
+    box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(grey, 300);
 
     // NOTE: Forces hardware acceleration, this resolves issue with HTML5 Drag & Drop
     //       API drag-preview 'capture' action in webkit browsers.
@@ -79,7 +78,23 @@ $-collapse-breakpoint-key: md-max;
     }
   }
 
+  &.sage-outline-item--is-dragging-descendant {
+    border: unset;
+    box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(grey, 300);
+
+    .sage-outline-item__actions-primary,
+    .sage-outline-item__actions-secondary,
+    .sage-outline-item__handle-collapse {
+      visibility: hidden;
+    }
+
+    > * {
+      opacity: 0.5;
+    }
+  }
+
   &.sage-outline-item--is-droptarget {
+    border-radius: sage-border(radius-large);
     box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(primary), inset 0 0 0 5px sage-color(white);
     background: repeating-linear-gradient(
       45deg,
@@ -95,6 +110,7 @@ $-collapse-breakpoint-key: md-max;
   }
 
   &.sage-outline-item--is-droptarget-invalid {
+    border-radius: sage-border(radius-large);
     box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(red, 200), inset 0 0 0 5px sage-color(white);
     background: repeating-linear-gradient(
       45deg,

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -2,6 +2,16 @@
   ** outline-item
   type: object
 
+  This is a unicorn component built for the SortableTree/Product-Outline
+  React component within Kajabi-Products. The current implementation
+  uses the raw css classes defined here rather than using a SageReact
+  component. This was done because the logic governing dragging & sorting
+  is tightly knit to the class modifiers provided in this file. A refactor
+  to a SageReact component is targeted at the end of this cycle. However, until
+  we can account for the entire featureset required for the Product Outline, we
+  consider a SageReact component premature optimization.
+
+  Component Owner: Product-Build UXD
 
 ================================================== */
 
@@ -11,11 +21,20 @@ $-collapse-breakpoint-key: md-max;
   display: grid;
   align-items: center;
   grid-template-rows: repeat(auto-fit, auto);
-  background: sage-color(white);
   grid-column-gap: sage-spacing(xs);
+  background: sage-color(white);
   will-change: background, box-shadow;
 
-  // Note: The height of this element is defined by its container
+  // NOTE: Height is governed by a parent React node to allow us
+  //       to dynamically adjust the height of elements depending
+  //       on the size of the dataset provided. If the dataset
+  //       is large we 'normalize' all of the node heights to
+  //       allow them to be predictably virtualized in a shodow
+  //       DOM when not visible. This prevents browser lag. For
+  //       small datasets, Categories have a larger height than
+  //       regular Outline Items
+  //
+  // stylelint-disable-next-line order/properties-order
   height: 100%;
 
   @media (min-width: sage-breakpoint($-collapse-breakpoint-key)) {
@@ -42,13 +61,20 @@ $-collapse-breakpoint-key: md-max;
 
   &.sage-outline-item--is-dragging {
     border-radius: sage-border(radius);
-    border: none;
+    border-color: transparent;
     box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(grey, 500);
-    transform: translateZ(0); // REQUIRED TO RESOLVE CHROME BUG – forces hardware acceleration
+
+    // NOTE: Forces hardware acceleration, this resolves issue with HTML5 Drag & Drop
+    //       API drag-preview 'capture' action in webkit browsers.
+    //
+    // stylelint-disable-next-line order/properties-order
+    transform: translateZ(0);
 
     .sage-outline-item__actions-primary,
     .sage-outline-item__actions-secondary,
-    .sage-outline-item__handle-collapse { visibility: hidden; }
+    .sage-outline-item__handle-collapse {
+      visibility: hidden;
+    }
   }
 
   &.sage-outline-item--is-droptarget {
@@ -61,7 +87,9 @@ $-collapse-breakpoint-key: md-max;
       sage-color(white) 24px
     );
 
-    > * { visibility: hidden; }
+    > * {
+      visibility: hidden;
+    }
   }
 
   &.sage-outline-item--is-droptarget-invalid {
@@ -74,7 +102,9 @@ $-collapse-breakpoint-key: md-max;
       sage-color(white) 24px
     );
 
-    > * { visibility: hidden; }
+    > * {
+      visibility: hidden;
+    }
   }
 
   &.sage-outline-item--depth-0 {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -11,7 +11,6 @@ $-collapse-breakpoint-key: md-max;
   display: grid;
   align-items: center;
   grid-template-rows: repeat(auto-fit, auto);
-  border: 1px solid transparent;
   background: sage-color(white);
   grid-column-gap: sage-spacing(xs);
 
@@ -37,14 +36,18 @@ $-collapse-breakpoint-key: md-max;
   }
 
   &.sage-outline-item--category {
-    border-top: sage-border();
     border-bottom: sage-border();
   }
 
   &.sage-outline-item--is-dragging {
-    border: 1px dashed sage-color(primary);
-    background: sage-color(primary, 100);
+    border-radius: sage-border(radius-large);
+    box-shadow: inset 0 0 0 2px sage-color(white), inset 0 0 0 3px sage-color(primary);
     transform: translateZ(0); // REQUIRED TO RESOLVE CHROME BUG – forces hardware acceleration
+  }
+
+  &.sage-outline-item--is-droptarget {
+    background: sage-color(primary, 100);
+    > * { visibility: hidden; }
   }
 
   &.sage-outline-item--depth-0 {
@@ -56,16 +59,16 @@ $-collapse-breakpoint-key: md-max;
       // no-op
     }
     &.sage-outline-item--category {
-      padding-left: sage-spacing(lg);
+      margin-left: sage-spacing(lg);
     }
   }
 
   &.sage-outline-item--depth-2 {
     &:not(.sage-outline-item--category) {
-      padding-left: sage-spacing(lg);
+      margin-left: sage-spacing(lg);
     }
     &.sage-outline-item--category {
-      padding-left: sage-spacing(xl);
+      margin-left: sage-spacing(xl);
     }
   }
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -34,8 +34,10 @@ $-collapse-breakpoint-key: md-max;
   //       small datasets, Categories have a larger height than
   //       regular Outline Items
   //
-  // stylelint-disable-next-line order/properties-order
+  // stylelint-disable order/properties-order
   height: 100%;
+  max-height: rem(80px);
+  // stylelint-enable order/properties-order
 
   @media (min-width: sage-breakpoint($-collapse-breakpoint-key)) {
     // Using static column values to ensure alignment

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -8,24 +8,10 @@
 $-collapse-breakpoint-key: md-max;
 
 .sage-outline-item {
-  overflow: hidden;
-  margin-bottom: sage-spacing(xs);
-  background-color: sage-color(white);
-  border: sage-border();
-  border-radius: sage-border(radius);
-
-  & & {
-    margin-bottom: 0;
-    border: unset;
-    border-radius: unset;
-  }
-}
-
-.sage-outline-item__content {
   display: grid;
   align-items: center;
   grid-template-rows: repeat(auto-fit, auto);
-  grid-column-gap: sage-spacing(sm);
+  grid-column-gap: sage-spacing(xs);
   padding-right: sage-spacing(sm);
   padding-left: sage-spacing(md);
 
@@ -43,30 +29,40 @@ $-collapse-breakpoint-key: md-max;
       ". actions-primary . handle-collapse";
   }
 
-  .sage-outline-item--category > & {
-    padding-top: sage-spacing(sm);
-    padding-bottom: sage-spacing(sm);
-    border-bottom: sage-border();
-  }
-
-  :not(.sage-outline-item--category) > & {
+  &:not(.sage-outline-item--category) {
     padding-top: sage-spacing(xs);
     padding-bottom: sage-spacing(xs);
     border-bottom: sage-border(light);
   }
 
-  :not(.sage-outline-item--category):last-child > & {
-    border-bottom: unset;
+  &.sage-outline-item--category {
+    padding-top: sage-spacing(sm);
+    padding-bottom: sage-spacing(sm);
+    border-bottom: sage-border();
+    border-top: sage-border();
   }
 
-  /* stylelint-disable selector-max-compound-selectors */
-  // Nested Item Identention
-  // Indents `type-category` that is 1-level deep and anything that is 2-levels deep
-  .sage-outline-item__children .sage-outline-item.sage-outline-item--category &,
-  .sage-outline-item__children .sage-outline-item.sage-outline-item--category .sage-outline-item__children & {
-    padding-left: sage-spacing(xl);
+  &.sage-outline-item--depth-0 {
+    // no-op
   }
-  /* stylelint-enable selector-max-compound-selectors */
+
+  &.sage-outline-item--depth-1 {
+    &:not(.sage-outline-item--category) {
+      padding-left: 0;
+    }
+    &.sage-outline-item--category {
+      padding-left: sage-spacing(lg);
+    }
+  }
+
+  &.sage-outline-item--depth-2 {
+    &:not(.sage-outline-item--category) {
+      padding-left: sage-spacing(lg);
+    }
+    &.sage-outline-item--category {
+      padding-left: sage-spacing(xl);
+    }
+  }
 }
 
 .sage-outline-item__title {
@@ -74,11 +70,11 @@ $-collapse-breakpoint-key: md-max;
   color: sage-color(charcoal, 400);
   @include truncate;
 
-  .sage-outline-item--category > .sage-outline-item__content & {
+  .sage-outline-item--category & {
     @extend %t-sage-body-semi;
   }
 
-  :not(.sage-outline-item--category) > .sage-outline-item__content & {
+  :not(.sage-outline-item--category) & {
     @extend %t-sage-body;
   }
 }
@@ -124,33 +120,20 @@ $-collapse-breakpoint-key: md-max;
     color: sage-color(charcoal, 200);
   }
 
-  /* stylelint-disable selector-max-compound-selectors */
-  // Category: Standard
-  .sage-outline-item--category > .sage-outline-item__content &::before {
-    content: sage-icon(folder);
+  .sage-outline-item--category &::before {
     color: sage-color(primary);
   }
 
-  // Category: Nested
-  .sage-outline-item__children .sage-outline-item--category > .sage-outline-item__content &::before {
-    content: sage-icon(arrow-corner);
-    color: sage-color(primary);
-  }
-  /* stylelint-enable selector-max-compound-selectors */
-
-  /* stylelint-disable declaration-no-important */
-  // Universal Hover For All
-  .sage-outline-item__content:hover > & {
+  .sage-outline-item:hover > & {
     &::before {
-      content: sage-icon(handle) !important;
-      color: sage-color(charcoal, 100) !important;
+      content: sage-icon(handle);
+      color: sage-color(charcoal, 100);
     }
 
     &:hover::before {
-      color: sage-color(primary) !important;
+      color: sage-color(primary);
     }
   }
-  /* stylelint-enable declaration-no-important */
 }
 
 .sage-outline-item__handle-collapse {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -11,8 +11,9 @@ $-collapse-breakpoint-key: md-max;
   display: grid;
   align-items: center;
   grid-template-rows: repeat(auto-fit, auto);
+  border: 1px solid transparent;
+  background: sage-color(white);
   grid-column-gap: sage-spacing(xs);
-  padding-right: sage-spacing(sm);
 
   // Note: The height of this element is defined by its container
   height: 100%;
@@ -38,6 +39,12 @@ $-collapse-breakpoint-key: md-max;
   &.sage-outline-item--category {
     border-top: sage-border();
     border-bottom: sage-border();
+  }
+
+  &.sage-outline-item--is-dragging {
+    border: 1px dashed sage-color(primary);
+    background: sage-color(primary, 100);
+    transform: translateZ(0); // REQUIRED TO RESOLVE CHROME BUG – forces hardware acceleration
   }
 
   &.sage-outline-item--depth-0 {
@@ -67,10 +74,6 @@ $-collapse-breakpoint-key: md-max;
   grid-area: title;
   color: sage-color(charcoal, 400);
   @include truncate;
-
-  .sage-outline-item--is-dragging & {
-    background: pink;
-  }
 
   .sage-outline-item--category & {
     @extend %t-sage-body-semi;
@@ -107,6 +110,7 @@ $-collapse-breakpoint-key: md-max;
   display: flex;
   grid-area: status;
   justify-content: flex-end;
+  transform: none;
 }
 
 .sage-outline-item__handle-drag {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -13,7 +13,9 @@ $-collapse-breakpoint-key: md-max;
   grid-template-rows: repeat(auto-fit, auto);
   grid-column-gap: sage-spacing(xs);
   padding-right: sage-spacing(sm);
-  padding-left: sage-spacing(md);
+
+  // Note: The height of this element is defined by its container
+  height: 100%;
 
   @media (min-width: sage-breakpoint($-collapse-breakpoint-key)) {
     // Using static column values to ensure alignment
@@ -30,16 +32,12 @@ $-collapse-breakpoint-key: md-max;
   }
 
   &:not(.sage-outline-item--category) {
-    padding-top: sage-spacing(xs);
-    padding-bottom: sage-spacing(xs);
     border-bottom: sage-border(light);
   }
 
   &.sage-outline-item--category {
-    padding-top: sage-spacing(sm);
-    padding-bottom: sage-spacing(sm);
-    border-bottom: sage-border();
     border-top: sage-border();
+    border-bottom: sage-border();
   }
 
   &.sage-outline-item--depth-0 {
@@ -48,7 +46,7 @@ $-collapse-breakpoint-key: md-max;
 
   &.sage-outline-item--depth-1 {
     &:not(.sage-outline-item--category) {
-      padding-left: 0;
+      // no-op
     }
     &.sage-outline-item--category {
       padding-left: sage-spacing(lg);
@@ -69,6 +67,10 @@ $-collapse-breakpoint-key: md-max;
   grid-area: title;
   color: sage-color(charcoal, 400);
   @include truncate;
+
+  .sage-outline-item--is-dragging & {
+    background: pink;
+  }
 
   .sage-outline-item--category & {
     @extend %t-sage-body-semi;
@@ -109,6 +111,7 @@ $-collapse-breakpoint-key: md-max;
 
 .sage-outline-item__handle-drag {
   grid-area: handle-drag;
+  padding-left: sage-spacing(sm);
   cursor: grab;
 
   &:active {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -13,6 +13,7 @@ $-collapse-breakpoint-key: md-max;
   grid-template-rows: repeat(auto-fit, auto);
   background: sage-color(white);
   grid-column-gap: sage-spacing(xs);
+  will-change: background, box-shadow;
 
   // Note: The height of this element is defined by its container
   height: 100%;
@@ -40,13 +41,39 @@ $-collapse-breakpoint-key: md-max;
   }
 
   &.sage-outline-item--is-dragging {
-    border-radius: sage-border(radius-large);
-    box-shadow: inset 0 0 0 2px sage-color(white), inset 0 0 0 3px sage-color(primary);
+    border-radius: sage-border(radius);
+    border: none;
+    box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(grey, 500);
     transform: translateZ(0); // REQUIRED TO RESOLVE CHROME BUG – forces hardware acceleration
+
+    .sage-outline-item__actions-primary,
+    .sage-outline-item__actions-secondary,
+    .sage-outline-item__handle-collapse { visibility: hidden; }
   }
 
   &.sage-outline-item--is-droptarget {
-    background: sage-color(primary, 100);
+    box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(primary), inset 0 0 0 5px sage-color(white);
+    background: repeating-linear-gradient(
+      45deg,
+      sage-color(grey, 300) 0,
+      sage-color(grey, 300) 12px,
+      sage-color(white) 12px,
+      sage-color(white) 24px
+    );
+
+    > * { visibility: hidden; }
+  }
+
+  &.sage-outline-item--is-droptarget-invalid {
+    box-shadow: inset 0 0 0 1px sage-color(white), inset 0 0 0 2px sage-color(red, 200), inset 0 0 0 5px sage-color(white);
+    background: repeating-linear-gradient(
+      45deg,
+      sage-color(red, 200) 0,
+      sage-color(red, 200) 12px,
+      sage-color(white) 12px,
+      sage-color(white) 24px
+    );
+
     > * { visibility: hidden; }
   }
 

--- a/lib/sage_rails/app/sage_components/sage_outline_item.rb
+++ b/lib/sage_rails/app/sage_components/sage_outline_item.rb
@@ -4,4 +4,6 @@ class SageOutlineItem < SageComponent
   attr_accessor :actions_primary
   attr_accessor :status
   attr_accessor :icon
+  attr_accessor :depth
+  attr_accessor :category
 end

--- a/lib/sage_rails/app/views/sage_components/_sage_outline_item.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_outline_item.html.erb
@@ -1,54 +1,46 @@
-<% is_category = component.content.present? %>
-
 <section class="
     sage-outline-item
-    <%= "sage-outline-item--category" if is_category %>
+    <%= "sage-outline-item--category" if component.category %>
+    <%= "sage-outline-item--depth-#{component.depth}" if component.depth %>
   "
 >
-  <div class="sage-outline-item__content">
-    <div
-      class="
-        sage-outline-item__handle-drag
-        <%= "sage-icon-#{component.icon}" if component.icon && !is_category %>
-      "
-      title="Click to drag"
-    ></div>
-    <h1 class="sage-outline-item__title">
-      <%= component.title %>
-    </h1>
-    <% if component.actions_primary %>
-      <div class="sage-outline-item__actions-primary">
-        <% component.actions_primary.each do |primary| %>
-          <%= primary.html_safe %>
-        <% end %>
-      </div>
-    <% end %>
-    <% if component.actions_secondary %>
-      <div class="sage-outline-item__actions-secondary">
-        <% component.actions_secondary.each do |secondary| %>
-          <%= secondary.html_safe %>
-        <% end %>
-      </div>
-    <% end %>
-    <% if component.status %>
-      <div class="sage-outline-item__status">
-        <%= component.status.html_safe %>
-      </div>
-    <% end %>
-    <% if is_category %>
-      <div class="sage-outline-item__handle-collapse">
-        <%= sage_component SageButton, {
-          value: "Add Content",
-          style: "tertiary",
-          icon: {style: "only", name: "caret-down"},
-          attributes: { "data-js-tooltip": "Collapse" }
-        } %>
-      </div>
-    <% end %>
-  </div>
-  <% if is_category %>
-    <div class="sage-outline-item__children">
-      <%= component.content %>
+  <div
+    class="
+      sage-outline-item__handle-drag
+      <%= "sage-icon-#{component.icon}" if component.icon %>
+    "
+    title="Click to drag"
+  ></div>
+  <h1 class="sage-outline-item__title">
+    <%= component.title %>
+  </h1>
+  <% if component.actions_primary %>
+    <div class="sage-outline-item__actions-primary">
+      <% component.actions_primary.each do |primary| %>
+        <%= primary.html_safe %>
+      <% end %>
+    </div>
+  <% end %>
+  <% if component.actions_secondary %>
+    <div class="sage-outline-item__actions-secondary">
+      <% component.actions_secondary.each do |secondary| %>
+        <%= secondary.html_safe %>
+      <% end %>
+    </div>
+  <% end %>
+  <% if component.status %>
+    <div class="sage-outline-item__status">
+      <%= component.status.html_safe %>
+    </div>
+  <% end %>
+  <% if component.category %>
+    <div class="sage-outline-item__handle-collapse">
+      <%= sage_component SageButton, {
+        value: "Add Content",
+        style: "tertiary",
+        icon: {style: "only", name: "caret-down"},
+        attributes: { "data-js-tooltip": "Collapse" }
+      } %>
     </div>
   <% end %>
 </section>


### PR DESCRIPTION
This reduces style logic that is better handled with react logic...
- Revise SageOutline to allow all elements to live at the same html depth
- Explicitly take an icon arg rather than attempting to add the correct "folder" icon depending on depth
- Remove the "Card" concept visually. This can be inserted into a card now.
- Add additional states that handle dragging and droptarget visual treatments
- Force outline items to grow to this size of their parent container (required for how React is calculating drag and drop locations)

Adds 6 new modifiers:
`sage-outline--category`
`sage-outline--depth-<number>`
`sage-outline--is-dragging`
`sage-outline--is-dragging-descendant`
`sage-outline--is-droptarget`
`sage-outline--is-droptarget-invalid`

Screencap:
![image](https://user-images.githubusercontent.com/565743/95387789-3e2f6000-08bf-11eb-9f8b-427609a18583.png)
