### PR TITLE
Sage docs cleanup

### DIFF
--- a/app/views/examples/elements/checkbox/_preview.html.erb
+++ b/app/views/examples/elements/checkbox/_preview.html.erb
@@ -1,6 +1,6 @@
 <!-- Default -->
-<%= sage_component SagePanelStack, {} do %>">
-  <%= sage_component SageCheckbox, { 
+<%= sage_component SagePanelStack, {} do %>
+  <%= sage_component SageCheckbox, {
     id:"c1",
     label_text: "Checkbox",
     checked: false,
@@ -9,7 +9,7 @@
   } %>
 
   <!-- Checked -->
-  <%= sage_component SageCheckbox, { 
+  <%= sage_component SageCheckbox, {
     id: "c2",
     label_text: "Checked",
     checked: true,
@@ -18,7 +18,7 @@
   } %>
 
   <!-- Disabled -->
-  <%= sage_component SageCheckbox, { 
+  <%= sage_component SageCheckbox, {
     id: "c3",
     label_text: "Disabled",
     checked: false,
@@ -27,7 +27,7 @@
   } %>
 
   <!-- Checked and disabled -->
-  <%= sage_component SageCheckbox, { 
+  <%= sage_component SageCheckbox, {
     id: "c4",
     label_text: "Checked and disabled",
     checked: true,
@@ -36,7 +36,7 @@
   } %>
 
   <!-- Error -->
-  <%= sage_component SageCheckbox, { 
+  <%= sage_component SageCheckbox, {
     id: "c5",
     label_text: "Error",
     checked: false,
@@ -45,7 +45,7 @@
   } %>
 
   <!-- Checked & Error -->
-  <%= sage_component SageCheckbox, { 
+  <%= sage_component SageCheckbox, {
     id: "c6",
     label_text: "Checked & Error",
     checked: true,

--- a/app/views/examples/elements/link/_preview.html.erb
+++ b/app/views/examples/elements/link/_preview.html.erb
@@ -1,7 +1,5 @@
-
-
 <h3>Standard link</h3>
-<%= sage_component SagePanelStack, {} do %>">
+<%= sage_component SagePanelStack, {} do %>
   <%= render "examples/elements/link/markup",
     url: "#",
     label: "Standard link",
@@ -21,7 +19,7 @@
 <% end %>
 
 <h3>External links</h3>
-<%= sage_component SagePanelStack, {} do %>">
+<%= sage_component SagePanelStack, {} do %>
   <%= render "examples/elements/link/markup",
     url: "https://example.com",
     label: "External link",
@@ -41,7 +39,7 @@
 <% end %>
 
 <h3>Help/Info links</h3>
-<%= sage_component SagePanelStack, {} do %>">
+<%= sage_component SagePanelStack, {} do %>
   <%= render "examples/elements/link/markup",
     url: "#",
     label: "Get help",

--- a/app/views/examples/elements/radio/_preview.html.erb
+++ b/app/views/examples/elements/radio/_preview.html.erb
@@ -1,6 +1,6 @@
 <!-- Default -->
-<%= sage_component SagePanelStack, {} do %>">
-  <%= sage_component SageRadio, { 
+<%= sage_component SagePanelStack, {} do %>
+  <%= sage_component SageRadio, {
     id: "r1",
     name: "radio1",
     value: "1",
@@ -8,7 +8,7 @@
     checked: true
   } %>
 
-  <%= sage_component SageRadio, { 
+  <%= sage_component SageRadio, {
     id: "r2",
     name: "radio1",
     value: "2",
@@ -16,7 +16,7 @@
   } %>
 
   <!-- Disabled -->
-  <%= sage_component SageRadio, { 
+  <%= sage_component SageRadio, {
     id: "r3",
     name: "radio2",
     value: "3",
@@ -25,7 +25,7 @@
   } %>
 
   <!-- Checked & Disabled -->
-  <%= sage_component SageRadio, { 
+  <%= sage_component SageRadio, {
     id: "r4",
     name: "radio3",
     value: "4",
@@ -35,7 +35,7 @@
   } %>
 
   <!-- Errror -->
-  <%= sage_component SageRadio, { 
+  <%= sage_component SageRadio, {
     id: "r5",
     name: "radio4",
     value: "5",

--- a/app/views/pages/elements.html.erb
+++ b/app/views/pages/elements.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :heading do %>
 <%= md(%(
 # Elements
-<p class="docs-heading__lead">Elements are the basic building blocks of matter. Applied to web interfaces, atoms are our HTML tags, such as a form label, an input or a button.</p>
+<p class="docs-heading__lead">Elements are the basic building blocks. Applied to web interfaces, elements are our HTML tags, such as a form label, an input or a button.</p>
 )) %>
 <% end %>
 <%= content_for :quick_links do %>

--- a/app/views/pages/objects.html.erb
+++ b/app/views/pages/objects.html.erb
@@ -1,9 +1,9 @@
 <%= content_for :heading do %>
 <%= md(%(
 # Objects
-<p class="docs-heading__lead">Objects are groups of atoms bonded together and are the smallest fundamental units of a compound.</p>
+<p class="docs-heading__lead">Objects are groups of elements bonded together.
 
-These Objects take on their own properties and serve as the backbone of our design systems.
+These Objects take on their own properties and serve as the backbone of our design systems.</p>
 
 )) %>
 <% end %>

--- a/lib/sage-frontend/javascript/system/tabs.js
+++ b/lib/sage-frontend/javascript/system/tabs.js
@@ -75,6 +75,8 @@ Sage.tabs = (function() {
     let elTabsParent = document.querySelector(`[${SELECTOR_TABS}="${tabsId}"]`);
     let elTab = elTabsParent.querySelector(`[${SELECTOR_TAB_ITEM}="${paneId}"]`);
     let tabsArray = Sage.util.nodelistToArray( elTabsParent.querySelectorAll(`[${SELECTOR_TAB_ITEM}]`) );
+    let elPane = document.querySelector(`[${SELECTOR_TAB_PANE}="${paneId}"]`);
+    let panesArray = elPane !== null ? Sage.util.nodelistToArray( elPane.parentElement.querySelectorAll(`[${SELECTOR_TAB_PANE}]`) ) : null;
 
     tabsArray.forEach((el) => {
       el.classList.remove(el.getAttribute(ACTIVE_CLASS_ATTRIBUTE));
@@ -89,11 +91,10 @@ Sage.tabs = (function() {
       elTab.focus();
     }
 
-    let elPane = document.querySelector(`[${SELECTOR_TAB_PANE}="${paneId}"]`);
-    let panesArray = Sage.util.nodelistToArray( elPane.parentElement.querySelectorAll(`[${SELECTOR_TAB_PANE}]`) );
-
-    panesArray.forEach((el) => el.classList.remove(CLASS_TAB_PANE_ACTIVE));
-    elPane.classList.add(CLASS_TAB_PANE_ACTIVE);
+    if (panesArray) {
+      panesArray.forEach((el) => el.classList.remove(CLASS_TAB_PANE_ACTIVE));
+      elPane.classList.add(CLASS_TAB_PANE_ACTIVE);
+    }
   }
 
   function dispatchChange(tabsId, paneId, evType) {


### PR DESCRIPTION
## Description
Noticed a few small nitpicky things as I was using the docs site quite a bit this week.

- removed extra closing tag markup from checkbox, radio, and link element preview
- wiped references to atomic design language 😿 
- corrects a console error with a guard in `tabs.js`
