### PR TITLE
EmptyState Size/Icon, Card DashedBorder

### DIFF
--- a/app/views/examples/objects/card/_preview.html.erb
+++ b/app/views/examples/objects/card/_preview.html.erb
@@ -21,11 +21,20 @@
   <% end %>
 <% end %>
 
+<%= sage_component SageCard, { border_dashed: true } do %>
+  <%= sage_component SageCardBlock, { type_block: true } do %>
+    <p>
+      A card with a dashed border. (<code>border_dashed</code>)
+    </p>
+  <% end %>
+<% end %>
+
+
 <%= md("
 Cards have three core areas:
 
-- **Header** — 
-  `.sage-card__header` 
+- **Header** —
+  `.sage-card__header`
   (optional) This area usually contains at least a title (`sage-card__title`)
   and often an icon or menu flanking the right corner.
   It employs the Sage Row layout base with `16px` gutters.
@@ -69,7 +78,7 @@ Cards have three core areas:
     These can also be nested inside each other for compound configurations.
 
 - **Footer** —
-  `.sage-card__footer` 
+  `.sage-card__footer`
   (optional) This area is less common in cards than on panels
   but when used it often contains one or more buttons
   that can be sent to the right edge of the card

--- a/app/views/examples/objects/card/_props.html.erb
+++ b/app/views/examples/objects/card/_props.html.erb
@@ -10,3 +10,9 @@
   <td>String</td>
   <td><code>null</code></td>
 </tr>
+<tr>
+  <td>border_dashed</td>
+  <td>Uses our Sage dashed border styles</td>
+  <td>Boolean</td>
+  <td><code>false</code></td>
+</tr>

--- a/app/views/examples/objects/empty_state/_preview.html.erb
+++ b/app/views/examples/objects/empty_state/_preview.html.erb
@@ -1,6 +1,16 @@
 <%= sage_component SageEmptyState, {
+  icon: "trash",
   title: "Title for state",
   text: "Text to appear below. Lorem ipsum dolor sit amet consectituor."
+} do %>
+  <p>Other stuff such as buttons...</p>
+<% end %>
+
+<%= sage_component SageEmptyState, {
+  icon: "bold",
+  title: "Title for state, small variety",
+  text: "Text to appear below. Lorem ipsum dolor sit amet consectituor.",
+  size: "sm",
 } do %>
   <p>Other stuff such as buttons...</p>
 <% end %>

--- a/app/views/examples/objects/empty_state/_preview.html.erb
+++ b/app/views/examples/objects/empty_state/_preview.html.erb
@@ -8,9 +8,9 @@
 
 <%= sage_component SageEmptyState, {
   icon: "bold",
-  title: "Title for state, small variety",
+  title: "Title for state, compact variety",
   text: "Text to appear below. Lorem ipsum dolor sit amet consectituor.",
-  size: "sm",
+  compact: true,
 } do %>
   <p>Other stuff such as buttons...</p>
 <% end %>

--- a/app/views/examples/objects/empty_state/_props.html.erb
+++ b/app/views/examples/objects/empty_state/_props.html.erb
@@ -1,8 +1,8 @@
 <tr>
-  <td>size</td>
+  <td>compact</td>
   <td>Adjusts the vertical padding of component for smaller contexts</td>
-  <td>String</td>
-  <td><code>null | "sm"</code></td>
+  <td>boolean</td>
+  <td><code>false</code></td>
 </tr>
 <tr>
   <td>icon</td>

--- a/app/views/examples/objects/empty_state/_props.html.erb
+++ b/app/views/examples/objects/empty_state/_props.html.erb
@@ -4,3 +4,9 @@
   <td>String</td>
   <td><code>null | "sm"</code></td>
 </tr>
+<tr>
+  <td>icon</td>
+  <td>Adds an icon above the content</td>
+  <td>String</td>
+  <td><code>null | icon-name</code></td>
+</tr>

--- a/app/views/examples/objects/empty_state/_props.html.erb
+++ b/app/views/examples/objects/empty_state/_props.html.erb
@@ -1,1 +1,6 @@
-
+<tr>
+  <td>size</td>
+  <td>Adjusts the vertical padding of component for smaller contexts</td>
+  <td>String</td>
+  <td><code>null | "sm"</code></td>
+</tr>

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
@@ -22,7 +22,7 @@
 }
 
 .sage-card--border-dashed {
-  border: unset;
+  border-color: sage-color(white);
   @include sage-dashed-border(
     $border-radius: $sage-card-border-radius,
     $color: sage-color(grey, 300),

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_card.scss
@@ -21,6 +21,14 @@
   padding-bottom: 0;
 }
 
+.sage-card--border-dashed {
+  border: unset;
+  @include sage-dashed-border(
+    $border-radius: $sage-card-border-radius,
+    $color: sage-color(grey, 300),
+  );
+}
+
 .sage-card__footer {
   @include sage-grid-card-row();
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_empty_state.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_empty_state.scss
@@ -15,6 +15,15 @@
   @include sage-grid-panel();
 }
 
+.sage-empty-state--size-sm {
+  padding-top: sage-spacing(xs);
+  padding-bottom: sage-spacing(xs);
+}
+
+.sage-empty-state__icon {
+  color: sage-color(charcoal, 100);
+}
+
 .sage-empty-state__title {
   @extend %t-sage-heading-4;
 

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_empty_state.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_empty_state.scss
@@ -15,7 +15,7 @@
   @include sage-grid-panel();
 }
 
-.sage-empty-state--size-sm {
+.sage-empty-state--compact {
   padding-top: sage-spacing(xs);
   padding-bottom: sage-spacing(xs);
 }

--- a/lib/sage_rails/app/sage_components/sage_card.rb
+++ b/lib/sage_rails/app/sage_components/sage_card.rb
@@ -1,4 +1,5 @@
 class SageCard < SageComponent
   attr_accessor :clear_top_padding
   attr_accessor :clear_bottom_padding
+  attr_accessor :border_dashed
 end

--- a/lib/sage_rails/app/sage_components/sage_empty_state.rb
+++ b/lib/sage_rails/app/sage_components/sage_empty_state.rb
@@ -1,4 +1,6 @@
 class SageEmptyState < SageComponent
+  attr_accessor :icon
   attr_accessor :title
   attr_accessor :text
+  attr_accessor :size
 end

--- a/lib/sage_rails/app/sage_components/sage_empty_state.rb
+++ b/lib/sage_rails/app/sage_components/sage_empty_state.rb
@@ -2,5 +2,5 @@ class SageEmptyState < SageComponent
   attr_accessor :icon
   attr_accessor :title
   attr_accessor :text
-  attr_accessor :size
+  attr_accessor :compact
 end

--- a/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
@@ -3,6 +3,7 @@
     sage-card
     <%= "sage-card--clear-padding-top" if component.clear_top_padding %>
     <%= "sage-card--clear-padding-bottom" if component.clear_bottom_padding %>
+    <%= "sage-card--border-dashed" if component.border_dashed %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
@@ -1,8 +1,12 @@
-<div
-  class="sage-empty-state"
+<section
+  class="
+    sage-empty-state
+    <%= "sage-empty-state--size-#{component.size}" if component.size %>
+  "
   <%= component.generated_html_attributes.html_safe %>
 >
-  <h2 class="sage-empty-state__title"><%= component.title %></h2>
+  <%= "<i class='sage-empty-state__icon sage-icon-#{component.icon}-3xl'></i>".html_safe if component.icon %>
+  <h1 class="sage-empty-state__title"><%= component.title %></h1>
   <p class="sage-empty-state__text"><%= component.text %></p>
   <%= component.content %>
-</div>
+</section>

--- a/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
@@ -1,7 +1,7 @@
 <section
   class="
     sage-empty-state
-    <%= "sage-empty-state--size-#{component.size}" if component.size %>
+    <%= "sage-empty-state--compact" if component.compact %>
   "
   <%= component.generated_html_attributes.html_safe %>
 >


### PR DESCRIPTION
## Description
Adds:
- Empty state size option
- Empty state icon option
- Card dashed border

### Screenshots
![image](https://user-images.githubusercontent.com/565743/98857865-e5526a80-241c-11eb-9566-8f6824fbe22e.png)
![image](https://user-images.githubusercontent.com/565743/98858473-e5069f00-241d-11eb-88dc-3f18a8606117.png)



## Related
BUILD-392
