### PR TITLE
Sage panel figure width adjustments

### DIFF
--- a/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
+++ b/lib/sage-frontend/stylesheets/system/patterns/objects/_panel.scss
@@ -53,7 +53,8 @@
   img {
     display: block;
     width: 100%;
-    height: 100%;
+    max-width: 100%;
+    height: auto;
     object-fit: cover;
   }
 }


### PR DESCRIPTION
## Description
The kajabi app filepicker applies an inline `width: auto` to images upon upload. When combined with images larger than the container's dimensions (typically a side panel), the `height: 100%` we have set on `sage-panel__figure img` results in images being displayed at their full height. The change in this PR allows the image to inherit its parent container's width, and keeps proportions intact.

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/99008373-de9a2500-24fa-11eb-9d95-9b12d1499c59.png)|![after](https://user-images.githubusercontent.com/816579/99008387-e5c13300-24fa-11eb-97ff-1466d34b1ed7.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. View the panel object [locally](http://localhost:4000/pages/object/panel) or on [staging](https://sage-kc-panel-figure-im-cvgu7n.herokuapp.com/pages/object/panel)
2. Verify that the sage panel figure image is scaling as expected, compared to [master](http://sage-design-system.kajabi.com/pages/object/panel)
(OPTIONAL) 3. Modify the image url(s) to use [larger](http://www.fillmurray.com/g/1200/800) and [smaller](http://placekitten.com/240) images, and confirm scaling is displayed as expected


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- SELL-372
