### PR TITLE
Remove border from first and last catalog item

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_catalog_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_catalog_item.scss
@@ -19,11 +19,11 @@ $-image-height-mobile: rem(120px);
   border-bottom: sage-border(light);
 
   &:first-child {
-    border-top: none;
+    border-top: 0;
   }
 
   &:last-child {
-    border-bottom: none;
+    border-bottom: 0;
   }
 
   &.sage-catalog-item--loading {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_catalog_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_catalog_item.scss
@@ -19,11 +19,11 @@ $-image-height-mobile: rem(120px);
   border-bottom: sage-border(light);
 
   &:first-child {
-    border-top: sage-border();
+    border-top: none;
   }
 
   &:last-child {
-    border-bottom: sage-border();
+    border-bottom: none;
   }
 
   &.sage-catalog-item--loading {


### PR DESCRIPTION
## Description
Removed the `border-top` from the first Catalog Item child and `border-bottom` from the last Catalog Item child

### Screenshots
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-11-06 at 4 40 16 PM](https://user-images.githubusercontent.com/1241836/98421967-3692e080-2050-11eb-8692-cef0ed087379.png)|![Screen Shot 2020-11-06 at 4 43 57 PM](https://user-images.githubusercontent.com/1241836/98421984-3f83b200-2050-11eb-91ea-c371226ec275.png)|


## Test notes
### Steps for testing
1. Visit the catalog items page: http://localhost:4000/pages/object/catalog_item

