### PR TITLE
[Rails] Fix Broken :html_attributes Concatenation

### DIFF
--- a/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/lib/sage_rails/app/sage_components/sage_component.rb
@@ -41,7 +41,7 @@ class SageComponent
     raise ArgumentError.new("SageComponent expects :html_attributes to be a hash") unless html_attributes_hash.is_a?(Hash)
 
     html_attributes_hash.each do |key, value|
-      generated_html_attributes << " #{key}=#{value.to_s}".html_safe
+      generated_html_attributes << " #{key}=\"#{value.to_s}\"".html_safe
     end
   end
 

--- a/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -2,6 +2,7 @@ class SagePagination < SageComponent
   attr_accessor :items
   attr_accessor :window
   attr_accessor :additional_params
+  attr_accessor :pager_params
 
   def initialize(attributes = {})
     super
@@ -25,7 +26,7 @@ class SagePagination < SageComponent
     else
       first = collection.offset_value + 1
       last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
-      "<strong>#{first}</strong> - <strong>#{last}</strong> of <strong>#{collection.total_count}</strong> Records" 
+      "<strong>#{first}</strong> - <strong>#{last}</strong> of <strong>#{collection.total_count}</strong> Records"
     end.html_safe
   end
 

--- a/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
@@ -5,7 +5,7 @@
     <%= "sage-card--clear-padding-bottom" if component.clear_bottom_padding %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_block.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_block.html.erb
@@ -4,7 +4,7 @@
     <%= "sage-type" if component.type_block && component.type_block == true %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_figure.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_figure.html.erb
@@ -4,7 +4,7 @@
     <%= "sage-card__figure--wistia" if component.is_wistia %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_footer.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_footer.html.erb
@@ -3,7 +3,7 @@
     <%= "sage-card__footer--align-spread" if component.align_spread %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_header.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_header.html.erb
@@ -1,6 +1,6 @@
 <header
   class="sage-card__header <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.title %>
     <h1 class="sage-card__title">

--- a/lib/sage_rails/app/views/sage_components/_sage_card_list.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_list.html.erb
@@ -1,6 +1,6 @@
 <ul
   class="sage-card__list <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </ul>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_list_item.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_list_item.html.erb
@@ -4,7 +4,7 @@
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </li>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_row.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_row.html.erb
@@ -4,7 +4,7 @@
     <%= "sage-grid-template-#{component.grid_template}" %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_card_stack.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card_stack.html.erb
@@ -1,6 +1,6 @@
 <div
   class="sage-card__stack <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
@@ -1,6 +1,6 @@
 <div
   class="sage-empty-state"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <h2 class="sage-empty-state__title"><%= component.title %></h2>
   <p class="sage-empty-state__text"><%= component.text %></p>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel.html.erb
@@ -5,7 +5,7 @@
     <%= "sage-panel--clear-padding-bottom" if component.clear_bottom_padding %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </section>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_block.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_block.html.erb
@@ -4,7 +4,7 @@
     <%= "sage-type" if component.type_block && component.type_block == true %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_figure.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_figure.html.erb
@@ -4,7 +4,7 @@
     <%= "sage-panel__figure--wistia" if component.is_wistia %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_footer.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_footer.html.erb
@@ -3,7 +3,7 @@
     <%= "sage-panel__footer--align-spread" if component.align_spread %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_header.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_header.html.erb
@@ -1,6 +1,6 @@
 <header
   class="sage-panel__header <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.title %>
     <h1 class="sage-panel__title">

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_list.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_list.html.erb
@@ -1,6 +1,6 @@
 <ul
   class="sage-panel__list <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </ul>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_list_item.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_list_item.html.erb
@@ -3,7 +3,7 @@
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </li>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_row.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_row.html.erb
@@ -4,7 +4,7 @@
     <%= "sage-grid-template-#{component.grid_template}" %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_stack.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_stack.html.erb
@@ -1,6 +1,6 @@
 <div
   class="sage-panel__stack <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_subheader.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_subheader.html.erb
@@ -1,6 +1,6 @@
 <header
   class="sage-panel__subheader <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.title %>
     <h2 class="sage-panel__subtitle">

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_tile.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_tile.html.erb
@@ -1,6 +1,6 @@
 <div
   class="sage-panel__tile <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_panel_tiles.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_panel_tiles.html.erb
@@ -3,7 +3,7 @@
     <%= "sage-panel__tiles--#{component.tiles_in_row}-up" %>
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>
 </div>

--- a/lib/sage_rails/app/views/sage_components/_sage_property.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_property.html.erb
@@ -3,7 +3,7 @@
     sage-property
     <%= component.generated_css_classes %>
   "
-  <%= component.generated_html_attributes %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <i class="sage-property__icon sage-icon-<%= component.icon %>"></i>
   <span class="sage-property__value">


### PR DESCRIPTION
## Description
Rails view was considering `generated_html_attributes` as "unsafe html". I tried a few workarounds but had some trouble getting this fixed. I settled on explicitly calling `html_safe` in each instance of the usage.

Sorry about the noisy diff here, all-in-all I think this explicitness is probably best anyway. 👍 
