### PR TITLE
Hide TabsPane Spacing When Empty

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_tabs.scss
@@ -32,7 +32,7 @@
   visibility: hidden;
 }
 
-.sage-tabs-pane--active {
+.sage-tabs-pane--active:not(:empty) {
   display: block;
   visibility: visible;
 


### PR DESCRIPTION
## Description
Hide TabsPane extra grid spacing when empty.

### Screenshots

|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/98827737-6fd2a400-23f4-11eb-8706-2dc152941771.png)|![image](https://user-images.githubusercontent.com/565743/98827570-4285f600-23f4-11eb-96d9-e0ee77cf2ef3.png)|


## Related
https://github.com/Kajabi/kajabi-products/pull/16481
