### PR TITLE
Outline Item - Added transition-delay to secondary actions

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -165,14 +165,16 @@ $-collapse-breakpoint-key: lg-max;
   }
 
   @media (min-width: sage-breakpoint($-collapse-breakpoint-key)) {
-    display: none;
     visibility: hidden;
+    transition: opacity $sage-transition;
+    transition-delay: 0.1s;
+    opacity: 0;
 
     :hover > &,
     :focus > &,
     :focus-within > & {
-      display: flex;
       visibility: visible;
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
## Description
Added a `transition-delay` to the `.sage-outline-item__actions-secondary`

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![outline-item-transition-delay-before](https://user-images.githubusercontent.com/1241836/98852445-4e39e280-241d-11eb-9335-cc26326fb275.gif)|![outline-item-transition-delay-after](https://user-images.githubusercontent.com/1241836/98852467-542fc380-241d-11eb-8e62-183387188368.gif)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the OutlineItem page: http://localhost:4000/pages/object/outline_item
1. Hover a row and observe the `transition-delay`
