### PR TITLE
Sortable: Hide container if empty

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_sortable.scss
@@ -6,7 +6,9 @@
 ================================================== */
 
 .sage-sortable {
-  /* stylelint-disable-line block-no-empty */
+  &:empty {
+    display: none;
+  }
 }
 
 .sage-sortable__item {


### PR DESCRIPTION
## Description
Hide sortable container if empty, in grid based layouts the empty sortable container creates an extra grid space. See screencap.

### Screenshots
![image](https://user-images.githubusercontent.com/565743/98961443-cdcdbd00-24c2-11eb-9e76-227cc1c4bd6e.png)

## Related
BUILD-387