### PR TITLE
Moved dropdown item icons to the right of the text

### DIFF
--- a/lib/sage-frontend/stylesheets/system/core/_icons.scss
+++ b/lib/sage-frontend/stylesheets/system/core/_icons.scss
@@ -70,9 +70,9 @@ $sage-icon-li-margin-right: 0.4em !default;
     @include sage-icon-base($icon-name);
   }
 
-  .sage-dropdown__item-control--icon-#{$icon-name}::before {
+  .sage-dropdown__item-control--icon-#{$icon-name}::after {
     @include sage-icon-base($icon-name);
-    margin: 0 sage-spacing(xs) 0 0;
+    margin: 0 0 0 sage-spacing(xs);
   }
 
   .sage-label--icon-left-#{$icon-name} {


### PR DESCRIPTION
## Description
Moved the `check` icon within `.sage-dropdown__item-control` to the right of the text. We're correcting misalignment of the text when an icon is present


### Screenshots
|  before  |  after  |
|--------|--------|
|![Screen_Shot_2020-11-06_at_3_03_19_PM](https://user-images.githubusercontent.com/1241836/98414738-86b67680-2041-11eb-9989-0d3ef09fdf7c.png)|![Screen_Shot_2020-11-06_at_3_01_31_PM](https://user-images.githubusercontent.com/1241836/98414748-8c13c100-2041-11eb-839e-90ab64141428.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the dropdown page: http://localhost:4000/pages/object/dropdown
2. Click the `select` dropdown and verify that the icon is on the right of the text
  * if you don't see an icon
    * Choose one of the dropdown items
    * Open the dropdown again then right-click on the previously selected dropdown item
    * In the inspector, `edit as HTML` that `.sage-dropdown__item-control`
    * Append the class `.sage-dropdown__item-control--icon-check` to the element and verify the placement of the icon 
