### PR TITLE
Sage Label Nested Buttons

### DIFF
--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -30,7 +30,6 @@ configs = [
       color: config[:color],
       value: %(
         #{config[:color].capitalize}
-        <button class="sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove"></button>
       )
     } %>
   <% end %>
@@ -72,12 +71,32 @@ configs = [
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Interactive</h3>
+<h3 class="t-sage-heading-6">Tags</h3>
 <%= sage_component SagePanelBlock, {} do %>
   <% configs.each do | config | %>
     <%= sage_component SageLabel, {
       color: config[:color],
-      interactive: true,
+      value: %(
+        #{config[:color].capitalize}
+      )
+    } do %>
+      <%= sage_component SageButton, {
+        value: "Close",
+        subtle: true,
+        small: true,
+        style: "secondary",
+        icon: { style: "only", name: "remove" },
+        css_classes: "sage-btn--tag"
+      } %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h3 class="t-sage-heading-6">Status</h3>
+<%= sage_component SagePanelBlock, {} do %>
+  <% configs.each do | config | %>
+    <%= sage_component SageLabel, {
+      color: config[:color],
       value: config[:color].capitalize,
       icon: config[:icon]
     } do %>

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -17,6 +17,10 @@ configs = [
     icon: "warning",
   },
   {
+    color: "danger",
+    icon: "danger",
+  },
+  {
     color: "locked",
     icon: "lock",
   }

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -80,37 +80,26 @@ configs = [
   <% configs.each do | config | %>
     <%= sage_component SageLabel, {
       color: config[:color],
-      value: %(
-        #{config[:color].capitalize}
-      )
-    } do %>
-      <%= sage_component SageButton, {
-        value: "Close",
-        subtle: true,
-        small: true,
-        style: "secondary",
-        icon: { style: "only", name: "remove" },
-        css_classes: "sage-btn--tag"
-      } %>
-    <% end %>
+      value: config[:color].capitalize,
+      icon: config[:icon],
+      is_interactive: true,
+      is_tag: true
+    } %>
   <% end %>
 <% end %>
 
+
 <h3 class="t-sage-heading-6">Status</h3>
+
 <%= sage_component SagePanelBlock, {} do %>
   <% configs.each do | config | %>
     <%= sage_component SageLabel, {
       color: config[:color],
       value: config[:color].capitalize,
-      icon: config[:icon]
-    } do %>
-      <%= sage_component SageButton, {
-        value: "Close",
-        subtle: true,
-        small: true,
-        style: "secondary",
-        icon: { style: "only", name: "caret-down" }
-      } %>
-    <% end %>
+      icon: config[:icon],
+      is_status: true,
+      is_interactive: true
+    } %>
+      
   <% end %>
 <% end %>

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -1,21 +1,36 @@
-<%
-colors = [
-  "draft",
-  "info",
-  "published",
-  "warning",
-  "locked"
+<% 
+configs = [
+  {
+    color: "draft",
+    icon: "draft",
+  },
+  {
+    color: "published",
+    icon: "check",
+  },
+  {
+    color: "info",
+    icon: "draft",
+  },
+  {
+    color: "warning",
+    icon: "warning",
+  },
+  {
+    color: "locked",
+    icon: "lock",
+  }
 ]
 %>
 
 <h3 class="t-sage-heading-6">Default</h3>
 <%= sage_component SagePanelBlock, {} do %>
-  <% colors.each do | color | %>
+  <% configs.each do | config | %>
     <%= sage_component SageLabel, {
-      color: color,
+      color: config[:color],
       value: %(
-        #{color.capitalize}
-        <button class="sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove"></button>
+        #{config[:color].capitalize}
+        <button class='sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove"></button>
       )
     } %>
   <% end %>
@@ -23,22 +38,22 @@ colors = [
 
 <h3 class="t-sage-heading-6">Subtle</h3>
 <%= sage_component SagePanelBlock, {} do %>
-  <% colors.each do | color | %>
+  <% configs.each do | config | %>
     <%= sage_component SageLabel, {
-      color: color,
+      color: config[:color],
       style: "subtle",
-      value: color.capitalize
+      value: config[:color].capitalize
     } %>
   <% end %>
 <% end %>
 
 <h3 class="t-sage-heading-6">Bold</h3>
 <%= sage_component SagePanelBlock, {} do %>
-  <% colors.each do | color | %>
+  <% configs.each do | config | %>
     <%= sage_component SageLabel, {
-      color: color,
+      color: config[:color],
       style: "bold",
-      value: color.capitalize
+      value: config[:color].capitalize
     } %>
   <% end %>
 <% end %>
@@ -59,12 +74,12 @@ colors = [
 
 <h3 class="t-sage-heading-6">Interactive</h3>
 <%= sage_component SagePanelBlock, {} do %>
-  <% colors.each do | color | %>
+  <% configs.each do | config | %>
     <%= sage_component SageLabel, {
-      color: color,
+      color: config[:color],
       interactive: true,
-      value: color.capitalize,
-      icon: "tag"
+      value: config[:color].capitalize,
+      icon: config[:icon]
     } do %>
       <%= sage_component SageButton, {
         value: "Close",

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -2,9 +2,9 @@
 colors = [
   "draft",
   "info",
-  "success",
+  "published",
   "warning",
-  "danger"
+  "locked"
 ]
 %>
 
@@ -64,14 +64,14 @@ colors = [
       color: color,
       interactive: true,
       value: color.capitalize,
-      icon: "caret-down"
+      icon: "tag"
     } do %>
       <%= sage_component SageButton, {
         value: "Close",
         subtle: true,
         small: true,
         style: "secondary",
-        icon: { style: "only", name: "trash" }
+        icon: { style: "only", name: "caret-down" }
       } %>
     <% end %>
   <% end %>

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -30,7 +30,7 @@ configs = [
       color: config[:color],
       value: %(
         #{config[:color].capitalize}
-        <button class='sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove"></button>
+        <button class="sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove"></button>
       )
     } %>
   <% end %>

--- a/app/views/examples/elements/label/_preview.html.erb
+++ b/app/views/examples/elements/label/_preview.html.erb
@@ -45,15 +45,15 @@ colors = [
 
 <h3 class="t-sage-heading-6">With Icons</h3>
 <%= sage_component SagePanelBlock, {} do %>
-  <%= sage_component SageLabel, {
+  <%= sage_component SageLabel, { 
     color: "draft",
     value: "Add",
-    icon: { style: "left", name: "add-small" }
+    icon: "add-small"
   } %>
   <%= sage_component SageLabel, {
     color: "draft",
     value: "Tag",
-    icon: { style: "right", name: "tag" }
+    icon: "tag"
   } %>
 <% end %>
 
@@ -64,7 +64,15 @@ colors = [
       color: color,
       interactive: true,
       value: color.capitalize,
-      icon: { style: "right", name: "caret-down" }
-    } %>
+      icon: "caret-down"
+    } do %>
+      <%= sage_component SageButton, {
+        value: "Close",
+        subtle: true,
+        small: true,
+        style: "secondary",
+        icon: { style: "only", name: "trash" }
+      } %>
+    <% end %>
   <% end %>
 <% end %>

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -82,6 +82,11 @@ $sage-icon-li-margin-right: 0.4em !default;
     margin: 0 sage-spacing(xs) 0 0;
   }
 
+  .sage-label__decor-icon--#{$icon-name}::before {
+    @include sage-icon-base($icon-name, md);
+    align-self: center;
+  }
+
   .sage-page-heading__toolbar-icon-#{$icon-name} {
     white-space: nowrap;
 

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -79,8 +79,8 @@ $sage-icon-li-margin-right: 0.4em !default;
     @include sage-icon-base($icon-name, md);
     align-self: center;
     position: relative;
-    margin: 0 sage-spacing(2xs) 0 0;
     top: 2px;
+    margin: 0 sage-spacing(2xs) 0 0;
   }
 
   .sage-page-heading__toolbar-icon-#{$icon-name} {

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -78,8 +78,8 @@ $sage-icon-li-margin-right: 0.4em !default;
   .sage-label--icon-#{$icon-name} .sage-label__value::before {
     @include sage-icon-base($icon-name, md);
     align-self: center;
-    margin: 0 sage-spacing(2xs) 0 0;
     position: relative;
+    margin: 0 sage-spacing(2xs) 0 0;
     top: 2px;
   }
 

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -79,8 +79,7 @@ $sage-icon-li-margin-right: 0.4em !default;
     @include sage-icon-base($icon-name, md);
     align-self: center;
     position: relative;
-    top: 2px;
-    margin: 0 sage-spacing(2xs) 0 0;
+    margin: 0 sage-spacing(xs) 0 0;
   }
 
   .sage-page-heading__toolbar-icon-#{$icon-name} {

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -61,7 +61,7 @@ $sage-icon-li-margin-right: 0.4em !default;
 
 
   // Other icons generated here
-  
+
   @include button-icon-generator($icon-name, $icon-code, only);
   @include button-icon-generator($icon-name, $icon-code, left);
   @include button-icon-generator($icon-name, $icon-code, right);
@@ -75,24 +75,10 @@ $sage-icon-li-margin-right: 0.4em !default;
     margin: 0 sage-spacing(xs) 0 0;
   }
 
-  .sage-label--icon-left-#{$icon-name} {
-    flex-direction: row;
-    gap: sage-spacing(xs);
-
-    &::before {
-      align-self: center;
-      @include sage-icon-base($icon-name, sm);
-    }
-  }
-
-  .sage-label--icon-right-#{$icon-name} {
-    flex-direction: row-reverse;
-    gap: sage-spacing(xs);
-
-    &::before {
-      align-self: center;
-      @include sage-icon-base($icon-name, sm);
-    }
+  .sage-label--icon-#{$icon-name} .sage-label__value::before {
+    @include sage-icon-base($icon-name, sm);
+    align-self: center;
+    margin: 0 sage-spacing(2xs) 0 0;
   }
 
   .sage-page-heading__toolbar-icon-#{$icon-name} {

--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -76,9 +76,11 @@ $sage-icon-li-margin-right: 0.4em !default;
   }
 
   .sage-label--icon-#{$icon-name} .sage-label__value::before {
-    @include sage-icon-base($icon-name, sm);
+    @include sage-icon-base($icon-name, md);
     align-self: center;
     margin: 0 sage-spacing(2xs) 0 0;
+    position: relative;
+    top: 2px;
   }
 
   .sage-page-heading__toolbar-icon-#{$icon-name} {

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -226,6 +226,7 @@
       &::before {
         @include sage-icon-base($icon-name);
         align-self: center;
+        justify-content: center;
       }
     }
   }

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -274,7 +274,6 @@
   }
 
   &:focus:not(:disabled):not([aria-disabled="true"]),
-  &:focus-within:not(:disabled):not([aria-disabled="true"]),
   &:active:not(:disabled):not([aria-disabled="true"]) {
     &::after {
       transform: translate3d(-50%, -50%, 0) scale(1);

--- a/lib/sage-frontend/stylesheets/system/core/_mixins.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_mixins.scss
@@ -249,7 +249,8 @@
 @mixin sage-focus-outline($outline-width: 2px, $outline-offset-block: 4px, $outline-offset-inline: 4px) {
   position: relative;
 
-  &:focus {
+  &:focus,
+  &:focus-within {
     outline: none;
   }
 
@@ -272,6 +273,7 @@
   }
 
   &:focus:not(:disabled):not([aria-disabled="true"]),
+  &:focus-within:not(:disabled):not([aria-disabled="true"]),
   &:active:not(:disabled):not([aria-disabled="true"]) {
     &::after {
       transform: translate3d(-50%, -50%, 0) scale(1);

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -92,6 +92,9 @@ $-btn-subtle-styles: (
   ),
 );
 
+// Custom variables
+$-label-interactive-icon-size: rem(24px);
+
 .sage-btn {
   @extend %t-sage-body-med;
   @include sage-button-style-reset();
@@ -155,6 +158,21 @@ $-btn-subtle-styles: (
   }
 
   .sage-label & {
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    right: 0;
+    width: $-label-interactive-icon-size;
+    min-height: $-label-interactive-icon-size;
+    margin: auto 0;
+    border-radius: 0 sage-border(radius) sage-border(radius) 0;
+
+    &::after {
+      width: $-label-interactive-icon-size;
+      height: $-label-interactive-icon-size;
+      border-radius: 0 sage-border(radius) sage-border(radius) 0;
+    }
+
     &:first-child:not(:last-child) {
       margin-right: sage-spacing(xs);
     }
@@ -166,6 +184,14 @@ $-btn-subtle-styles: (
     + & {
       margin-left: 0;
     }
+
+    &.sage-btn--tag::before {
+      font-size: sage-font-size(md);
+    }
+  }
+
+  .sage-label__value & {
+    width: rem(28px);
   }
 
   .sage-page-heading__actions & {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -88,7 +88,7 @@ $-label-inset-border: 0 0 0 1px inset;
 
     &:hover {
       .sage-label__value {
-        background-color: sage-color-combo($-color-name, default, background-accent)
+        background-color: sage-color-combo($-color-name, default, background-accent);
       }
 
       .sage-btn::before {
@@ -97,9 +97,9 @@ $-label-inset-border: 0 0 0 1px inset;
     }
 
     .sage-btn {
+      display: flex;
       width: rem(24px);
       min-height: rem(24px);
-      display: flex;
       justify-content: center;
       border-radius: 0 sage-border(radius) sage-border(radius) 0;
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -36,6 +36,10 @@ $-label-inset-border: 0 0 0 1px inset;
   position: absolute;
   right: sage-spacing(xs);
   margin: auto 0;
+
+  .sage-btn::before {
+    font-size: rem(8px);
+  }
 }
 
 .sage-label--truncate {
@@ -68,12 +72,16 @@ $-label-inset-border: 0 0 0 1px inset;
     @include sage-focus-outline--update-color( sage-color-combo($-color-name, subtle, background) );
 
     .sage-label__value {
-      padding-right: rem(36px);
+      padding-right: rem(32px);
 
       &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
         background-color: darken(sage-color-combo($-color-name, default, background), 5%);
       }
     }
+
+    .sage-btn:focus::after {
+      transform: translate3d(-50%, calc(-50% - 1px), 0) scale(1);
+    }    
   }
 
   // .sage-btn & {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -8,6 +8,10 @@
 $-label-padding: 0 sage-spacing(xs) !default;
 $-label-border-radius: sage-border(radius) !default;
 $-label-inset-border: 0 0 0 1px inset;
+$-label-primary-icon-background-accent: #3e92ee;
+$-label-warning-background-accent: #f9df8b;
+$-label-danger-background-accent: #f3988c;
+$-label-danger-icon-background-accent: #da665e;
 
 .sage-label {
   display: inline-flex;
@@ -19,6 +23,8 @@ $-label-inset-border: 0 0 0 1px inset;
   @extend %t-sage-body-small-semi;
 
   appearance: none;
+  display: flex;
+  align-items: center;
   padding: $-label-padding;
   white-space: nowrap;
   border-radius: $-label-border-radius;
@@ -30,15 +36,9 @@ $-label-inset-border: 0 0 0 1px inset;
   &:active {
     outline: none;
   }
-}
 
-.sage-label__button-wrapper {
-  position: absolute;
-  right: 0;
-  margin: auto 0;
-
-  .sage-btn::before {
-    font-size: rem(8px);
+  .sage-btn {
+    width: 28px;
   }
 }
 
@@ -72,17 +72,15 @@ $-label-inset-border: 0 0 0 1px inset;
       padding-right: rem(32px);
 
       @include sage-focus-outline();
-      @include sage-focus-outline--update-color( sage-color-combo($-color-name, subtle, background) );
+      @include sage-focus-outline--update-color( sage-color-combo($-color-name, default, foreground) );
 
       &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
         color: sage-color-combo($-color-name, bold, foreground-accent);
       }
     }
 
-    .sage-label__button-wrapper {
-      &:hover .sage-btn {
-        background-color: sage-color-combo($-color-name, default, inner-button-background);
-      }
+    .sage-btn:hover {
+      background-color: sage-color-combo($-color-name, default, inner-button-background);
     }
 
     &:hover {
@@ -98,11 +96,15 @@ $-label-inset-border: 0 0 0 1px inset;
     .sage-btn {
       display: flex;
       justify-content: center;
+      position: absolute;
+      right: 0;
       width: rem(24px);
       min-height: rem(24px);
+      margin: auto 0;
       border-radius: 0 sage-border(radius) sage-border(radius) 0;
 
       &::before {
+        font-size: rem(8px);
         font-weight: sage-font-weight(bold);
         color: sage-color-combo($-color-name, default, foreground);
       }
@@ -129,4 +131,21 @@ $-label-inset-border: 0 0 0 1px inset;
   // }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`
+}
+
+// Overwrites for colors that dont exist in color palette specific to this interaction
+.sage-label--info.sage-label--interactive .sage-btn:hover {
+  background-color: $-label-primary-icon-background-accent;
+}
+
+.sage-label--danger.sage-label--interactive .sage-btn:hover {
+  background-color: $-label-danger-icon-background-accent;
+}
+
+.sage-label--warning.sage-label--interactive:hover .sage-label__value {
+  background-color: $-label-warning-background-accent;
+}
+
+.sage-label--danger.sage-label--interactive:hover .sage-label__value {
+  background-color: $-label-danger-background-accent;
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -76,7 +76,6 @@ $-label-inset-border: 0 0 0 1px inset;
 
       &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
         color: sage-color-combo($-color-name, bold, foreground-accent);
-        // background-color: darken(sage-color-combo($-color-name, default, background), 5%);
       }
     }
 
@@ -98,9 +97,9 @@ $-label-inset-border: 0 0 0 1px inset;
 
     .sage-btn {
       display: flex;
+      justify-content: center;
       width: rem(24px);
       min-height: rem(24px);
-      justify-content: center;
       border-radius: 0 sage-border(radius) sage-border(radius) 0;
 
       &::before {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -5,20 +5,20 @@
 
 ================================================== */
 
+$-label-interactive-icon-size: rem(24px);
+$-label-interactive-icon-size-small: rem(16px);
 $-label-padding: 0 sage-spacing(xs) !default;
 $-label-border-radius: sage-border(radius) !default;
 $-label-inset-border: 0 0 0 1px inset;
-
-// temporary colors to be used only with interactive labels
-$-label-primary-icon-background-accent: #3e92ee;
-$-label-warning-background-accent: #f9df8b;
-$-label-danger-background-accent: #f3988c;
-$-label-danger-icon-background-accent: #da665e;
 
 .sage-label {
   display: inline-flex;
   align-items: center;
   position: relative;
+
+  &[class*="sage-label--icon-only"] {
+    background-color: transparent;
+  }
 }
 
 .sage-label__value {
@@ -38,15 +38,15 @@ $-label-danger-icon-background-accent: #da665e;
   &:active {
     outline: none;
   }
-
-  .sage-btn {
-    width: rem(28px);
-  }
 }
 
 .sage-label--truncate {
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.sage-label__decor-icon {
+  pointer-events: none;
 }
 
 @each $-color-name, $-color-settings in $sage-color-combos {
@@ -95,13 +95,13 @@ $-label-danger-icon-background-accent: #da665e;
       }
     }
 
-    .sage-btn {
+    .sage-label__decor-icon {
       display: flex;
       justify-content: center;
       position: absolute;
       right: 0;
-      width: rem(24px);
-      min-height: rem(24px);
+      width: $-label-interactive-icon-size-small;
+      min-height: $-label-interactive-icon-size;
       margin: auto 0;
       border-radius: 0 sage-border(radius) sage-border(radius) 0;
 
@@ -112,8 +112,8 @@ $-label-danger-icon-background-accent: #da665e;
       }
 
       &::after {
-        width: rem(24px);
-        height: rem(24px);
+        width: $-label-interactive-icon-size;
+        height: $-label-interactive-icon-size;
         border-radius: 0 sage-border(radius) sage-border(radius) 0;
       }
 
@@ -122,27 +122,10 @@ $-label-danger-icon-background-accent: #da665e;
       }
 
       &.sage-btn--tag::before {
-        font-size: rem(16px);
+        font-size: sage-font-size(md);
       }
     }
   }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`
-}
-
-// Overwrites for colors that dont exist in color palette specific to this interaction
-.sage-label--info.sage-label--interactive .sage-btn:hover {
-  background-color: $-label-primary-icon-background-accent;
-}
-
-.sage-label--danger.sage-label--interactive .sage-btn:hover {
-  background-color: $-label-danger-icon-background-accent;
-}
-
-.sage-label--warning.sage-label--interactive:hover .sage-label__value {
-  background-color: $-label-warning-background-accent;
-}
-
-.sage-label--danger.sage-label--interactive:hover .sage-label__value {
-  background-color: $-label-danger-background-accent;
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -10,16 +10,32 @@ $-label-border-radius: sage-border(radius) !default;
 $-label-inset-border: 0 0 0 1px inset;
 
 .sage-label {
-  @extend %t-sage-body-small-semi;
-
   display: inline-flex;
   align-items: center;
+  position: relative;
+}
+
+.sage-label__value {
+  @extend %t-sage-body-small-semi;
+
   appearance: none;
   padding: $-label-padding;
-  text-align: center;
   white-space: nowrap;
   border-radius: $-label-border-radius;
   border: unset;
+  outline: none;
+
+  &:hover,
+  &:focus,
+  &:active {
+    outline: none;
+  }
+}
+
+.sage-label__button-wrapper {
+  position: absolute;
+  right: sage-spacing(xs);
+  margin: auto 0;
 }
 
 .sage-label--truncate {
@@ -28,41 +44,45 @@ $-label-inset-border: 0 0 0 1px inset;
 }
 
 @each $-color-name, $-color-settings in $sage-color-combos {
-  .sage-label--#{$-color-name} {
+  $-color-modifier: ".sage-label--#{$-color-name}";
+
+  #{$-color-modifier} .sage-label__value {
     color: sage-color-combo($-color-name, default, foreground);
     background-color: sage-color-combo($-color-name, default, background);
+  }
 
-    &.sage-label--subtle {
-      color: sage-color-combo($-color-name, subtle, foreground);
-      background-color: sage-color(white);
-      // Box shadow instead of border so that size and inner spacing is not affected
-      box-shadow: $-label-inset-border sage-color-combo($-color-name, subtle, background);
-    }
+  #{$-color-modifier}.sage-label--subtle .sage-label__value {
+    color: sage-color-combo($-color-name, subtle, foreground);
+    background-color: sage-color(white);
+    // Box shadow instead of border so that size and inner spacing is not affected
+    box-shadow: $-label-inset-border sage-color-combo($-color-name, subtle, background);
+  }
 
-    &.sage-label--bold {
-      color: sage-color-combo($-color-name, bold, foreground);
-      background-color: sage-color-combo($-color-name, bold, background);
-    }
+  #{$-color-modifier}.sage-label--bold .sage-label__value {
+    color: sage-color-combo($-color-name, bold, foreground);
+    background-color: sage-color-combo($-color-name, bold, background);
+  }
 
-    &.sage-label--interactive {
-      cursor: pointer;
+  #{$-color-modifier}.sage-label--interactive {
+    @include sage-focus-outline();
+    @include sage-focus-outline--update-color( sage-color-combo($-color-name, subtle, background) );
 
-      @include sage-focus-outline();
-      @include sage-focus-outline--update-color( sage-color-combo($-color-name, subtle, background) );
+    .sage-label__value {
+      padding-right: rem(36px);
 
       &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
         background-color: darken(sage-color-combo($-color-name, default, background), 5%);
       }
     }
-
-    .sage-btn & {
-      &:focus,
-      &:active {
-        background-color: inherit;
-        box-shadow: $-label-inset-border transparent;
-      }
-    }
   }
+
+  // .sage-btn & {
+  //   &:focus,
+  //   &:active {
+  //     background-color: inherit;
+  //     box-shadow: $-label-inset-border transparent;
+  //   }
+  // }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -34,7 +34,7 @@ $-label-inset-border: 0 0 0 1px inset;
 
 .sage-label__button-wrapper {
   position: absolute;
-  right: sage-spacing(xs);
+  right: 0;
   margin: auto 0;
 
   .sage-btn::before {
@@ -68,22 +68,59 @@ $-label-inset-border: 0 0 0 1px inset;
   }
 
   #{$-color-modifier}.sage-label--interactive {
-    @include sage-focus-outline();
-    @include sage-focus-outline--update-color( sage-color-combo($-color-name, subtle, background) );
-
     .sage-label__value {
       padding-right: rem(32px);
 
+      @include sage-focus-outline();
+      @include sage-focus-outline--update-color( sage-color-combo($-color-name, subtle, background) );
+
       &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
-        background-color: darken(sage-color-combo($-color-name, default, background), 5%);
+        color: sage-color-combo($-color-name, bold, foreground-accent);
+        // background-color: darken(sage-color-combo($-color-name, default, background), 5%);
       }
     }
 
-    .sage-btn:focus::after {
-      transform: translate3d(-50%, calc(-50% - 1px), 0) scale(1);
+    .sage-label__button-wrapper {
+      &:hover .sage-btn {
+        background-color: sage-color-combo($-color-name, default, inner-button-background);
+      }
+    }
+
+    &:hover {
+      .sage-label__value {
+        background-color: sage-color-combo($-color-name, default, background-accent)
+      }
+
+      .sage-btn::before {
+        color: sage-color-combo($-color-name, default, foreground-accent);
+      }
+    }
+
+    .sage-btn {
+      width: rem(24px);
+      min-height: rem(24px);
+      display: flex;
+      justify-content: center;
+      border-radius: 0 sage-border(radius) sage-border(radius) 0;
+
+      &::before {
+        font-weight: sage-font-weight(bold);
+        color: sage-color-combo($-color-name, default, foreground);
+      }
+
+      &::after {
+        width: rem(24px);
+        height: rem(24px);
+        border-radius: 0 sage-border(radius) sage-border(radius) 0;
+      }
+
+      &:focus {
+        // color: sage-color-combo($-color-name, default, foreground-accent);
+        @include sage-focus-outline--update-color( sage-color-combo($-color-name, default, foreground-accent) );
+      }
     }
   }
-  
+
   // .sage-btn & {
   //   &:focus,
   //   &:active {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -81,7 +81,7 @@ $-label-inset-border: 0 0 0 1px inset;
 
     .sage-btn:focus::after {
       transform: translate3d(-50%, calc(-50% - 1px), 0) scale(1);
-    }    
+    }
   }
   // .sage-btn & {
   //   &:focus,

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -83,7 +83,6 @@ $-label-inset-border: 0 0 0 1px inset;
       transform: translate3d(-50%, calc(-50% - 1px), 0) scale(1);
     }    
   }
-
   // .sage-btn & {
   //   &:focus,
   //   &:active {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -8,6 +8,8 @@
 $-label-padding: 0 sage-spacing(xs) !default;
 $-label-border-radius: sage-border(radius) !default;
 $-label-inset-border: 0 0 0 1px inset;
+
+// temporary colors to be used only with interactive labels
 $-label-primary-icon-background-accent: #3e92ee;
 $-label-warning-background-accent: #f9df8b;
 $-label-danger-background-accent: #f3988c;
@@ -38,7 +40,7 @@ $-label-danger-icon-background-accent: #da665e;
   }
 
   .sage-btn {
-    width: 28px;
+    width: rem(28px);
   }
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -98,26 +98,41 @@ $-label-danger-icon-background-accent: #da665e;
       justify-content: center;
       position: absolute;
       right: 0;
-      width: rem(24px);
-      min-height: rem(24px);
       margin: auto 0;
       border-radius: 0 sage-border(radius) sage-border(radius) 0;
 
       &::before {
-        font-size: rem(8px);
+        // font-size: rem(8px);
         font-weight: sage-font-weight(bold);
         color: sage-color-combo($-color-name, default, foreground);
       }
 
       &::after {
-        width: rem(24px);
-        height: rem(24px);
+        // width: rem(24px);
+        // height: rem(24px);
         border-radius: 0 sage-border(radius) sage-border(radius) 0;
       }
 
       &:focus {
-        // color: sage-color-combo($-color-name, default, foreground-accent);
         @include sage-focus-outline--update-color( sage-color-combo($-color-name, default, foreground-accent) );
+      }
+
+      &.sage-btn--small {
+        width: rem(24px);
+        min-height: rem(24px);
+
+        &::before {
+          font-size: rem(8px);
+        }
+  
+        &::after {
+          width: rem(24px);
+          height: rem(24px);
+        }
+
+        &.sage-btn--tag::before {
+          font-size: rem(16px);
+        }
       }
     }
   }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -98,18 +98,20 @@ $-label-danger-icon-background-accent: #da665e;
       justify-content: center;
       position: absolute;
       right: 0;
+      width: rem(24px);
+      min-height: rem(24px);
       margin: auto 0;
       border-radius: 0 sage-border(radius) sage-border(radius) 0;
 
       &::before {
-        // font-size: rem(8px);
+        font-size: rem(8px);
         font-weight: sage-font-weight(bold);
         color: sage-color-combo($-color-name, default, foreground);
       }
 
       &::after {
-        // width: rem(24px);
-        // height: rem(24px);
+        width: rem(24px);
+        height: rem(24px);
         border-radius: 0 sage-border(radius) sage-border(radius) 0;
       }
 
@@ -117,33 +119,11 @@ $-label-danger-icon-background-accent: #da665e;
         @include sage-focus-outline--update-color( sage-color-combo($-color-name, default, foreground-accent) );
       }
 
-      &.sage-btn--small {
-        width: rem(24px);
-        min-height: rem(24px);
-
-        &::before {
-          font-size: rem(8px);
-        }
-  
-        &::after {
-          width: rem(24px);
-          height: rem(24px);
-        }
-
-        &.sage-btn--tag::before {
-          font-size: rem(16px);
-        }
+      &.sage-btn--tag::before {
+        font-size: rem(16px);
       }
     }
   }
-
-  // .sage-btn & {
-  //   &:focus,
-  //   &:active {
-  //     background-color: inherit;
-  //     box-shadow: $-label-inset-border transparent;
-  //   }
-  // }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_label.scss
@@ -83,6 +83,7 @@ $-label-inset-border: 0 0 0 1px inset;
       transform: translate3d(-50%, calc(-50% - 1px), 0) scale(1);
     }
   }
+  
   // .sage-btn & {
   //   &:focus,
   //   &:active {

--- a/lib/sage-frontend/stylesheets/system/tokens/_color_combos.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_color_combos.scss
@@ -10,8 +10,10 @@ $sage-color-combos: (
   draft: (
     default: (
       foreground: sage-color(charcoal, 400),
-      foreground-accent: sage-color(charcoal, 400),
+      foreground-accent: sage-color(charcoal, 500),
       background: sage-color(grey, 300),
+      background-accent: sage-color(grey, 400),
+      inner-button-background: sage-color(grey, 500),
     ),
     subtle: (
       foreground: sage-color(charcoal, 200),
@@ -23,11 +25,13 @@ $sage-color-combos: (
       background: sage-color(charcoal, 400),
     )
   ),
-  success: (
+  published: (
     default: (
       foreground: sage-color(sage, 400),
-      foreground-accent: sage-color(sage, 400),
+      foreground-accent: sage-color(sage, 500),
       background: sage-color(sage, 100),
+      background-accent: sage-color(sage, 200),
+      inner-button-background: sage-color(sage, 300),
     ),
     subtle: (
       foreground: sage-color(sage, 400),
@@ -42,8 +46,10 @@ $sage-color-combos: (
   info: (
     default: (
       foreground: sage-color(primary, 400),
-      foreground-accent: sage-color(primary, 300),
+      foreground-accent: sage-color(primary, 500),
       background: sage-color(primary, 100),
+      background-accent: sage-color(primary, 200),
+      inner-button-background: sage-color(primary, 300),
     ),
     subtle: (
       foreground: sage-color(primary, 400),
@@ -55,11 +61,31 @@ $sage-color-combos: (
       background: sage-color(primary, 300),
     )
   ),
+  locked: (
+    default: (
+      foreground: sage-color(purple, 400),
+      foreground-accent: sage-color(purple, 500),
+      background: sage-color(purple, 100),
+      background-accent: sage-color(purple, 200),
+      inner-button-background: sage-color(purple, 300),
+    ),
+    subtle: (
+      foreground: sage-color(purple, 400),
+      foreground-accent: sage-color(purple, 300),
+      background: sage-color(purple, 200),
+    ),
+    bold: (
+      foreground: sage-color(purple, 100),
+      background: sage-color(purple, 300),
+    )
+  ),
   warning: (
     default: (
-      foreground: sage-color(yellow, 500),
-      foreground-accent: sage-color(yellow, 300),
+      foreground: sage-color(yellow, 400),
+      foreground-accent: sage-color(yellow, 500),
       background: sage-color(yellow, 200),
+      background-accent: sage-color(yellow, 400),
+      inner-button-background: sage-color(yellow, 300),
     ),
     subtle: (
       foreground: sage-color(yellow, 400),
@@ -73,9 +99,11 @@ $sage-color-combos: (
   ),
   danger: (
     default: (
-      foreground: sage-color(red, 500),
-      foreground-accent: sage-color(red, 300),
+      foreground: sage-color(red, 400),
+      foreground-accent: sage-color(red, 500),
       background: sage-color(red, 200),
+      background-accent: sage-color(red, 400),
+      inner-button-background: sage-color(red, 300),
     ),
     subtle: (
       foreground: sage-color(red, 400),

--- a/lib/sage-frontend/stylesheets/system/tokens/_color_combos.scss
+++ b/lib/sage-frontend/stylesheets/system/tokens/_color_combos.scss
@@ -5,6 +5,11 @@
   @return map-get($combo-set, $color-type);
 }
 
+// Color overrides
+$-label-primary-icon-background-accent: #3e92ee;
+$-label-warning-background-accent: #f9df8b;
+$-label-danger-background-accent: #f3988c;
+$-label-danger-icon-background-accent: #da665e;
 
 $sage-color-combos: (
   draft: (
@@ -48,7 +53,7 @@ $sage-color-combos: (
       foreground: sage-color(primary, 400),
       foreground-accent: sage-color(primary, 500),
       background: sage-color(primary, 100),
-      background-accent: sage-color(primary, 200),
+      background-accent: $-label-primary-icon-background-accent,
       inner-button-background: sage-color(primary, 300),
     ),
     subtle: (
@@ -84,7 +89,7 @@ $sage-color-combos: (
       foreground: sage-color(yellow, 400),
       foreground-accent: sage-color(yellow, 500),
       background: sage-color(yellow, 200),
-      background-accent: sage-color(yellow, 400),
+      background-accent: $-label-warning-background-accent,
       inner-button-background: sage-color(yellow, 300),
     ),
     subtle: (
@@ -102,8 +107,8 @@ $sage-color-combos: (
       foreground: sage-color(red, 400),
       foreground-accent: sage-color(red, 500),
       background: sage-color(red, 200),
-      background-accent: sage-color(red, 400),
-      inner-button-background: sage-color(red, 300),
+      background-accent: $-label-danger-background-accent,
+      inner-button-background: $-label-danger-icon-background-accent,
     ),
     subtle: (
       foreground: sage-color(red, 400),

--- a/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/lib/sage_rails/app/sage_components/sage_label.rb
@@ -1,7 +1,6 @@
 class SageLabel < SageComponent
   attr_accessor :color
   attr_accessor :style
-  attr_accessor :interactive
   attr_accessor :icon
   attr_accessor :value
   attr_accessor :html_tag

--- a/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/lib/sage_rails/app/sage_components/sage_label.rb
@@ -4,4 +4,7 @@ class SageLabel < SageComponent
   attr_accessor :icon
   attr_accessor :value
   attr_accessor :html_tag
+  attr_accessor :is_interactive
+  attr_accessor :is_status
+  attr_accessor :is_tag
 end

--- a/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -1,4 +1,4 @@
-<% is_interactive = component.content.present? %>
+<% is_interactive = component.is_interactive %>
 <% label_content_tag = is_interactive ? "button" : "span" %>
 
 <span
@@ -17,7 +17,18 @@
   />
     <%= component.value.html_safe %>
   </<%= label_content_tag %>>
-  <% if component.content %>
-      <%= component.content %>
+
+  <% if component.is_tag %>
+    <%= sage_component SageButton, {
+      value: "Close",
+      subtle: true,
+      small: true,
+      style: "secondary",
+      icon: { style: "only", name: "remove" }
+    } %>
+  <% end %>
+
+  <% if component.is_status %>
+    <span class="sage-label__decor-icon sage-label__decor-icon--caret-down"></span>
   <% end %>
 </span>

--- a/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -15,11 +15,9 @@
     class="sage-label__value"
     <%= component.generated_html_attributes %>
   />
-    <%= component.value %>
+    <%= component.value.html_safe %>
   </<%= label_content_tag %>>
   <% if component.content %>
-    <span class="sage-label__button-wrapper">
       <%= component.content %>
-    </span>
   <% end %>
 </span>

--- a/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -1,20 +1,25 @@
-<% html_tag = component.interactive ? "button" : component.html_tag.present? ? component.html_tag : "span" %>
+<% is_interactive = component.content.present? %>
+<% label_content_tag = is_interactive ? "button" : "span" %>
 
-<<%= html_tag %>
+<span
   class="
     sage-label
     <%= "sage-label--#{component.color}" if component.color %>
     <%= "sage-label--#{component.style}" if component.style %>
-    <%= "sage-label--interactive" if component.interactive %>
-    <%= "sage-label--icon-#{component.icon[:style]}-#{component.icon[:name]}" if component.icon %>
+    <%= "sage-label--interactive" if is_interactive %>
+    <%= "sage-label--icon-#{component.icon}" if component.icon %>
     <%= component.generated_css_classes %>
   "
 >
-  <% if component.icon&.dig(:style) == "only" %>
-    <span class="visually-hidden">
-      <%= component.value.html_safe %>
+  <<%= label_content_tag %>
+    class="sage-label__value"
+    <%= component.generated_html_attributes %>
+  />
+    <%= component.value %>
+  </<%= label_content_tag %>>
+  <% if component.content %>
+    <span class="sage-label__button-wrapper">
+      <%= component.content %>
     </span>
-  <% else %>
-    <%= component.value.html_safe %>
   <% end %>
-</<%= html_tag %>>
+</span>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
This PR updates the interactive label.  The interactive label now calls for two icons. The second icon will also be a clickable button. The clickable button is a `SageButton` component that has `icon: { style: "only", name: "caret-down" }`

### Screenshots
|  before  |  after  |
|--------|--------|
|![interactive-tags-before](https://user-images.githubusercontent.com/1241836/98836160-fabc9a00-2406-11eb-9392-c28302e61844.gif)|![interactive-tags-after](https://user-images.githubusercontent.com/1241836/98836188-014b1180-2407-11eb-93be-9ba00483c07d.gif)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the Sage Label page: http://localhost:4000/pages/element/label

