### PR TITLE
Add reset button to search rails component

### DIFF
--- a/app/views/examples/elements/search/_preview.html.erb
+++ b/app/views/examples/elements/search/_preview.html.erb
@@ -1,12 +1,16 @@
 <h3 class="t-sage-heading-6">Default</h3>
 <%= sage_component SageSearch, {
+  id: "search-1",
   placeholder: "Search Products",
-  value: nil
+  value: nil,
+  label_text: "Search"
 } %>
 
 <h3 class="t-sage-heading-6">Contained</h3>
 <%= sage_component SageSearch, {
+  id: "search-2",
   placeholder: "Search Products",
   value: nil,
-  contained: true
+  contained: true,
+  label_text: "Search"
 } %>

--- a/app/views/examples/elements/search/_props.html.erb
+++ b/app/views/examples/elements/search/_props.html.erb
@@ -1,4 +1,10 @@
 <tr>
+  <td>id</td>
+  <td>Unique identifier for the search. Should match the "for" attribute on the corresponding label.</td>
+  <td>String</td>
+  <td></td>
+</tr>
+<tr>
   <td>value</td>
   <td>The value of the search input.</td>
   <td>String</td>
@@ -14,5 +20,11 @@
   <td>contained</td>
   <td>Is in the context of a "search toolbar" area.</td>
   <td>Boolean</td>
+  <td></td>
+</tr>
+<tr>
+  <td>label_text</td>
+  <td>The value of the search label.</td>
+  <td>String</td>
   <td></td>
 </tr>

--- a/lib/sage-frontend/javascript/system/index.js
+++ b/lib/sage-frontend/javascript/system/index.js
@@ -20,5 +20,6 @@ require('./accordion-panel')
 require('./copy-button')
 require('./panel-controls')
 require('./popover')
+require('./search')
 
 require('./init')

--- a/lib/sage-frontend/javascript/system/init.js
+++ b/lib/sage-frontend/javascript/system/init.js
@@ -41,6 +41,7 @@ Sage.init = function(elementNamesToInitLegacy) {
   initDocumentPresenceListener('[data-js-tabs]',                                 Sage.tabs.init,          Sage.tabs.unbind);
   initDocumentPresenceListener('[data-js-copy-button]',                          Sage.copyButton.init,    Sage.copyButton.unbind);
   initDocumentPresenceListener('[data-js-accordion="header"]',                   Sage.accordion.init,     Sage.accordion.unbind);
+  initDocumentPresenceListener('[data-js-search]',                               Sage.search.init,        Sage.search.unbind);
   initDocumentPresenceListener('[data-js-select]',                               Sage.select.init,        Sage.select.unbind);
   initDocumentPresenceListener('[data-js-panel-controls]',                       Sage.panelControls.init, Sage.panelControls.unbind);
   initDocumentPresenceListener('[data-js-popover]',                              Sage.popover.init,       Sage.popover.unbind);

--- a/lib/sage-frontend/javascript/system/search.js
+++ b/lib/sage-frontend/javascript/system/search.js
@@ -1,0 +1,47 @@
+Sage.search = (function() {
+  // ==================================================
+  // Variables
+  // ==================================================
+
+  const SELECTOR_SEARCH_INPUT = '.sage-search__input';
+  const CLASS_VISIBLE = 'sage-search--has-text';
+
+
+  // ==================================================
+  // Functions
+  // ==================================================
+
+  function init(el) {
+    el.addEventListener('keydown', searchOnInputHandler);
+  }
+
+  function unbind(el) {
+    el.removeEventListener('keydown', searchOnInputHandler);
+  }
+
+  function searchOnInputHandler(evt) {
+    const elParent = evt.currentTarget;
+    const elInput = elParent.querySelector(SELECTOR_SEARCH_INPUT);
+
+    hasValue(elInput) ? addVisibleButtonState(elParent) : removeVisibleButtonState(elParent);
+  }
+
+  // check if the search value has text or not
+  function hasValue(el) {
+    return el.value.length >= 0
+  }
+
+  function addVisibleButtonState(elParent) {
+    elParent.classList.add(CLASS_VISIBLE);
+  }
+
+  function removeVisibleButtonState(elParent) {
+    elParent.classList.remove(CLASS_VISIBLE);
+  }
+
+  return {
+    init: init,
+    unbind: unbind
+  }
+
+})();

--- a/lib/sage-frontend/javascript/system/search.js
+++ b/lib/sage-frontend/javascript/system/search.js
@@ -3,7 +3,9 @@ Sage.search = (function() {
   // Variables
   // ==================================================
 
+  const SELECTOR_SEARCH = 'data-js-search';
   const SELECTOR_SEARCH_INPUT = '.sage-search__input';
+  const SELECTOR_SEARCH_BUTTON = '.sage-search__reset-button';
   const CLASS_VISIBLE = 'sage-search--has-text';
 
 
@@ -12,11 +14,17 @@ Sage.search = (function() {
   // ==================================================
 
   function init(el) {
+    const elButton = el.querySelector(SELECTOR_SEARCH_BUTTON);
+
     el.addEventListener('keydown', searchOnInputHandler);
+    elButton.addEventListener('click', searchClearClickHandler);
   }
 
   function unbind(el) {
+    const elButton = el.querySelector(SELECTOR_SEARCH_BUTTON);
+
     el.removeEventListener('keydown', searchOnInputHandler);
+    elButton.removeEventListener('click', searchClearClickHandler);
   }
 
   function searchOnInputHandler(evt) {
@@ -24,6 +32,15 @@ Sage.search = (function() {
     const elInput = elParent.querySelector(SELECTOR_SEARCH_INPUT);
 
     hasValue(elInput) ? addVisibleButtonState(elParent) : removeVisibleButtonState(elParent);
+  }
+
+  function searchClearClickHandler(evt) {
+    const elParent = evt.currentTarget.closest(`[${SELECTOR_SEARCH}]`);
+    const elInput = elParent.querySelector(SELECTOR_SEARCH_INPUT);
+
+    elParent.classList.remove(CLASS_VISIBLE);
+    elInput.value = ""; /* reset the search field */
+    elInput.blur(); /* force refresh with blur event */
   }
 
   // check if the search value has text or not

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
@@ -92,6 +92,10 @@ $-search-icon: "::before";
   }
 }
 
+.sage-search__label {
+  @include visually-hidden()
+}
+
 .sage-search__input {
   position: relative;
   z-index: 1;

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
@@ -92,8 +92,9 @@ $-search-icon: "::before";
   }
 }
 
-.sage-search__label {
-  @include visually-hidden()
+.sage-search__label,
+.sage-search__clear-button-text {
+  @include visually-hidden();
 }
 
 .sage-search__input {
@@ -116,5 +117,21 @@ $-search-icon: "::before";
 
   .sage-panel-controls__toolbar & {
     border-radius: sage-border(radius);
+  }
+
+  // remove default webkit search field styling
+  &::-webkit-search-decoration,
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-results-button,
+  &::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+}
+
+.sage-search__reset-button {
+  visibility: hidden;
+
+  .sage-search--has-text & {
+    visibility: visible;
   }
 }

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
@@ -129,6 +129,7 @@ $-search-icon: "::before";
 }
 
 .sage-search__reset-button {
+  margin-right: sage-spacing(xs);
   visibility: hidden;
 
   .sage-search--has-text & {

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
@@ -124,7 +124,7 @@ $-search-icon: "::before";
   &::-webkit-search-cancel-button,
   &::-webkit-search-results-button,
   &::-webkit-search-results-decoration {
-    -webkit-appearance: none;
+    -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
   }
 }
 

--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_search.scss
@@ -129,8 +129,8 @@ $-search-icon: "::before";
 }
 
 .sage-search__reset-button {
-  margin-right: sage-spacing(xs);
   visibility: hidden;
+  margin-right: sage-spacing(xs);
 
   .sage-search--has-text & {
     visibility: visible;

--- a/lib/sage_rails/app/sage_components/sage_search.rb
+++ b/lib/sage_rails/app/sage_components/sage_search.rb
@@ -1,5 +1,7 @@
 class SageSearch < SageComponent
+  attr_accessor :id
   attr_accessor :value
   attr_accessor :placeholder
   attr_accessor :contained
+  attr_accessor :label_text
 end

--- a/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -1,11 +1,19 @@
-<div class="
-  sage-search
-  <%= "sage-search--contained" if component.contained %>
-">
-  <input
-    class="sage-search__input"
-    type="search"
-    placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
-    value="<%= component.value %>"
-  />
-</div>
+<form>
+  <div 
+    role="search"
+    class="
+    sage-search
+    <%= "sage-search--contained" if component.contained %>
+  ">
+    <label for="<%= component.id %>" class="sage-search__label">
+      <%= component.label_text %>
+    </label>
+    <input
+      id="<%= component.id %>"
+      class="sage-search__input"
+      type="search"
+      placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
+      value="<%= component.value %>"
+    />
+  </div>
+</form>

--- a/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -17,13 +17,16 @@
       placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
       value="<%= component.value %>"
     />
-    
-    <%# TODO UXD: update Sage Button to accept a type parameter so that we can allow a type=reset here %>
-    <button 
-      class="sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove sage-search__reset-button" 
-      type="reset"
-    >
-      <span class="sage-search__clear-button-text">clear search</span>
-    </button>
+    <%= sage_component SageButton, {
+      value: "Clear Search",
+      style: "secondary",
+      css_classes: "sage-search__reset-button",
+      subtle: true,
+      icon: {
+        style: "only",
+        name: "remove"
+      }
+    } %>
+
   </div>
 </form>

--- a/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -1,10 +1,12 @@
 <form>
   <div 
     role="search"
-    class="
-    sage-search
+    class=" sage-search
     <%= "sage-search--contained" if component.contained %>
-  ">
+    "
+    data-js-search
+
+  >
     <label for="<%= component.id %>" class="sage-search__label">
       <%= component.label_text %>
     </label>
@@ -15,5 +17,13 @@
       placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
       value="<%= component.value %>"
     />
+    
+    <%# TODO UXD: update Sage Button to accept a type parameter so that we can allow a type=reset here %>
+    <button 
+      class="sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove sage-search__reset-button" 
+      type="reset"
+    >
+      <span class="sage-search__clear-button-text">clear search</span>
+    </button>
   </div>
 </form>

--- a/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -1,32 +1,30 @@
-<form>
-  <div 
-    role="search"
-    class=" sage-search
-    <%= "sage-search--contained" if component.contained %>
-    "
-    data-js-search
+<form 
+  role="search"
+  class=" sage-search
+  <%= "sage-search--contained" if component.contained %>
+  "
+  data-js-search
 
-  >
-    <label for="<%= component.id %>" class="sage-search__label">
-      <%= component.label_text %>
-    </label>
-    <input
-      id="<%= component.id %>"
-      class="sage-search__input"
-      type="search"
-      placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
-      value="<%= component.value %>"
-    />
-    <%= sage_component SageButton, {
-      value: "Clear Search",
-      style: "secondary",
-      css_classes: "sage-search__reset-button",
-      subtle: true,
-      icon: {
-        style: "only",
-        name: "remove"
-      }
-    } %>
+>
+  <label for="<%= component.id %>" class="sage-search__label">
+    <%= component.label_text %>
+  </label>
+  <input
+    id="<%= component.id %>"
+    class="sage-search__input"
+    type="search"
+    placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
+    value="<%= component.value %>"
+  />
+  <%= sage_component SageButton, {
+    value: "Clear Search",
+    style: "secondary",
+    css_classes: "sage-search__reset-button",
+    subtle: true,
+    icon: {
+      style: "only",
+      name: "remove"
+    }
+  } %>
 
-  </div>
 </form>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adding a custom reset button to clear any inserted text. The button is only visible is text is present
- [x] - Added a dymanic reset buton
- [x] - Added `<form>` and `<label>` for a11y
- [x] - The reset should refresh the page in addition to clearing text - this event fires in `kajabi-products`

### Screenshots
|  before  |  after  |
|--------|--------|
|![search-before](https://user-images.githubusercontent.com/1241836/98706671-bbc61000-2344-11eb-8190-9706b039c9d8.gif)|![search-after](https://user-images.githubusercontent.com/1241836/98706688-c1bbf100-2344-11eb-93ce-0d40a0df1eae.gif)|

### Steps for testing
1. Visit the Sage search page: http://localhost:4000/pages/element/search
2. Type text into the search field and notice the `x` icon to the right
3. Click the `x` and observe the page refresh


## Related
- https://kajabi.atlassian.net/browse/BUILD-347 -> `Adding a clear icon to the search bar`
