### PR TITLE
Patches issue with checkbox being squished

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_dropdown.scss
@@ -163,6 +163,8 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 .sage-dropdown__item-label {
   @include truncate();
 
+  flex: 1;
+
   .sage-dropdown__item-checkbox + & {
     margin-left: sage-spacing(xs);
   }


### PR DESCRIPTION
## Description

Makes a patch to ensure that dropdown item labels truncate when they're long rather than squishing the checkbox.

### Screenshots

|  before  |  after  |
|--------|--------|
| ![Screen Shot 2020-10-20 at 10 50 12 AM](https://user-images.githubusercontent.com/17955295/96603550-204ffb00-12c2-11eb-99de-e67ba62bc454.png) | ![Screen Shot 2020-10-20 at 10 50 01 AM](https://user-images.githubusercontent.com/17955295/96603568-2514af00-12c2-11eb-8689-e7021f15f656.png) |
