### PR TITLE
Jcm component examples

### DIFF
--- a/app/views/examples/elements/_element.html.erb
+++ b/app/views/examples/elements/_element.html.erb
@@ -11,25 +11,25 @@
   do_content: do_content,
   dont_content: dont_content %>
 
-<div class="sage-panel-set">
-  <%= render "examples/shared/preview",
+<%= render "examples/shared/preview",
+  type: "element",
+  title: @title %>
+
+<% if info_content[:use_legacy_html_code_source] %>
+  <%= render "examples/shared/legacy_code",
     type: "element",
     title: @title %>
+<% else %>
+  <%= render "examples/shared/code",
+    type: "element",
+    title: @title %>
+<% end %>
 
-  <% if info_content[:use_legacy_html_code_source] %>
-    <%= render "examples/shared/legacy_code",
-      type: "element",
-      title: @title %>
-  <% else %>
-    <%= render "examples/shared/code",
-      type: "element",
-      title: @title %>
-  <% end %>
+<%= render "examples/shared/props",
+  props_content: props_content, 
+  title: @title %>
 
-  <%= render "examples/shared/props",
-    props_content: props_content %>
-
-  <%= render "examples/shared/rules",
-    do_content: do_content,
-    dont_content: dont_content %>
-</div>
+<%= render "examples/shared/rules",
+  do_content: do_content,
+  dont_content: dont_content, 
+  title: @title %>

--- a/app/views/examples/elements/_element_preview.html.erb
+++ b/app/views/examples/elements/_element_preview.html.erb
@@ -1,34 +1,32 @@
 <% permalink = "element-#{title}" %>
-
-<%= sage_component SagePanel, {} do %>
-  <%= sage_component SagePanelHeader, {} do %>
-    <h2 id="<%= permalink %>" class="sage-panel__title">
-      <%= link_to title.titleize, "##{permalink}", class: "example__link" %>
-    </h2>
-    <%= sage_component SageButtonGroup, { gap: :md } do %>
-      <%= sage_component SageButton, {
-        value: "View Details",
-        style: "secondary",
-        subtle: true,
-        icon: { name: "preview-on", style: "only" },
-        attributes: {
-          "data-js-tooltip": "Inspect element details",
-          href: pages_element_path(title),
-        }
-      } %>
-      <%= sage_component SageButton, {
-        value: "Opens #{title.titleize} in a new window",
-        style: "secondary",
-        subtle: true,
-        icon: { name: "launch", style: "only" },
-        attributes: {
-          "data-js-tooltip": "Open breakout page",
-          href: pages_breakout_path(type: :element, title: title),
-          target: "_blank",
-        }
-      } %>
-    <% end %>
+<%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+  <h2 id="<%= permalink %>">
+    <%= link_to title.titleize, pages_element_path(title), class: "example__link" %>
+  </h2>
+  <%= sage_component SageButtonGroup, { gap: :md } do %>
+    <%= sage_component SageButton, {
+      value: "View Details",
+      style: "secondary",
+      subtle: true,
+      icon: { name: "preview-on", style: "only" },
+      attributes: {
+        "data-js-tooltip": "Inspect element details",
+        href: pages_element_path(title),
+      }
+    } %>
+    <%= sage_component SageButton, {
+      value: "Opens #{title.titleize} in a new window",
+      style: "secondary",
+      subtle: true,
+      icon: { name: "launch", style: "only" },
+      attributes: {
+        "data-js-tooltip": "Open breakout page",
+        href: pages_breakout_path(type: :element, title: title),
+        target: "_blank",
+      }
+    } %>
   <% end %>
-
+<% end %>
+<%= sage_component SageCard, { spacer: {bottom: :xl} } do %>
   <%= render "examples/elements/#{title}/preview" %>
 <% end %>

--- a/app/views/examples/elements/breadcrumbs/_preview.html.erb
+++ b/app/views/examples/elements/breadcrumbs/_preview.html.erb
@@ -1,4 +1,9 @@
-<h4>Default</h4>
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Default",
+  } %>
+<% end %>
 <%= sage_component SageBreadcrumbs, {
   items: [
     {
@@ -16,7 +21,12 @@
   ]
 } %>
 
-<h4>Back Link Variation</h4>
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Back Link Variation",
+  } %>
+<% end %>
 <%= sage_component SageBreadcrumbs, {
   has_back_icon: true,
   items: [
@@ -27,7 +37,12 @@
   ]
 } %>
 
-<h4>Progress Bar Variation</h4>
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Progress Bar Variation",
+  } %>
+<% end %>
 <%= sage_component SageBreadcrumbs, {
   is_progressbar: true,
   items: [

--- a/app/views/examples/elements/button/_preview.html.erb
+++ b/app/views/examples/elements/button/_preview.html.erb
@@ -18,7 +18,12 @@ demo_configs = [
 ]
 %>
 <% demo_configs.each do | config | %>
-  <h3 class="t-sage-heading-6"><%= config[:heading] %></h3>
+  <%= sage_component SageCardBlock, {} do %>
+    <%= sage_component SageLabel, {
+      color: "draft",
+      value: config[:heading],
+    } %>
+  <% end %>
 
   <% [false, true].each do | disabled | %>
     <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
@@ -76,7 +81,12 @@ demo_configs = [
 <% end %>
 
 <% demo_configs.each do | config | %>
-  <h3 class="t-sage-heading-6">Subtle <%= config[:heading] %></h3>
+  <%= sage_component SageCardBlock, {} do %>
+    <%= sage_component SageLabel, {
+      color: "draft",
+      value: "Subtle #{config[:heading]}",
+    } %>
+  <% end %>
 
   <% [false, true].each do | size | %>
     <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
@@ -138,7 +148,12 @@ demo_configs = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Button group: Align End</h3>
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Button group: Align End",
+  } %>
+<% end %>
 <%= sage_component SageButtonGroup, { gap: :md, align: "end" } do %>
   <%= sage_component SageButton, {
     value: "Cancel",
@@ -150,7 +165,13 @@ demo_configs = [
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Shadow Treatment</h3>
+
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Shadow Treatment",
+  } %>
+<% end %>
 <p>
   Regular buttons allow for a "raised" shadow treatement to be toggled on or off.
   This is on by default for "Primary" button styles and can be toggled off with "no_shadow".

--- a/app/views/examples/objects/_object.html.erb
+++ b/app/views/examples/objects/_object.html.erb
@@ -11,25 +11,23 @@
   do_content: do_content,
   dont_content: dont_content %>
 
-<div class="sage-panel-set">
-  <%= render "examples/shared/preview",
+<%= render "examples/shared/preview",
+  type: "object",
+  title: @title %>
+
+<% if info_content[:use_legacy_html_code_source] %>
+  <%= render "examples/shared/legacy_code",
     type: "object",
     title: @title %>
+<% else %>
+  <%= render "examples/shared/code",
+    type: "object",
+    title: @title %>
+<% end %>
 
-  <% if info_content[:use_legacy_html_code_source] %>
-    <%= render "examples/shared/legacy_code",
-      type: "object",
-      title: @title %>
-  <% else %>
-    <%= render "examples/shared/code",
-      type: "object",
-      title: @title %>
-  <% end %>
+<%= render "examples/shared/props",
+  props_content: props_content %>
 
-  <%= render "examples/shared/props",
-    props_content: props_content %>
-
-  <%= render "examples/shared/rules",
-    do_content: do_content,
-    dont_content: dont_content %>
-</div>
+<%= render "examples/shared/rules",
+  do_content: do_content,
+  dont_content: dont_content %>

--- a/app/views/examples/objects/_object.html.erb
+++ b/app/views/examples/objects/_object.html.erb
@@ -26,8 +26,10 @@
 <% end %>
 
 <%= render "examples/shared/props",
-  props_content: props_content %>
+  props_content: props_content,
+  title: @title %>
 
 <%= render "examples/shared/rules",
   do_content: do_content,
-  dont_content: dont_content %>
+  dont_content: dont_content,
+  title: @title %>

--- a/app/views/examples/objects/_object_preview.html.erb
+++ b/app/views/examples/objects/_object_preview.html.erb
@@ -1,34 +1,34 @@
 <% permalink = "object-#{title}" %>
 
-<%= sage_component SagePanel, {} do %>
-  <%= sage_component SagePanelHeader, {} do %>
-    <h2 id="<%= permalink %>" class="sage-panel__title">
-      <%= link_to title.titleize, "##{permalink}", class: "example__link" %>
-    </h2>
-    <%= sage_component SageButtonGroup, { gap: :md } do %>
-      <%= sage_component SageButton, {
-        value: "View Details",
-        style: "secondary",
-        subtle: true,
-        icon: { name: "preview-on", style: "only" },
-        attributes: {
-          "data-js-tooltip": "Inspect element details",
-          href: pages_object_path(title),
-        }
-      } %>
-      <%= sage_component SageButton, {
-        value: "Opens #{title.titleize} in a new window",
-        style: "secondary",
-        subtle: true,
-        icon: { name: "launch", style: "only" },
-        attributes: {
-          "data-js-tooltip": "Open breakout page",
-          href: pages_breakout_path(type: :object, title: title),
-          target: "_blank",
-        }
-      } %>
-    <% end %>
+<%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+  <h2 id="<%= permalink %>">
+    <%= link_to title.titleize, pages_object_path(title), class: "example__link" %>
+  </h2>
+  <%= sage_component SageButtonGroup, { gap: :md } do %>
+    <%= sage_component SageButton, {
+      value: "View Details",
+      style: "secondary",
+      subtle: true,
+      icon: { name: "preview-on", style: "only" },
+      attributes: {
+        "data-js-tooltip": "Inspect element details",
+        href: pages_object_path(title),
+      }
+    } %>
+    <%= sage_component SageButton, {
+      value: "Opens #{title.titleize} in a new window",
+      style: "secondary",
+      subtle: true,
+      icon: { name: "launch", style: "only" },
+      attributes: {
+        "data-js-tooltip": "Open breakout page",
+        href: pages_breakout_path(type: :object, title: title),
+        target: "_blank",
+      }
+    } %>
   <% end %>
-
+<% end %>
+<%= sage_component SageCard, { spacer: {bottom: :xl} } do %>
   <%= render "examples/objects/#{title}/preview" %>
 <% end %>
+

--- a/app/views/examples/shared/_code.html.erb
+++ b/app/views/examples/shared/_code.html.erb
@@ -1,23 +1,19 @@
-<%= sage_component SagePanel, {
-  spacer: { bottom: :lg, top: :lg }
-} do %>
-  <%= sage_component SagePanelHeader, { title: "SageRails Code" } %>
-  <div class="example__code">
-    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
-    <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
-      <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/", type.pluralize, title, "_preview.html.erb")) %></code></pre>
-    </div>
-  </div>
+<%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+  <h2 id="<%= title %>-example-code">SageRails Code</h2>
 <% end %>
+<div class="example__code sage-spacer-bottom-xl">
+  <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+  <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
+    <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/", type.pluralize, title, "_preview.html.erb")) %></code></pre>
+  </div>
+</div>
 
-<%= sage_component SagePanel, {
-  spacer: { bottom: :lg, top: :lg }
-} do %>
-  <%= sage_component SagePanelHeader, { title: "HTML Code" } %>
-  <div class="example__code">
-    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
-    <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
-      <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
-    </div>
-  </div>
+<%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+  <h2>HTML Code</h2>
 <% end %>
+<div class="example__code sage-spacer-bottom-xl">
+  <button class="example__expand-btn" aria-expanded="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
+  <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
+    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
+  </div>
+</div>

--- a/app/views/examples/shared/_legacy_code.html.erb
+++ b/app/views/examples/shared/_legacy_code.html.erb
@@ -1,9 +1,9 @@
-<%= sage_component SagePanel, { spacer: { bottom: :lg, top: :lg } } do %>
-  <%= sage_component SagePanelHeader, { title: "HTML Code"} %>
-  <div class="example__code">
-    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= title %>">Expand this code snippet</button>
-    <div id="example-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
-      <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "examples/#{type.pluralize}/#{title}/preview") %></code></pre>
-    </div>
-  </div>
+<%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+  <h2 id="<%= title %>-example-code">HTML Code</h2>
 <% end %>
+<div class="example__code sage-spacer-bottom-xl">
+  <button class="example__expand-btn" aria-expanded="false" aria-controls="example-code-<%= title %>">Expand this code snippet</button>
+  <div id="example-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
+    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML render "examples/#{type.pluralize}/#{title}/preview") %></code></pre>
+  </div>
+</div>

--- a/app/views/examples/shared/_preview.html.erb
+++ b/app/views/examples/shared/_preview.html.erb
@@ -1,7 +1,6 @@
-<%= sage_component SagePanel, {} do %>
-  <%= sage_component SagePanelHeader, {} do %>
-    <h2 id="<%= title %>-example-preview" class="sage-panel__title">Preview</h2>
-  <% end %>
-
+<%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+  <h2 id="<%= title %>-example-preview">Preview</h2>
+<% end %>
+<%= sage_component SageCard, { spacer: {bottom: :xl} } do %>
   <%= render "examples/#{type.pluralize}/#{title}/preview" %>
 <% end %>

--- a/app/views/examples/shared/_props.html.erb
+++ b/app/views/examples/shared/_props.html.erb
@@ -1,9 +1,8 @@
 <% if props_content.present? %>
-  <%= sage_component SagePanel, {} do %>
-    <%= sage_component SagePanelHeader, {} do %>
-      <h2 id="<%= @title %>-example-props" class="sage-panel__title">Properties</h2>
-    <% end %>
-
+  <%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+    <h2 id="<%= title %>-example-props">Properties</h2>
+  <% end %>
+  <%= sage_component SageCard, { spacer: {bottom: :xl} } do %>
     <div class="sage-table-wrapper">
       <div class="sage-table-wrapper__overflow">
         <table class="sage-table sage-table--properties">

--- a/app/views/examples/shared/_rules.html.erb
+++ b/app/views/examples/shared/_rules.html.erb
@@ -1,17 +1,21 @@
 <% if do_content.present? || dont_content.present? %>
-  <%= sage_component SagePanel, {} do %>
-    <%= sage_component SagePanelHeader, {} do %>
-      <h2 id="<%= @title %>-example-best-practices" class="sage-panel__title">Best Practices</h2>
-    <% end %>
-
-    <%= sage_component SagePanelRow, { grid_template: "m", vertical_align: "start" } do %>
-      <%= sage_component SagePanelStack, {} do %>
-        <%= sage_component SagePanelSubheader, { title: "Do" } %>
+  <%= sage_component SageCardRow, { grid_template: "te", spacer: {bottom: :sm} } do %>
+    <h2 id="<%= title %>-example-best-practices">Best Practices</h2>
+  <% end %>
+  <%= sage_component SageCard, { spacer: {bottom: :xl} } do %>
+    <%= sage_component SageGridRow, { } do %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "6" } do %> 
+        <%= sage_component SageLabel, {
+          color: "success",
+          value: "Do",
+        } %>
         <%= do_content %>
       <% end %>
-
-      <%= sage_component SagePanelStack, {} do %>
-        <%= sage_component SagePanelSubheader, { title: "Don't" } %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "6" } do %> 
+        <%= sage_component SageLabel, {
+            color: "danger",
+            value: "Don't",
+          } %>
         <%= dont_content %>
       <% end %>
     <% end %>

--- a/app/views/pages/elements.html.erb
+++ b/app/views/pages/elements.html.erb
@@ -16,8 +16,6 @@
     </ul>
   </div>
 <% end %>
-<div class="sage-panel-set">
-  <% sorted_sage_elements.each do |element| %>
-    <%= render "examples/elements/element_preview", title: element[:title], description: element[:description] %>
-  <% end %>
-</div>
+<% sorted_sage_elements.each do |element| %>
+  <%= render "examples/elements/element_preview", title: element[:title], description: element[:description] %>
+<% end %>

--- a/app/views/pages/objects.html.erb
+++ b/app/views/pages/objects.html.erb
@@ -17,8 +17,6 @@ These Objects take on their own properties and serve as the backbone of our desi
     </ul>
   </div>
 <% end %>
-<div class="sage-panel-set">
-  <% sorted_sage_objects.each do |object| %>
-    <%= render "examples/objects/object_preview", title: object[:title], description: object[:description] %>
-  <% end %>
-</div>
+<% sorted_sage_objects.each do |object| %>
+  <%= render "examples/objects/object_preview", title: object[:title], description: object[:description] %>
+<% end %>

--- a/lib/sage-frontend/stylesheets/docs/_example.scss
+++ b/lib/sage-frontend/stylesheets/docs/_example.scss
@@ -129,7 +129,6 @@ $-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
   overflow: hidden;
   position: relative;
   max-height: $-example-code-preview-height;
-  margin: 0 0 sage-spacing();
 
   .prettyprint {
     margin-bottom: 0;


### PR DESCRIPTION
## Description
Finishing up removing the panels from the Design System Docs and using cards instead. This cleans up the look but makes it simpler to browse. Also moves to use labels in the previews to clean up that look also. I believe that @philschanely is thinking about ways to improve that experience as a whole so didn't refactor everything but gave it as an example.

### Screenshots
<img width="1113" alt="Screen Shot 2020-11-02 at 4 54 13 PM" src="https://user-images.githubusercontent.com/14350772/97934977-156a8100-1d2c-11eb-9ddd-231086b4f852.png">
