### PR TITLE
Outline Item - Updated responsive styles

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/elements/_button.scss
@@ -375,8 +375,13 @@ $-btn-subtle-styles: (
 
 .sage-btn__truncate-text {
   @include truncate;
-}
 
+  @media (max-width: sage-breakpoint(lg-max)) {
+    .sage-outline-item__actions-primary & {
+      @include visually-hidden();
+    }
+  }
+}
 
 // Button groups allow for several buttons together to be spaced appropriately
 .sage-btn-group {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -15,7 +15,7 @@
 
 ================================================== */
 
-$-collapse-breakpoint-key: md-max;
+$-collapse-breakpoint-key: lg-max;
 
 .sage-outline-item {
   display: grid;
@@ -47,11 +47,8 @@ $-collapse-breakpoint-key: md-max;
   }
 
   @media (max-width: sage-breakpoint($-collapse-breakpoint-key)) {
-    grid-template-columns: min-content 1fr max-content min-content;
-    grid-row-gap: sage-spacing(2xs);
-    grid-template-areas:
-      "handle-drag title actions-secondary status"
-      ". actions-primary . handle-collapse";
+    grid-template-columns: min-content 1fr max-content min-content min-content rem(24px);
+    grid-template-areas: "handle-drag title actions-secondary actions-primary status handle-collapse";
   }
 
   // ------------------ ( /Category )
@@ -161,8 +158,10 @@ $-collapse-breakpoint-key: md-max;
   flex-direction: row;
   align-items: center;
 
-  > *:not(:last-child) {
-    margin-right: sage-spacing(lg);
+  @media (max-width: sage-breakpoint($-collapse-breakpoint-key)) {
+    &.sage-btn-group > *:not(:last-child) {
+      margin-right: sage-spacing(sm);
+    }
   }
 
   @media (min-width: sage-breakpoint($-collapse-breakpoint-key)) {
@@ -184,6 +183,14 @@ $-collapse-breakpoint-key: md-max;
   align-items: center;
   justify-content: flex-end;
   padding-left: sage-spacing(md);
+
+  @media (max-width: sage-breakpoint($-collapse-breakpoint-key)) {
+    padding-left: sage-spacing(xs);
+
+    .sage-btn__truncate-text {
+      @include visually-hidden();
+    }
+  }
 }
 
 .sage-outline-item__status {

--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_outline_item.scss
@@ -186,10 +186,6 @@ $-collapse-breakpoint-key: lg-max;
 
   @media (max-width: sage-breakpoint($-collapse-breakpoint-key)) {
     padding-left: sage-spacing(xs);
-
-    .sage-btn__truncate-text {
-      @include visually-hidden();
-    }
   }
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updated responsive styles for the Outline Item component

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![outline-responsive-before](https://user-images.githubusercontent.com/1241836/98868212-674e8d80-2435-11eb-9e10-35e8ec19f9d6.gif)|![outline-responsive-after](https://user-images.githubusercontent.com/1241836/98868240-72092280-2435-11eb-924f-548b31350805.gif)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the Outline Item page: http://localhost:4000/pages/object/outline_item

