### PR TITLE
Add message and error coloring to textarea

### DIFF
--- a/app/views/examples/elements/form_textarea/_markup.html.erb
+++ b/app/views/examples/elements/form_textarea/_markup.html.erb
@@ -1,6 +1,7 @@
-<div class="sage-textarea">
-    <textarea class="sage-textarea__field" id="<%= id %>" name="<%= id %>" placeholder="<%= placeholder %>" <%= disabled ? "disabled" : "" %>><% if content != "" %><%= content %><% end %></textarea>
-    <% if label_text != "" %>
-    <label for="<%= id %>" class="sage-textarea__label"><%= label_text %></label>
-    <% end %>
-  </div>
+<div class="sage-textarea<% if has_error %> sage-textarea--error<% end %>">
+  <textarea class="sage-textarea__field" id="<%= id %>" name="<%= id %>" placeholder="<%= placeholder %>" <%= disabled ? "disabled" : "" %>><% if content != "" %><%= content %><% end %></textarea>
+  <% if label_text != "" %>
+  <label for="<%= id %>" class="sage-textarea__label"><%= label_text %></label>
+  <% end %>
+  <% if message_text != "" %><div class="sage-textarea__message"><%= message_text %></div><% end %>
+</div>

--- a/app/views/examples/elements/form_textarea/_preview.html.erb
+++ b/app/views/examples/elements/form_textarea/_preview.html.erb
@@ -6,7 +6,20 @@
     placeholder: "Your message",
     label_text: "Your message",
     disabled: false,
-    content: ""
+    has_error: false,
+    content: "",
+    message_text: ""
+  %>
+  
+  <h3 class="t-sage-heading-6">Error</h3>
+  <%= render "examples/elements/form_textarea/markup",
+    id: "txtarea-example",
+    placeholder: "Your message",
+    label_text: "Your message",
+    disabled: false,
+    content: "",
+    has_error: true,
+    message_text: "Error message"
   %>
 
   <h3 class="t-sage-heading-6">No label (placeholder only)</h3>
@@ -15,7 +28,9 @@
     placeholder: "Your message",
     label_text: "",
     disabled: false,
-    content: ""
+    has_error: false,
+    content: "",
+    message_text: ""
   %>
 
   <h3 class="t-sage-heading-6">Disabled</h3>
@@ -24,7 +39,9 @@
     placeholder: "Your message",
     label_text: "Your message",
     disabled: true,
-    content: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Praesent commodo cursus magna, vel scelerisque nisl consectetur et."
+    has_error: false,
+    content: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.",
+    message_text: ""
   %>
 
 </fieldset>

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_form_textarea.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_form_textarea.scss
@@ -41,6 +41,10 @@
 .sage-textarea__message {
   @extend %t-sage-body-xsmall;
   color: sage-color(charcoal, 100);
+
+  .sage-textarea--error & {
+    color: $sage-inputfield-color-error;
+  }
 }
 
 .sage-textarea__field {


### PR DESCRIPTION
## Description

Add message and error coloring to textarea

<img width="808" alt="Screen Shot 2020-11-05 at 5 46 42 PM" src="https://user-images.githubusercontent.com/17955295/98304908-e0119d80-1f8e-11eb-9256-e22481518be7.png">