### PR TITLE
Inline and button "copy text" overflow fix

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_copy_text.scss
@@ -23,6 +23,7 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
   @include sage-copy-text;
 
   display: inline-block;
+  max-width: 100%;
   padding: 0 sage-spacing(xs);
 
   .sage-copy-btn & {
@@ -40,7 +41,7 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
 .sage-copy-text-card {
   @include sage-grid-stack;
   @include sage-copy-text;
-  
+
   width: 100%;
   padding: $sage-card-padding;
 }
@@ -61,6 +62,7 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
   display: inline-flex;
   flex-flow: row-reverse;
   align-items: center;
+  max-width: 100%;
   padding-right: sage-spacing(2xs);
 
   &::before {


### PR DESCRIPTION
## Description
Applies a `max-width` to prevent long strings of text (like URLs) from overflowing "copy text" element bounds. This occurs most often on mobile devices and in limited-width containers, like modals.


### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/97244106-fd878000-17b4-11eb-9a05-69c321a0c1a1.png)|![after](https://user-images.githubusercontent.com/816579/97244113-037d6100-17b5-11eb-9cf1-71fe4f90262d.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Navigate to the "Copy text" element preview
2. Decrease the viewport size of your browser to simulate a mobile view
3. Verify that the text does not overflow past the container

