### PR TITLE
Update help link until popover content is available

### DIFF
--- a/app/views/examples/objects/page_heading/_preview.html.erb
+++ b/app/views/examples/objects/page_heading/_preview.html.erb
@@ -29,7 +29,6 @@
   title: "Page Title",
   spacer: { bottom: :xl },
   help_title: "About This Cool Thing",
-  help_html: "<p>This is a block of content.</p>",
   help_link: {
     href: "#",
     name: "Help"

--- a/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -11,6 +11,17 @@
   <% end %>
   <h1 class="sage-page-heading__title">
     <%= component.title %>
+    <% if component.help_link.present? && component.help_html.blank? %> 
+      <a href="<%= component.help_link[:url] %>" 
+        class="sage-link--no-launch sage-link--help-icon-only" 
+        target="_blank" 
+        referrer="no-referrer"
+      >
+        <span class="visually-hidden">
+          <%= component.help_link[:label] %>
+        </span>
+      </a>
+    <% end %>
     <% if component.help_title && component.help_link && component.help_html %>
       <%= sage_component SagePopover, {
         title: component.help_title,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Followup PR to add back the `Help Link` functionality instead of a `Popover` if `help_html` is not present

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![page-heading-help-link-before](https://user-images.githubusercontent.com/1241836/99427675-51c0e400-28cb-11eb-80d1-d0abd1aae291.gif)|![page-heading-help-link-after](https://user-images.githubusercontent.com/1241836/99427686-55ed0180-28cb-11eb-96e1-ac4191e5534a.gif)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit page heading page: http://localhost:4000/pages/object/page_heading

