### PR TITLE
Added sage_page_heading_intro back to Sage Page Heading

### DIFF
--- a/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -4,6 +4,11 @@
       <%= content_for :sage_breadcrumbs %>
     </div>
   <% end %>
+  <% if content_for? :sage_page_heading_intro %>
+    <div class="sage-page-heading__intro">
+      <%= content_for :sage_page_heading_intro %>
+    </div>
+  <% end %>
   <h1 class="sage-page-heading__title">
     <%= component.title %>
     <% if component.help_title && component.help_link && component.help_html %>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Added `sage_page_heading_intro` back to page heading

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-11-12 at 2 09 53 PM](https://user-images.githubusercontent.com/1241836/98990996-d6d58300-24f0-11eb-969e-48f74a7eabe4.png)|![Screen Shot 2020-11-12 at 2 09 41 PM](https://user-images.githubusercontent.com/1241836/98991012-db9a3700-24f0-11eb-8d06-004456d13135.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit page heading page: http://localhost:4000/pages/object/page_heading


