### PR TITLE
Sage Search followup

### DIFF
--- a/lib/sage-frontend/javascript/system/search.js
+++ b/lib/sage-frontend/javascript/system/search.js
@@ -14,21 +14,15 @@ Sage.search = (function() {
   // ==================================================
 
   function init(el) {
-    const elButton = el.querySelector(SELECTOR_SEARCH_BUTTON);
     const elInput = el.querySelector(SELECTOR_SEARCH_INPUT);
-    
+
     // check the input for a value on load
     hasValue(elInput) ? addVisibleButtonState(el) : removeVisibleButtonState(el);
-
-    el.addEventListener('keydown', searchOnInputHandler);
-    elButton.addEventListener('click', searchClearClickHandler);
+    el.addEventListener('keyup', searchOnInputHandler);
   }
 
   function unbind(el) {
-    const elButton = el.querySelector(SELECTOR_SEARCH_BUTTON);
-
-    el.removeEventListener('keydown', searchOnInputHandler);
-    elButton.removeEventListener('click', searchClearClickHandler);
+    el.removeEventListener('keyup', searchOnInputHandler);
   }
 
   function searchOnInputHandler(evt) {
@@ -36,16 +30,6 @@ Sage.search = (function() {
     const elInput = elParent.querySelector(SELECTOR_SEARCH_INPUT);
 
     hasValue(elInput) ? addVisibleButtonState(elParent) : removeVisibleButtonState(elParent);
-  }
-
-  function searchClearClickHandler(evt) {
-    const elParent = evt.currentTarget.closest(`[${SELECTOR_SEARCH}]`);
-    const elInput = elParent.querySelector(SELECTOR_SEARCH_INPUT);
-    const event = new Event('change');
-
-    elParent.classList.remove(CLASS_VISIBLE);
-    elInput.value = ""; /* reset the search field */
-    elInput.dispatchEvent(event);/* force refresh with blur event */
   }
 
   // check if the search value has text or not

--- a/lib/sage-frontend/javascript/system/search.js
+++ b/lib/sage-frontend/javascript/system/search.js
@@ -15,6 +15,10 @@ Sage.search = (function() {
 
   function init(el) {
     const elButton = el.querySelector(SELECTOR_SEARCH_BUTTON);
+    const elInput = el.querySelector(SELECTOR_SEARCH_INPUT);
+    
+    // check the input for a value on load
+    hasValue(elInput) ? addVisibleButtonState(el) : removeVisibleButtonState(el);
 
     el.addEventListener('keydown', searchOnInputHandler);
     elButton.addEventListener('click', searchClearClickHandler);
@@ -37,15 +41,16 @@ Sage.search = (function() {
   function searchClearClickHandler(evt) {
     const elParent = evt.currentTarget.closest(`[${SELECTOR_SEARCH}]`);
     const elInput = elParent.querySelector(SELECTOR_SEARCH_INPUT);
+    const event = new Event('change');
 
     elParent.classList.remove(CLASS_VISIBLE);
     elInput.value = ""; /* reset the search field */
-    elInput.blur(); /* force refresh with blur event */
+    elInput.dispatchEvent(event);/* force refresh with blur event */
   }
 
   // check if the search value has text or not
   function hasValue(el) {
-    return el.value.length >= 0
+    return el.value.length > 0
   }
 
   function addVisibleButtonState(elParent) {

--- a/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -1,4 +1,4 @@
-<form 
+<div
   role="search"
   class=" sage-search
   <%= "sage-search--contained" if component.contained %>
@@ -27,4 +27,4 @@
     }
   } %>
 
-</form>
+</div>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - Resolve broken test stemming from adding a `<form>` as the form wrapper instead of a `<div>`
- [x] - updated reset button to be visible on load if the search input have a value

* functionality will be handled on the `kajabi-products` side. Clicking the button does nothing

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
##### This can only be checked on the app side using the kajabi-products / sage link
1. Visit a page with a form. I use http://www.kajabi.test:3000/admin/products/
2. Enter a value into the search form then press `Enter`
3. When the page refreshes, notice the reset icon is visibe

