### PR TITLE
Sortable: Match New Comps

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -16,8 +16,19 @@
   align-items: center;
   padding: sage-spacing(xs) $sage-panel-padding;
   background: sage-color(white);
-  border-bottom: sage-border(light);
+  border-bottom: sage-border();
+  border-left: sage-border();
+  border-right: sage-border();
   cursor: grab;
+
+  &:first-child {
+    border-radius: sage-border(radius) sage-border(radius) 0 0;
+    border-top: sage-border();
+  }
+
+  &:last-child {
+    border-radius: 0 0 sage-border(radius) sage-border(radius);
+  }
 
   &::before {
     @include sage-icon-base(handle);

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -16,19 +16,7 @@
   align-items: center;
   padding: sage-spacing(xs) $sage-panel-padding;
   background: sage-color(white);
-  border-bottom: sage-border();
-  border-left: sage-border();
-  border-right: sage-border();
   cursor: grab;
-
-  &:first-child {
-    border-radius: sage-border(radius) sage-border(radius) 0 0;
-    border-top: sage-border();
-  }
-
-  &:last-child {
-    border-radius: 0 0 sage-border(radius) sage-border(radius);
-  }
 
   &::before {
     @include sage-icon-base(handle);
@@ -47,24 +35,19 @@
 
   &.sage-sortable__item--card {
     padding: sage-spacing(xs) $sage-card-padding;
-    border: sage-border();
-    border-radius: sage-border(radius-large);
+    border-bottom: sage-border();
+    border-left: sage-border();
+    border-right: sage-border();
     transition: $sage-transition;
     transition-property: border-color, box-shadow;
 
-    &:not(:last-child) {
-      margin-bottom: sage-spacing(xs);
+    &:first-child {
+      border-radius: sage-border(radius) sage-border(radius) 0 0;
+      border-top: sage-border();
     }
 
-    &:focus,
-    &:hover {
-      box-shadow: sage-shadow(sm);
-    }
-
-    &.sage-sortable__item--active,
-    &:active {
-      border-color: sage-color(primary);
-      box-shadow: sage-shadow(md);
+    &:last-child {
+      border-radius: 0 0 sage-border(radius) sage-border(radius);
     }
   }
 


### PR DESCRIPTION
## Description
Updates Sortable default styles to match new comps.
https://www.figma.com/file/TO8XSqt6tgscFcShhkWVdm/Products-Admin?node-id=1008%3A3304

### Screenshots

|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/98691794-a7294e00-232b-11eb-84ae-87fa09063569.png)|![image](https://user-images.githubusercontent.com/565743/98691759-9c6eb900-232b-11eb-8d0c-eb258c5aca04.png)|


## Test notes

### Steps for testing
n/a, this is only lipstick :)


## Related
https://github.com/Kajabi/kajabi-products/pull/16475

