### PR TITLE
Override Bootstrap focus outline on radio inputs

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_radio.scss
@@ -130,6 +130,8 @@ $-radio-focus-outline-color: currentColor !default;
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {
+    outline: none;
+    
     &::before {
       transform: translate3d(-50%, -50%, 0) scale(1);
       opacity: 1;


### PR DESCRIPTION
## Description
`:focus` state of radio inputs displays an inherited outline style from Bootstrap. Combined with Sage `:focus` styles, this seems to show a "misshapen" inner ring on the control:

![radio-button-focus-outline](https://user-images.githubusercontent.com/816579/97612523-c42d5b00-19d4-11eb-9a40-86cac400d787.png)

This is intended as a **temporary** fix until Bootstrap's stylesheets are fully removed.
