### PR TITLE
Revised modal sizing

### DIFF
--- a/app/views/examples/objects/modal/_markup.html.erb
+++ b/app/views/examples/objects/modal/_markup.html.erb
@@ -5,7 +5,7 @@
       <aside class="sage-modal__header-aside">
         <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
           <span class="visually-hidden">Menu</span>
-        </a>
+        </button>
       </aside>
     </header>
     <div class="sage-modal__content">
@@ -13,9 +13,9 @@
     </div>
     <footer class="sage-modal__footer">
       <aside class="sage-modal__footer-aside">
-        <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</a>
+        <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
       </aside>
-      <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</a>
+      <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
     </footer>
   </section>
 </dialog>

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_modal.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_modal.scss
@@ -15,6 +15,7 @@ $-modal-padding-y: sage-spacing(md);
   position: fixed;
   overflow-y: scroll;
   z-index: sage-z-index(modal, -1);
+  padding: sage-spacing(md);
   background-color: rgba(sage-color(charcoal, 500), 0.4);
   background-image: linear-gradient(
     rgba(sage-color(charcoal, 200), 0.3) 0%,
@@ -38,8 +39,8 @@ $-modal-padding-y: sage-spacing(md);
   visibility: hidden;
   display: none;
   z-index: sage-z-index(modal);
-  min-width: min-content;
-  width: sage-container(modal);
+  width: calc(100vw - #{sage-spacing(md)});
+  max-width: sage-container(modal);
   margin: 0;
   border-radius: sage-border(radius);
   background-color: sage-color(white);
@@ -82,6 +83,7 @@ $-modal-padding-y: sage-spacing(md);
 .sage-modal__footer {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   margin: $-modal-padding-y $-modal-padding-x;
 }
 


### PR DESCRIPTION
## Description
Proposed adjustments to the default modal. Current implementation of the modal makes use of `min-width: min-content`. This works as expected for normal content flow, but in the case where a child element is intended to truncate, the `min-content` value prevents the overflow from being hidden (see examples below for WIP examples using the copy text button element).

There doesn't yet appear to be a mockup in Figma, so these changes are likely to be temporary until we have more feedback from design.

Also addresses:
- padding around the modal has been adjusted to match base spacing (`24px`) at mobile viewports
- `button` tags in the template were being closed with anchor link tags
- vertically centers footer elements to match spec in Figma

### Questions:
- should we create "presets" around defined sizes? if so, we'll need to get input from design on what those might be


### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

| |  before  |  after  |
|---|----|----|
| normal use (padding increased, otherwise no change) |![before-sage-modal](https://user-images.githubusercontent.com/816579/97376433-9207e600-187a-11eb-9c91-875a045a03d3.png)|![after-sage-modal](https://user-images.githubusercontent.com/816579/97376551-e27f4380-187a-11eb-951f-a8b3dad0c0aa.png)|
| with "copy text button" element on a WIP modal|![before-modal-truncate](https://user-images.githubusercontent.com/816579/97376582-f75bd700-187a-11eb-9516-d9034470aef7.png)|![after-modal-truncate](https://user-images.githubusercontent.com/816579/97376598-fcb92180-187a-11eb-9244-df9254c89f43.png)|


