### PR TITLE
Fix busted Dropdown Search attr

### DIFF
--- a/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -19,7 +19,7 @@
       <%= sage_component SageSearch, {
         placeholder: "Search",
         value: nil,
-        html_attribute: {
+        html_attributes: {
           "aria-label": "options_search"
         }
       } %>


### PR DESCRIPTION
## Description
🥵 I broke the Dropdown with a misnamed attribute for SageSearch.